### PR TITLE
Don't convert `save_args` to state dictionary

### DIFF
--- a/orbax/checkpoint/pytree_checkpoint_handler.py
+++ b/orbax/checkpoint/pytree_checkpoint_handler.py
@@ -386,8 +386,6 @@ class PyTreeCheckpointHandler(AsyncCheckpointHandler):
 
     if save_args is None:
       save_args = jax.tree_util.tree_map(lambda x: SaveArgs(), item)
-    else:
-      save_args = utils.to_state_dict(save_args)
     jax.tree_util.tree_map(
         functools.partial(_validate_save_args, enable_flax=self._enable_flax),
         save_args)


### PR DESCRIPTION
If you have a custom PyTree node while trying to `save_kwargs` Orbax will fail as it first converts `save_kwargs` to a state dictionary. Perhaps there was a reason for doing this but it's not immediately obvious to me. For example, this fails when it shouldn't:

```py
from orbax.checkpoint import Checkpointer, CheckpointManager, PyTreeCheckpointHandler, SaveArgs
from flax import struct
import jax


@struct.dataclass
class Test:
  a: int = 0

chkpt = CheckpointManager("logdir", checkpointers=Checkpointer(PyTreeCheckpointHandler()))

state = {'test': Test()}
save_args = jax.tree_util.tree_map(lambda _: SaveArgs(use_flax=True), state)
chkpt.save(step=0, items=state, save_kwargs={'save_args': save_args})
```