### PR TITLE
[replica-parallel] Add replica-parallel saving

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/serialization/replica_slices_test.py
+++ b/checkpoint/orbax/checkpoint/_src/serialization/replica_slices_test.py
@@ -54,9 +54,9 @@ def make_multi_device_array(shape, partitioned):
   return data, num_partitions, num_replicas
 
 
-@parameterized.product(partitioned=[False, True])
 class ReplicaSlicesTest(parameterized.TestCase):
 
+  @parameterized.product(partitioned=[False, True])
   def test_get_replica_slices_single_replica(self, partitioned):
     if jax.device_count() < 4:
       self.skipTest('Not enough devices to test.')
@@ -67,48 +67,84 @@ class ReplicaSlicesTest(parameterized.TestCase):
 
     # Using an addressable replica_id yields that replica.
     for replica_id in range(num_replicas):
-      rslices = replica_slices.get_replica_slices(arr, replica_id=replica_id)
+      rslices = replica_slices.get_replica_slices(
+          arr, replica_id=replica_id, use_replica_parallel=False,
+      )
       self.assertLen(rslices.replica_slices, num_partitions)
-      self.assertEqual(rslices.replica_id, replica_id)
 
     # Omitting replica_id yields _some_ replica.
     rslices = replica_slices.get_replica_slices(
-        arr, replica_id=None
+        arr, replica_id=None, use_replica_parallel=False,
     )
     self.assertLen(rslices.replica_slices, num_partitions)
-    self.assertIsNone(rslices.replica_id)
 
     # Using an unaddressable replica_id yields nothing.
     rslices = replica_slices.get_replica_slices(
-        arr,
-        replica_id=-1,
+        arr, replica_id=-1, use_replica_parallel=False,
     ).replica_slices
     self.assertEmpty(rslices)
 
-  def test_transfer(self, partitioned):
+  @parameterized.parameters(
+      [
+          ((64, 64), 0),
+          ((13, 64), 1),
+          ((13, 11), None),
+      ]
+  )
+  def test_get_replica_slices_replica_parallel(self, shape, expected_axis):
+    arr, _, num_replicas = make_multi_device_array(
+        shape, partitioned=False
+    )
+
+    rslices = replica_slices.get_replica_slices(
+        arr, replica_id=0, use_replica_parallel=True
+    ).replica_slices
+    if expected_axis is None:
+      # Replica-parallel expected to fail. Fall back to a single replica owning
+      # the entire shard.
+      self.assertEqual(len(rslices), 1)
+      self.assertIsNone(rslices[0].slice_args)
+    else:
+      # Replica-parallel expected to succeed. Every replica owns some data.
+      # We're running on a single host, so all replicas' shards are addressable.
+      self.assertEqual(len(rslices), num_replicas)
+      for rslice in rslices:
+        self.assertTrue(rslice.slice_args)
+        self.assertEqual(rslice.slice_args.axis, expected_axis)
+
+  @parameterized.product(
+      partitioned=[False, True],
+      use_replica_parallel=[False, True],
+  )
+  def test_transfer(self, partitioned, use_replica_parallel):
     if jax.device_count() < 4:
       self.skipTest('Not enough devices to test.')
-    arr, num_partitions, _ = make_multi_device_array(
-        (64, 64),
-        partitioned=partitioned,
+    arr, num_partitions, num_replicas = make_multi_device_array(
+        (64, 64), partitioned=partitioned,
     )
-    replica0_shards = [
-        shard for shard in arr.addressable_shards if shard.replica_id == 0
-    ]
 
-    rslices = replica_slices.transfer_arrays_to_host([arr], replica_id=0)[0]
-    self.assertLen(rslices.replica_slices, num_partitions)
-    self.assertEqual(len(rslices.replica_slices), len(replica0_shards))
+    rslices = replica_slices.transfer_arrays_to_host(
+        [arr], replica_id=0, use_replica_parallel=use_replica_parallel,
+    )[0]
 
-    index_start = lambda x: x.index[0].start or 0
-    rslices = sorted(rslices.replica_slices, key=index_start)
-    replica0_shards = sorted(replica0_shards, key=index_start)
-
-    for rslice, replica0_shard in zip(rslices, replica0_shards):
+    # Replica slices cover every element of the original array exactly once, and
+    # combining all the replica slices is equivalent to the original array.
+    combined_rslices = np.zeros(arr.shape) * np.nan
+    for rslice in rslices.replica_slices:
       self.assertTrue(rslice.is_on_host)
-      self.assertIsInstance(rslice.data, np.ndarray)
-      self.assertEqual(rslice.index, replica0_shard.index)
-      np.testing.assert_array_equal(rslice.data, replica0_shard.data)
+      self.assertTrue(np.all(np.isnan(combined_rslices[rslice.index])))
+      combined_rslices[rslice.index] = rslice.data()
+    self.assertFalse(np.any(np.isnan(arr)))
+    self.assertFalse(np.any(np.isnan(combined_rslices)))
+    np.testing.assert_array_equal(combined_rslices, arr)
+
+    if use_replica_parallel:
+      # With replica-parallel we transfer each of the `num_partitions` shards
+      # as `num_replicas` slices.
+      self.assertLen(rslices.replica_slices, num_partitions * num_replicas)
+    else:
+      # With single-replica we transfer a single slice for each shard.
+      self.assertLen(rslices.replica_slices, num_partitions)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/serialization/serialization.py
+++ b/checkpoint/orbax/checkpoint/_src/serialization/serialization.py
@@ -252,6 +252,7 @@ async def async_serialize(
     context: Optional[ts.Context] = None,
     primary_host: Optional[int] = 0,
     replica_id: int = 0,
+    use_replica_parallel: bool = True,
     transaction: Optional[ts.Transaction] = None,
     byte_limiter: Optional[ByteLimiter] = None,
 ):
@@ -281,6 +282,7 @@ async def async_serialize(
   rslices = replica_slices.transfer_arrays_to_host(
       [arr_inp],
       replica_id,
+      use_replica_parallel,
   )[0]
 
   byte_limiter = byte_limiter or get_byte_limiter()

--- a/checkpoint/orbax/checkpoint/experimental/emergency/checkpoint_manager.py
+++ b/checkpoint/orbax/checkpoint/experimental/emergency/checkpoint_manager.py
@@ -71,7 +71,11 @@ def local_checkpoint_handler() -> PyTreeCheckpointHandler:
   local_registry = type_handlers.create_type_handler_registry(
       (
           jax.Array,
-          type_handlers.ArrayHandler(primary_host=None, replica_id=None),
+          type_handlers.ArrayHandler(
+              primary_host=None,
+              replica_id=None,
+              use_replica_parallel=False,
+          ),
       ),
   )
   return PyTreeCheckpointHandler(
@@ -96,7 +100,11 @@ def _local_checkpoint_handler(
   local_registry = type_handlers.create_type_handler_registry(
       (
           jax.Array,
-          type_handlers.ArrayHandler(primary_host=None, replica_id=None),
+          type_handlers.ArrayHandler(
+              primary_host=None,
+              replica_id=None,
+              use_replica_parallel=False,
+          ),
       ),
   )
   return PyTreeCheckpointHandler(


### PR DESCRIPTION
(Follow-up to https://github.com/google/orbax/pull/1319)

**Adds "replica-parallel" saving in which each replica of a shard saves an equally-sized slice.** In effect, this drives down the time spent on saving checkpoints as data-parallelism increases.

**Motivation:** Depending on their sharding and replication, JAX arrays may consist of multiple shards. In case of replication each shard carries a distinct `replica_id`, distinguishing the copies of the same logical shard from one another. Orbax's current behavior is to save the same `replica_id`-copy for all shards of all arrays ("single-replica" saving). In the presence of replication this is suboptimal, since the work could be parallelized across all replicas.

**This PR** adapts `ArrayHandler` to operate in "replica-parallel" mode (`use_replica_parallel=True`). In this mode we determine the first axis for which an array's shards are evenly-divisible by the number of replicas `R`. If such an axis exists, we will then assign each replica to save one R-th of the overall shard. Otherwise we fall back to "single-replica" saving.

---

While this patch is mostly relevant to large-scale training across many hosts, the following self-contained example illustrates the difference between existing "single-replica" saving and "replica-parallel" saving:
https://gist.github.com/gspschmid/41a78da35c0b14fafaff7bed3d52c5bc

For simplicity, I ran this example in a single process controlling 8 GPUs to save a fully-replicated array of ~4.3GBs. Attached are the output and profile for the last iteration.

**Single-replica (Orbax v0.9.0):**
```
=== iteration 5/5 ===
[gc] 0.91s
[save (offload)] 0.09s
[save (persist)] 5.42s
```
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/43ea7d47-8d01-4311-adae-5236885feb38">

**Replica-parallel (this PR):**
```
=== iteration 5/5 ===
[gc] 1.01s
[save (offload)] 0.05s
[save (persist)] 2.27s
```
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/f2fee33a-7330-4dfb-89ad-9da343404c63">

---

A few observations:
* As expected, replica-parallel distributes the D2H transfers across all 8 devices. Since I am running only a single process the persistence step is still serialized; with multiple processes this would be parallelized as well.
* Since I am running only a single process on a single host the absolute speed-up of the D2H (transfer) step is small, around 50ms/save. Note that the D2H already takes up relatively little time (~100ms), and we "merely" reduce it by 2x due to contention for bus bandwidth. Note that in a multi-host setting we should experience close to perfect scaling, as each host offloads to local host memory.
* _Surprisingly, overall save time (including the commit step of tensorstore) is reduced by 2x._ I am not sure why, but suspect that this is related to us effectively splitting each existing `ts[index].write(...)` into 8 smaller ones. The microbenchmark uses tensorstore's `memory://` backend, so it remains to be seen whether this improvement holds up in realistic use cases.
* _Garbage collection_ has an outsize impact on this microbenchmark (regardless of whether we use replica-parallel or not). I had not noticed this effect in earlier rounds of benchmarking Orbax and tensorstore, so I am wondering whether this might be a recent regression.