### PR TITLE
Create empty dictionary for empty nodes

### DIFF
--- a/orbax/checkpoint/pytree_checkpoint_handler.py
+++ b/orbax/checkpoint/pytree_checkpoint_handler.py
@@ -327,8 +327,8 @@ class PyTreeCheckpointHandler(AsyncCheckpointHandler):
     """Gets parameter names for PyTree elements."""
     state_dict = utils.to_state_dict(item)
     names = traverse_util.unflatten_dict({
-        k: '.'.join(k)
-        for k in traverse_util.flatten_dict(state_dict, keep_empty_nodes=True)
+        k: dict() if v == traverse_util.empty_node else '.'.join(k)
+        for k, v in traverse_util.flatten_dict(state_dict, keep_empty_nodes=True).items()
     })
     r = flax.serialization.from_state_dict(item, names)
     return r


### PR DESCRIPTION
If you currently have an "empty node" in your PyTree Orbax fails to get the PyTree names properly. The issues is when you traverse the PyTree these empty nodes must correspond to empty dictionaries or else Flax gets confused. A test case that fails,

```py
from orbax.checkpoint import Checkpointer, CheckpointManager, PyTreeCheckpointHandler,
from typing import NamedTuple

class EmptyNamedTuple(NamedTuple):
    ...

chkpt = CheckpointManager("logdir", checkpointers=Checkpointer(PyTreeCheckpointHandler()))

state = {'test': EmptyNamedTuple()}
chkpt.save(step=0, items=state)
```

If you manually check for the empty node everything works as expected.