### PR TITLE
[replica-parallel] Add replica slices concept

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/serialization/replica_slices.py
+++ b/checkpoint/orbax/checkpoint/_src/serialization/replica_slices.py
@@ -1,0 +1,198 @@
+# Copyright 2024 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+import dataclasses
+
+from absl import logging
+import jax
+import jax.numpy as jnp
+import math
+import numpy as np
+from orbax.checkpoint._src.arrays import numpy_utils
+from orbax.checkpoint._src.arrays import types
+from orbax.checkpoint._src.arrays.fragments import Fragment, Fragments, validate_fragments_can_be_stacked
+from orbax.checkpoint._src.multihost import multihost
+from typing import Callable, Optional, Sequence
+
+
+Shape = types.Shape
+Index = types.Index
+
+
+@dataclasses.dataclass(frozen=True)
+class ReplicaSliceOnDevice:
+  """
+  ReplicaSliceOnDevice represents the part of a jax.Shard that a replica is
+  uniquely responsible for.
+
+  With single-replica checkpointing the entirety of each jax.Shard is owned by
+  exactly one replica. (Currently the only option.)
+  """
+
+  replica_id: int
+  index: Index
+  data: jax.Array
+
+
+@dataclasses.dataclass
+class ReplicaSlices:
+  """
+  ReplicaSlices groups all the sliced data of one jax.Array that a replica is
+  uniquely responsible for. Slices may be either on-device (as a list of
+  ReplicaSliceOnDevice) or on-host (as a list of indices and numpy arrays).
+  """
+
+  global_shape: Shape
+  local_shape: Shape
+  sharding: jax.sharding.Sharding
+  dtype: np.dtype
+  # Whether the replica slices have been transferred and are ready as ndarrays
+  transferred: bool
+  replica_slices: list[ReplicaSliceOnDevice] | list[tuple[Index, np.ndarray]]
+
+  @property
+  def nbytes(self) -> int:
+    slice_nbytes = math.prod(self.local_shape) * self.dtype.itemsize
+    return slice_nbytes * len(self.replica_slices)
+
+  def to_fragments(self) -> Fragments:
+    assert self.transferred
+    fragments = Fragments(
+        shape=self.global_shape,
+        dtype=self.dtype,
+        fragments=[
+            Fragment(
+                index=numpy_utils.resolve_slice(index, self.global_shape),
+                value=data,
+            )
+            for index, data in self.replica_slices
+        ],
+    )
+    if fragments.fragments:
+      validate_fragments_can_be_stacked(fragments)
+    if not fragments.is_degenerate():
+      assert self.local_shape == fragments.fragments[0].shape
+    return fragments
+
+
+def get_replica_slices(
+    arr: jax.Array,
+    replica_id: Optional[int],
+) -> ReplicaSlices:
+  """Returns the replica slices a given replica is responsible for.
+  Does not transfer allocate or transfer any data."""
+  Result = tuple[list[ReplicaSliceOnDevice], Shape]
+  shard0 = arr.addressable_shards[0]
+
+  # single-replica: a single replica saves an entire shard.
+  def pick_single_replica() -> Result:
+    # Omitting the replica id just picks the first addressable shard's replica
+    # id so that the process writes each of its addressable shards exactly
+    # once. (This is the desired behavior for local checkpointing.)
+    target_replica_id = replica_id or shard0.replica_id
+    rslices = [
+        ReplicaSliceOnDevice(
+            replica_id=shard.replica_id,
+            index=shard.index,
+            data=shard.data,
+        )
+        for shard in arr.addressable_shards
+        if shard.replica_id == target_replica_id
+    ]
+    local_shape = shard0.data.shape
+    return rslices, local_shape
+
+  shards_info = ', '.join(
+      [
+          f'Shard(index={shard.index}, replica_id={shard.replica_id})'
+          for shard in arr.addressable_shards
+      ]
+  )
+  logging.vlog(
+      1,
+      '[process=%d] get_replica_slices: replica_id=%d, shards=[%s]',
+      multihost.process_index(),
+      replica_id,
+      shards_info,
+  )
+
+  # In order for all processes to agree on the right serialization metadata
+  # we want to compute the correct local shape regardless of whether there
+  # are any replica slices to save locally.
+  rslices, local_shape = pick_single_replica()
+  return ReplicaSlices(
+      global_shape=arr.shape,
+      local_shape=local_shape,
+      sharding=arr.sharding,
+      dtype=arr.dtype,
+      transferred=False,
+      replica_slices=rslices,
+  )
+
+
+def transfer_arrays_to_host(
+    arrays: Sequence[jax.Array],
+    replica_id: Optional[int],
+    *,
+    enable_pinned_host_transfer: bool = True,
+) -> Sequence[ReplicaSlices]:
+  """
+  Transfers jax.Arrays to host memory and returns all the fragments to be
+  serialized by the given replica, along with local shape. Blocks until
+  completion.
+  """
+
+  def use_pinned_host_transfer(device):
+    has_pinned_host = any(
+        m.kind == 'pinned_host' for m in device.addressable_memories()
+    )
+    return (
+        enable_pinned_host_transfer
+        and has_pinned_host
+        and jax._src.config.enable_memories.value  # pylint: disable=protected-access
+    )
+
+  def async_transfer_slice(rslice: ReplicaSliceOnDevice) -> tuple[Index, jax.Array]:
+    index = rslice.index
+    data = rslice.data
+    device = data.device
+    # Start the asynchronous device-to-host copy
+    if use_pinned_host_transfer(device):
+      # If available, transfer to pinned host memory
+      data = jax.device_put(
+          data,
+          jax.sharding.SingleDeviceSharding(device, memory_kind='pinned_host'),
+      )
+    else:
+      data.copy_to_host_async()
+    return rslice.index, data
+
+  # Gather the replica slices to be saved for each array.
+  rslices_per_array = [get_replica_slices(arr, replica_id) for arr in arrays]
+  # Kick off transfers for all replica slices to be saved.
+  transfers_per_array = [
+      [async_transfer_slice(rslice) for rslice in rslices.replica_slices]
+      for rslices in rslices_per_array
+  ]
+  # Wait for all the transferred data to be ready.
+  return [
+      dataclasses.replace(
+          rslices,
+          transferred=True,
+          # Conversion to numpy arrays forces block_until_ready.
+          replica_slices=[(index, np.asarray(data)) for index, data in transfers],
+      )
+      for rslices, transfers in zip(rslices_per_array, transfers_per_array)
+  ]

--- a/checkpoint/orbax/checkpoint/_src/serialization/replica_slices_test.py
+++ b/checkpoint/orbax/checkpoint/_src/serialization/replica_slices_test.py
@@ -1,0 +1,79 @@
+# Copyright 2024 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import numpy as np
+from orbax.checkpoint._src.serialization.replica_slices import get_replica_slices, transfer_arrays_to_host
+
+
+def make_multi_device_array(shape, spec):
+  key = jax.random.PRNGKey(0)
+  x = jax.random.normal(jax.random.PRNGKey(0), shape)
+  mesh = jax.sharding.Mesh(jax.devices(), ('x',))
+  sharding = jax.sharding.NamedSharding(mesh, spec)
+  return jax.device_put(x, sharding)
+
+
+def is_pow_of_two(n):
+  while n > 1:
+    n, rem = divmod(n, 2)
+    if rem == 1:
+      return False
+  return True
+
+
+class ReplicaSlicesTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    num_devices = len(jax.devices())
+    assert num_devices >= 2
+    assert is_pow_of_two(num_devices)
+
+  def test_get_replica_slices_single_replica(self):
+    replicated_spec = jax.sharding.PartitionSpec()
+    arr = make_multi_device_array((64, 64), replicated_spec)
+    num_replicas = len(arr.devices())
+
+    # Using an addressable replica_id yields that replica.
+    for replica_id in range(num_replicas):
+      rslices = get_replica_slices(arr, replica_id=replica_id).replica_slices
+      self.assertEqual(len(rslices), 1)
+      self.assertEqual(rslices[0].replica_id, replica_id)
+
+    # Omitting replica_id yields _some_ replica.
+    rslices = get_replica_slices(arr, replica_id=None).replica_slices
+    self.assertEqual(len(rslices), 1)
+
+    # Using an unaddressable replica_id yields nothing.
+    rslices = get_replica_slices(arr, replica_id=-1).replica_slices
+    self.assertEqual(len(rslices), 0)
+
+  def test_transfer(self):
+    replicated_spec = jax.sharding.PartitionSpec()
+    arr = make_multi_device_array((32, 32), replicated_spec)
+    shard0 = next(shard for shard in arr.addressable_shards if shard.replica_id == 0)
+
+    rslices = transfer_arrays_to_host([arr], replica_id=0)[0]
+    self.assertEqual(len(rslices.replica_slices), 1)
+    index, shard_data_on_host = rslices.replica_slices[0]
+    self.assertEqual(index, shard0.index)
+    self.assertIsInstance(shard_data_on_host, np.ndarray)
+    np.testing.assert_array_equal(shard0.data, shard_data_on_host)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/checkpoint/orbax/checkpoint/_src/serialization/serialization.py
+++ b/checkpoint/orbax/checkpoint/_src/serialization/serialization.py
@@ -36,6 +36,7 @@ from orbax.checkpoint._src.arrays import numpy_utils
 from orbax.checkpoint._src.arrays import types
 from orbax.checkpoint._src.multihost import multihost
 from orbax.checkpoint._src.serialization import tensorstore_utils as ts_utils
+from orbax.checkpoint._src.serialization.replica_slices import ReplicaSlices, transfer_arrays_to_host
 import tensorstore as ts
 
 
@@ -68,8 +69,7 @@ async def create_async_array_from_callback(
   )
 
 
-def _get_metadata(arr):
-  local_shape = arr.addressable_data(0).shape
+def _get_metadata(arr: jax.Array, local_shape: Shape):
   return {
       'compressor': {'id': 'zstd'},
       'shape': arr.shape,
@@ -246,123 +246,6 @@ async def reserved_bytes(
     await byte_limiter.release_bytes(nbytes)
 
 
-@dataclasses.dataclass
-class _Shard:
-  index: Index
-  data: np.ndarray | jax.Array
-
-
-def get_unique_shards(
-    arr: jax.Array,
-    replica_id: int | None,
-) -> list[jax.Shard]:
-  """Returns the list of jax.Shard that should be transferred to host memory."""
-  shards_info = ', '.join([
-      f'Shard(index={shard.index}, replica_id={shard.replica_id})'
-      for shard in arr.addressable_shards
-  ])
-  logging.vlog(
-      1,
-      '[process=%d] array shards: replica_id=%d, %s',
-      multihost.process_index(),
-      replica_id,
-      shards_info,
-  )
-  if replica_id is None:
-    replica_id = arr.addressable_shards[0].replica_id
-  return [
-      shard
-      for shard in arr.addressable_shards
-      if shard.replica_id == replica_id
-  ]
-
-
-def _transfer_shard_to_host(
-    shard: jax.Shard,
-    enable_pinned_host_transfer: bool,
-) -> _Shard:
-  """Asynchronously transfers shard data to host memory. Does not block."""
-  data = shard.data
-  has_pinned_host = any(
-      m.kind == 'pinned_host' for m in shard.device.addressable_memories()
-  )
-  if (
-      enable_pinned_host_transfer
-      and has_pinned_host
-      and jax._src.config.enable_memories.value  # pylint: disable=protected-access
-  ):
-    # If available, transfer to pinned host memory
-    sharding = jax.sharding.SingleDeviceSharding(
-        shard.device, memory_kind='pinned_host'
-    )
-    data = jax.device_put(data, sharding)
-  else:
-    data.copy_to_host_async()
-  return _Shard(shard.index, data)
-
-
-def shards_to_fragments(
-    shards: list[jax.Shard | _Shard],
-    global_shape: Shape,
-    dtype: jnp.dtype,
-) -> fragments.Fragments:
-  """Converts a list of jax.Shard to a Fragments."""
-  fragmentses = fragments.Fragments(
-      shape=global_shape,
-      dtype=dtype,
-      fragments=[
-          fragments.Fragment(
-              index=numpy_utils.resolve_slice(shard.index, global_shape),
-              # Conversion to numpy array forces block_until_ready.
-              value=np.asarray(shard.data),
-          )
-          for shard in shards
-      ],
-  )
-  if fragmentses.fragments:
-    fragments.validate_fragments_can_be_stacked(fragmentses)
-  return fragmentses
-
-
-def transfer_arrays_to_host(
-    arrays: Sequence[jax.Array],
-    replica_id: int | None,
-    *,
-    enable_pinned_host_transfer: bool = True,
-) -> Sequence[fragments.Fragments]:
-  """Transfers a jax.Array to host memory. Blocks until completion."""
-  transferred_shards_per_array = []
-  for arr in arrays:
-    shards_to_transfer = get_unique_shards(arr, replica_id)
-    transferred_shards = [
-        _transfer_shard_to_host(shard, enable_pinned_host_transfer)
-        for shard in shards_to_transfer
-    ]
-    transferred_shards_per_array.append(transferred_shards)
-  return [
-      shards_to_fragments(transferred_shards, arr.shape, arr.dtype)
-      for arr, transferred_shards in zip(arrays, transferred_shards_per_array)
-  ]
-
-
-async def _write_fragment(
-    fragment: fragments.Fragment,
-    t: ts.TensorStore,
-    byte_limiter: ByteLimiter,
-):
-  """Writes a single array using TensorStore. No copy is performed."""
-  assert isinstance(fragment.value, np.ndarray)
-  requested_bytes = estimate_write_memory_footprint(fragment.value)
-  async with reserved_bytes(byte_limiter, requested_bytes):
-    await t[fragment.index].write(
-        fragment.value,
-        # Avoid additional copy of input array into the TensorStore chunk
-        # cache. The data array of a shard is guaranteed to be immutable and
-        # therefore it is safe to retain a reference indefinitely.
-        can_reference_source_data_indefinitely=True,
-    )
-
-
 async def async_serialize(
     arr_inp: jax.Array,
     tensorstore_spec: Dict[str, Any],
@@ -375,7 +258,7 @@ async def async_serialize(
   """Serialize an array using TensorStore.
 
   Performs a D2H transfer of the array. Prefer to use
-  `async_serialize_fragments`
+  `async_serialize_from_host`
   by separately performing a D2H transfer, and then starting the serialization
   in a background thread.
 
@@ -394,18 +277,22 @@ async def async_serialize(
       of bytes in flight when writing to TensorStore. If None, no limitation
       will be applied.
   """
+  # Start D2H transfer in parallel for each array.
+  rslices = transfer_arrays_to_host(
+      [arr_inp],
+      replica_id,
+  )[0]
+
   byte_limiter = byte_limiter or get_byte_limiter()
   # 'metadata' may not be present at the top level (for example, if we are using
   # a 'cast' driver).
   if not _spec_has_metadata(tensorstore_spec):
-    tensorstore_spec['metadata'] = _get_metadata(arr_inp)
+    tensorstore_spec['metadata'] = _get_metadata(arr_inp, rslices.local_shape)
   # Set dtype if it's not in spec
   if 'dtype' not in tensorstore_spec:
     tensorstore_spec['dtype'] = jnp.dtype(arr_inp.dtype).name
-  # Start D2H transfer in parallel for each array.
-  host_fragments = transfer_arrays_to_host([arr_inp], replica_id)[0]
-  await async_serialize_fragments(
-      host_fragments,
+  await async_serialize_from_host(
+      rslices,
       tensorstore_spec,
       context=context,
       primary_host=primary_host,
@@ -414,8 +301,8 @@ async def async_serialize(
   )
 
 
-async def async_serialize_fragments(
-    shards: fragments.Fragments,
+async def async_serialize_from_host(
+    rslices_on_host: ReplicaSlices,
     tensorstore_spec: Dict[str, Any],
     *,
     context: Optional[ts.Context] = None,
@@ -423,11 +310,10 @@ async def async_serialize_fragments(
     transaction: Optional[ts.Transaction] = None,
     byte_limiter: Optional[ByteLimiter] = None,
 ):
-  """Serialize a host-local shards using TensorStore.
+  """Serialize replica slices using TensorStore.
 
   Args:
-    shards: A fragments.Fragments object. Individual shards are expected to
-      be host-local.
+    rslices_on_host: Replica slices obtained via transfer_arrays_to_host.
     tensorstore_spec: The tensorstore spec to use.
     context: ts.Context instance.
     primary_host: Primary host, which indicates the host that will be treated as
@@ -442,6 +328,8 @@ async def async_serialize_fragments(
   Raises:
     KeyError: If `metadata` or `dtype` is not found in the tensorstore spec.
   """
+  if not rslices_on_host.transferred:
+    raise ArgumentError('replica slices have not been transferred to host')
   byte_limiter = byte_limiter or get_byte_limiter()
   if not _spec_has_metadata(tensorstore_spec):
     raise KeyError('`metadata` not found in tensorstore spec.')
@@ -474,15 +362,25 @@ async def async_serialize_fragments(
       context=context,
       transaction=transaction,
   )
-  write_shard_coros = jax.tree.map(
-      functools.partial(
-          _write_fragment,
-          t=t,
-          byte_limiter=byte_limiter,
-      ),
-      shards.fragments,
-  )
-  await asyncio.gather(*write_shard_coros)
+
+  async def write_fragment(fragment: fragments.Fragment):
+    """Writes a single fragment using TensorStore. No copy is performed."""
+    assert isinstance(fragment.value, np.ndarray)
+    requested_bytes = estimate_write_memory_footprint(fragment.value)
+    async with reserved_bytes(byte_limiter, requested_bytes):
+      await t[fragment.index].write(
+          fragment.value,
+          # Avoid additional copy of input array into the TensorStore chunk
+          # cache. The data array of a shard is guaranteed to be immutable and
+          # therefore it is safe to retain a reference indefinitely.
+          can_reference_source_data_indefinitely=True,
+      )
+
+  write_coros = [
+      write_fragment(fragment)
+      for fragment in rslices_on_host.to_fragments().fragments
+  ]
+  await asyncio.gather(*write_coros)
 
 
 def estimate_write_memory_footprint(arr: np.ndarray) -> int:


### PR DESCRIPTION
Adds the concept of "replica slices", an explicit representation of which replica ids save which slices out of an array. The intent is for replica slices to allow us to generalize beyond Orbax's current restriction that requires each shard to be saved by exactly one replica.

**Motivation:** Depending on their sharding and replication, JAX arrays may consist of multiple shards. In case of replication each shard carries a distinct `replica_id`, distinguishing the copies of the same logical shard from one another. Orbax's current behavior is to save the same `replica_id`-copy for all shards of all arrays ("single-replica" saving). In the presence of replication this is suboptimal, since the work could be parallelized across all replicas.

This PR is an initial step in the direction of "replica-parallel" saving: we make "replica slices" and related metadata explicit, but do not change any of Orbax's behavior.

Care is taken to compute the resulting `local_shape` (the shape of slices written by each replica) even when the local process does not end up saving any data. This seems necessary, since, to the best of my understanding, only one particular process may set tensorstore metadata, and tensorstore's chunk shape, in particular, is derived from `local_shape`.