### PR TITLE
[replica-parallel] Configurable limits for replica-parallel checkpoint saving

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/serialization/replica_slices.py
+++ b/checkpoint/orbax/checkpoint/_src/serialization/replica_slices.py
@@ -208,7 +208,7 @@ def get_replica_slices(
     arr: jax.Array,
     replica_id: Optional[int],
     use_replica_parallel: bool,
-    min_shard_bytes_for_replica_parallel: Optional[int],
+    min_slice_bytes_for_replica_parallel: Optional[int],
     max_replicas_for_replica_parallel: Optional[int],
 ) -> ReplicaSlices:
   """Returns the replica slices a given replica is responsible for.
@@ -224,6 +224,11 @@ def get_replica_slices(
     use_replica_parallel: Whether to use replica-parallel serialization to allow
       arrays with replicated shards to be written cooperatively by different
       hosts.
+    min_slice_bytes_for_replica_parallel: Minimum number of bytes needed per
+      write request to allow writing of replicated shards to be parallelized.
+    max_replicas_for_replica_parallel: Maximum number of replicas over which
+      to parallelize the writing of replicated shards if use_replica_parallel
+      is True.
 
   Returns:
     ReplicaSlices object.
@@ -258,12 +263,17 @@ def get_replica_slices(
       )
 
     # Check whether replica-parallel applies: we are dealing with non-empty
-    # shards, we have more than one replica, and some dimension of the shards
-    # is evenly divisible across replicas.
+    # shards, we have more than one replica, some dimension of the shards
+    # is evenly divisible across replicas, and each slice saved would have
+    # size at least min_slice_bytes_for_replica_parallel.
     axis, local_shape = calculate_replica_parallel_axis_and_local_shape(
       arr, max_replicas_for_replica_parallel
     )
-    if axis is None or local_shape is None:
+    slice_nbytes_ok = (
+      min_slice_bytes_for_replica_parallel is None
+      or math.prod(local_shape) * arr.itemsize < min_slice_bytes_for_replica_parallel
+    )
+    if (axis is None or local_shape is None or not slice_nbytes_ok):
       return None
 
     rslices: list[ReplicaSlice] = []
@@ -309,15 +319,9 @@ def get_replica_slices(
         ]),
     )
 
-  # Check whether shards are large enough for replica-parallel saving.
-  is_safe_to_slice = (
-    min_shard_bytes_for_replica_parallel is None
-    or shard0.data.nbytes >= min_shard_bytes_for_replica_parallel
-  )
-
   # Small pinned host arrays have layout requirements so slicing them might hang
   # this is a temporary workaround to avoid this. TODO: b/417243451
-  is_safe_to_slice = is_safe_to_slice and (
+  is_safe_to_slice = (
       arr.sharding.memory_kind != 'pinned_host'
       or arr.ndim >= 2
       and arr.addressable_shards[0].data.size % 1024 == 0
@@ -349,7 +353,7 @@ def transfer_arrays_to_host(
     use_replica_parallel: bool,
     *,
     enable_pinned_host_transfer: bool = False,
-    min_shard_bytes_for_replica_parallel: Optional[int] = None,
+    min_slice_bytes_for_replica_parallel: Optional[int] = None,
     max_replicas_for_replica_parallel: Optional[int] = None,
 ) -> Sequence[ReplicaSlices]:
   """Transfers arrays to host memory.
@@ -366,8 +370,8 @@ def transfer_arrays_to_host(
       hosts.
     enable_pinned_host_transfer: Whether to allow transfer to pinned host
       memory. Pinned memory is closely associated with a TPU device and can
-    min_shard_bytes_for_replica_parallel: Minimum number of bytes needed per
-      shard to allow writing of replicated shards to be parallelized.
+    min_slice_bytes_for_replica_parallel: Minimum number of bytes needed per
+      write request to allow writing of replicated shards to be parallelized.
     max_replicas_for_replica_parallel: Maximum number of replicas over which
       to parallelize the writing of replicated shards if use_replica_parallel
       is True.
@@ -412,7 +416,7 @@ def transfer_arrays_to_host(
   # Gather the replica slices to be saved for each array.
   rslices_per_array = [
       get_replica_slices(arr, replica_id, use_replica_parallel, 
-                         min_shard_bytes_for_replica_parallel, 
+                         min_slice_bytes_for_replica_parallel, 
                          max_replicas_for_replica_parallel)
       for arr in arrays
   ]

--- a/checkpoint/orbax/checkpoint/_src/serialization/replica_slices_test.py
+++ b/checkpoint/orbax/checkpoint/_src/serialization/replica_slices_test.py
@@ -107,11 +107,6 @@ class ReplicaSlicesTest(parameterized.TestCase):
       self.skipTest('Test requires multiple devices.')
     arr, _, num_replicas = make_multi_device_array(shape, partitioned=False)
 
-    # If we use 128 devices, then for the (64, 64) test, there will be no axis
-    # of each shard such that the axis size is divisibile by num_replicas = 128.
-    if jax.device_count() >= 128:
-      self.skipTest('Test requires < 128 devices.')
-
     rslices = replica_slices.get_replica_slices(
         arr, replica_id=0, use_replica_parallel=True,
         min_slice_bytes_for_replica_parallel=None,

--- a/checkpoint/orbax/checkpoint/_src/serialization/type_handlers.py
+++ b/checkpoint/orbax/checkpoint/_src/serialization/type_handlers.py
@@ -886,7 +886,7 @@ class ArrayHandler(types.TypeHandler):
       primary_host: Optional[int] = 0,
       replica_id: Optional[int] = 0,
       use_replica_parallel: bool = True,
-      min_shard_bytes_for_replica_parallel: Optional[int] = None,
+      min_slice_bytes_for_replica_parallel: Optional[int] = None,
       max_replicas_for_replica_parallel: Optional[int] = None,
       enable_write_sharding_file: bool = True,
       array_metadata_store: array_metadata_store_lib.Store | None = None,
@@ -902,8 +902,9 @@ class ArrayHandler(types.TypeHandler):
         set to None, each shards will pick first replica_id to be used.  It's
         useful in the case that all hosts are only working with local storage.
       use_replica_parallel: Whether to parallelize saving across replicas.
-      min_shard_bytes_for_replica_parallel: Minimum number of bytes needed per
-        shard to parallelize saving across replicas.
+      min_slice_bytes_for_replica_parallel: Minimum number of bytes that should 
+        be written by any individual write when use_replica_parallel is True. 
+        Parallel saving is disabled if writes would not meet this threshold.
       max_replicas_for_replica_parallel: Maximum number of replicas over which
         saving will be parallelized if use_replica_parallel is True.
       enable_write_sharding_file: whether to write sharding file, defaults to
@@ -916,7 +917,7 @@ class ArrayHandler(types.TypeHandler):
     self._replica_id = replica_id
     self._enable_write_sharding_file = enable_write_sharding_file
     self._use_replica_parallel = use_replica_parallel
-    self._min_shard_bytes_for_replica_parallel = min_shard_bytes_for_replica_parallel
+    self._min_slice_bytes_for_replica_parallel = min_slice_bytes_for_replica_parallel
     self._max_replicas_for_replica_parallel = max_replicas_for_replica_parallel
     self._array_metadata_store = array_metadata_store
     self._ext_metadata = dict()
@@ -1175,7 +1176,7 @@ class ArrayHandler(types.TypeHandler):
         self._replica_id,
         self._use_replica_parallel,
         enable_pinned_host_transfer=infos[0].enable_pinned_host_transfer,
-        min_shard_bytes_for_replica_parallel=self._min_shard_bytes_for_replica_parallel,
+        min_slice_bytes_for_replica_parallel=self._min_slice_bytes_for_replica_parallel,
         max_replicas_for_replica_parallel=self._max_replicas_for_replica_parallel,
     )
 
@@ -1359,7 +1360,7 @@ class ArrayHandler(types.TypeHandler):
               v,
               replica_id=self._replica_id,
               use_replica_parallel=self._use_replica_parallel,
-              min_shard_bytes_for_replica_parallel=self._min_shard_bytes_for_replica_parallel,
+              min_slice_bytes_for_replica_parallel=self._min_slice_bytes_for_replica_parallel,
               max_replicas_for_replica_parallel=self._max_replicas_for_replica_parallel,
           ).nbytes
       )

--- a/checkpoint/orbax/checkpoint/_src/serialization/type_handlers.py
+++ b/checkpoint/orbax/checkpoint/_src/serialization/type_handlers.py
@@ -886,6 +886,8 @@ class ArrayHandler(types.TypeHandler):
       primary_host: Optional[int] = 0,
       replica_id: Optional[int] = 0,
       use_replica_parallel: bool = True,
+      min_shard_bytes_for_replica_parallel: Optional[int] = None,
+      max_replicas_for_replica_parallel: Optional[int] = None,
       enable_write_sharding_file: bool = True,
       array_metadata_store: array_metadata_store_lib.Store | None = None,
   ):
@@ -900,6 +902,10 @@ class ArrayHandler(types.TypeHandler):
         set to None, each shards will pick first replica_id to be used.  It's
         useful in the case that all hosts are only working with local storage.
       use_replica_parallel: Whether to parallelize saving across replicas.
+      min_shard_bytes_for_replica_parallel: Minimum number of bytes needed per
+        shard to parallelize saving across replicas.
+      max_replicas_for_replica_parallel: Maximum number of replicas over which
+        saving will be parallelized if use_replica_parallel is True.
       enable_write_sharding_file: whether to write sharding file, defaults to
         True.
       array_metadata_store: Store to manage per host ArrayMetadata. To disable
@@ -910,6 +916,8 @@ class ArrayHandler(types.TypeHandler):
     self._replica_id = replica_id
     self._enable_write_sharding_file = enable_write_sharding_file
     self._use_replica_parallel = use_replica_parallel
+    self._min_shard_bytes_for_replica_parallel = min_shard_bytes_for_replica_parallel
+    self._max_replicas_for_replica_parallel = max_replicas_for_replica_parallel
     self._array_metadata_store = array_metadata_store
     self._ext_metadata = dict()
 
@@ -1167,6 +1175,8 @@ class ArrayHandler(types.TypeHandler):
         self._replica_id,
         self._use_replica_parallel,
         enable_pinned_host_transfer=infos[0].enable_pinned_host_transfer,
+        min_shard_bytes_for_replica_parallel=self._min_shard_bytes_for_replica_parallel,
+        max_replicas_for_replica_parallel=self._max_replicas_for_replica_parallel,
     )
 
     return [
@@ -1349,6 +1359,8 @@ class ArrayHandler(types.TypeHandler):
               v,
               replica_id=self._replica_id,
               use_replica_parallel=self._use_replica_parallel,
+              min_shard_bytes_for_replica_parallel=self._min_shard_bytes_for_replica_parallel,
+              max_replicas_for_replica_parallel=self._max_replicas_for_replica_parallel,
           ).nbytes
       )
       read_sizes.append(

--- a/checkpoint/orbax/checkpoint/_src/serialization/type_handlers.py
+++ b/checkpoint/orbax/checkpoint/_src/serialization/type_handlers.py
@@ -902,9 +902,9 @@ class ArrayHandler(types.TypeHandler):
         set to None, each shards will pick first replica_id to be used.  It's
         useful in the case that all hosts are only working with local storage.
       use_replica_parallel: Whether to parallelize saving across replicas.
-      min_slice_bytes_for_replica_parallel: Minimum number of bytes that should 
-        be written by any individual write when use_replica_parallel is True. 
-        Parallel saving is disabled if writes would not meet this threshold.
+      min_slice_bytes_for_replica_parallel: Minimum number of bytes per replica 
+        slice. Only uses replica-parallel when the amount of data written per 
+        replica is greater than or equal to this number.
       max_replicas_for_replica_parallel: Maximum number of replicas over which
         saving will be parallelized if use_replica_parallel is True.
       enable_write_sharding_file: whether to write sharding file, defaults to

--- a/checkpoint/orbax/checkpoint/test_utils.py
+++ b/checkpoint/orbax/checkpoint/test_utils.py
@@ -759,13 +759,17 @@ def assert_every_n_is_x_apart(testclass, values, n, x):
 
 
 def get_expected_chunk_shape(
-    arr: jax.Array, *, use_replica_parallel: bool = True
+    arr: jax.Array, *,
+    use_replica_parallel: bool = True,
+    max_replicas_for_replica_parallel: Optional[bool] = None
 ) -> tuple[int, ...]:
   """Expected chunk shape for an array, accounting for replica-parallel."""
   if not use_replica_parallel:
     return arr.sharding.shard_shape(arr.shape)
   _, local_shape = (
-      replica_slices.calculate_replica_parallel_axis_and_local_shape(arr)
+      replica_slices.calculate_replica_parallel_axis_and_local_shape(
+        arr, max_replicas_for_replica_parallel
+      )
   )
   if local_shape is None:
     local_shape = arr.sharding.shard_shape(arr.shape)

--- a/checkpoint/orbax/checkpoint/test_utils.py
+++ b/checkpoint/orbax/checkpoint/test_utils.py
@@ -766,14 +766,14 @@ def get_expected_chunk_shape(
   """Expected chunk shape for an array, accounting for replica-parallel."""
   if not use_replica_parallel:
     return arr.sharding.shard_shape(arr.shape)
-  _, local_shape = (
+  
+  if (replica_parallel_info := 
       replica_slices.calculate_replica_parallel_axis_and_local_shape(
         arr, max_replicas_for_replica_parallel
-      )
-  )
-  if local_shape is None:
-    local_shape = arr.sharding.shard_shape(arr.shape)
-  return local_shape
+      )) is None:
+    return arr.sharding.shard_shape(arr.shape)
+
+  return replica_parallel_info[1]
 
 
 def filter_metadata_fields(


### PR DESCRIPTION
**Adds parameters `min_slice_bytes_for_replica_parallel` and `max_replicas_for_replica_parallel` to `ArrayHandler` to allow users to configure replica-parallel checkpoint saving.** If `use_replica_parallel` is set to true, saving will be parallelized over at most `max_replicas_for_replica_parallel` different replicas. If the bytes per replica slice is less than `min_slice_bytes_for_replica_parallel`, replica-parallel saving is disabled.

**Motivation:** JAX arrays may consist of multiple shards, which may in turn be duplicated across multiple ‘replicas’. #1319 and #1320 added support for parallelizing the saving of JAX array shards over these replicas. However, this parallelism combined with a high DP factor implies a large number of small writes, which in turn can cause storage backends to throttle write requests. This PR introduces configurable limits on when to use replica parallel saving and over how many replicas saving should be parallelized.