### PR TITLE
Fix restore args in checkpoint.md

### DIFF
--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -109,7 +109,7 @@ if mngr.latest_step() is not None:  # existing checkpoint present
   # be managing multiple items, as shown in the previous section. It is also
   # valid to just have one item, as shown here.
   restored = mngr.restore(mngr.latest_step(), 
-                items=train_state, restore_kwargs=restore_args)
+                items=train_state, restore_kwargs={'restore_args': restore_args})
 
 start_step = 0 if mngr.latest_step() is None else mngr.latest_step() + 1
 for step in range(start_step, start_step + num_steps):


### PR DESCRIPTION
I believe restore_args must be equal to {'restore_args': restore_args} instead. Otherwise this will fail with unexpected keyword argument error.