### PR TITLE
Avoid ZeroDivisionError in bytes_per_sec

### DIFF
--- a/checkpoint/orbax/checkpoint/base_pytree_checkpoint_handler.py
+++ b/checkpoint/orbax/checkpoint/base_pytree_checkpoint_handler.py
@@ -100,7 +100,7 @@ def _get_batch_memory_size(handler: TypeHandler, values: Sequence[Any]) -> int:
 
 def _log_io_per_sec_metric(name: str, size: int, start_time: float):
   time_elapsed = time.time() - start_time
-  bytes_per_sec = float(size) / time_elapsed
+  bytes_per_sec = float('inf') if time_elapsed == 0 else float(size) / time_elapsed
   logging.info(
       '[process=%d] %s: %s/s (bytes written: %s) (time elapsed: %s) (per-host)',
       multihost.process_index(),


### PR DESCRIPTION
I ran into a divide-by-zero error here in this CI job: https://github.com/jax-ml/jax_ml_stack/actions/runs/10495114319/job/29072878114?pr=7