### PR TITLE
Fix invalid key

### DIFF
--- a/export/orbax/export/jax_module.py
+++ b/export/orbax/export/jax_module.py
@@ -186,7 +186,7 @@ def _get_param_names(params: PyTree) -> PyTree:
   """Gets parameter names for PyTree elements."""
 
   def _param_name_from_keypath(keypath: Tuple[Any, ...]) -> str:
-    return '.'.join([str(ckpt_utils.get_key_name(k)) for k in keypath])
+    return '.'.join([str(ckpt_utils.get_key_name(k)) for k in keypath]).replace("~", "_")
 
   names = jax.tree_util.tree_map_with_path(
       lambda kp, _: _param_name_from_keypath(kp), params


### PR DESCRIPTION
orbax-export does not seem to work with pytrees with '~' in the keys. This is used for example in dm-haiku parameters.

This replaces any '~' parameter in the variable name with '_' as done in the example here https://dm-haiku.readthedocs.io/en/latest/notebooks/jax2tf.html.

I am not sure if this is the best thing to do but it is a hot-fix that works, any suggestion on how to make this more general would also be appreciated.