### PR TITLE
Make TensorFlow dependency optional in orbax-export

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .
-        pip install .[dev] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+        pip install .[dev,tensorflow] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
     - name: Test with pytest
       run: |
         test_dir=$(mktemp -d)

--- a/export/README.md
+++ b/export/README.md
@@ -6,6 +6,9 @@
 
 `import orbax.export`
 
+Note that Orbax depends on TensorFlow, which is not included in the above commands.
+You should install TensorFlow separately, e.g. `pip install tensorflow` or `pip install tensorflow-cpu`.
+
 Orbax includes a serialization library for JAX users, enabling the exporting of
 JAX models to the TensorFlow SavedModel format. 
 

--- a/export/pyproject.toml
+++ b/export/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     'jaxlib',
     'numpy',
     'dataclasses-json',
-    'tensorflow',
 ]
 
 dynamic = ['version']
@@ -45,4 +44,7 @@ dev = [
     'pytest',
     'pytest-xdist',
     'tf-nightly'
+]
+tensorflow = [
+    'tensorflow',
 ]


### PR DESCRIPTION
This is so that users can choose different TensorFlow versions.

Closes #364 