### PR TITLE
HNS checkpoint folder moved to _todelete_subdirectory for future deletion to avoid slow listing

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/path/deleter.py
+++ b/checkpoint/orbax/checkpoint/_src/path/deleter.py
@@ -227,20 +227,16 @@ class StandardCheckpointDeleter:
                 dest_path = destination_parent_dir / delete_target.name
                 destination_folder_id = str(dest_path.relative_to(f'gs://{bucket_name}'))
                 source_resource_name = f'projects/_/buckets/{bucket_name}/folders/{source_folder_id}'
-
                 logging.info('Rename API call: Source: %s', source_resource_name)
                 logging.info('Rename API call: Destination ID: %s', destination_folder_id)
-
                 request = storage_control_v2.RenameFolderRequest(
                     name=source_resource_name,
                     destination_folder_id=destination_folder_id,
                 )
                 op = client.rename_folder(request=request)
                 op.result()
-
                 logging.info('Successfully renamed step %d to %s', step, dest_path)
                 return
-
             except Exception as e:
                 logging.error(
                     'HNS rename failed for step %d. Error: %s',


### PR DESCRIPTION
When a checkpoint folder is renamed, it's moved into a _todelete_ subdirectory. This directory is created as a sibling to the main checkpoints/ folder.

This approach prevents these renamed folders from being listed during a checkpoint restore operation, which lists the contents of the checkpoints/ directory.

Note: This implementation uses a direct GCS API call as a temporary solution. This functionality will be migrated to tf.io once it becomes available there.