### PR TITLE
Fix _glob_step_paths if HNS is enabled

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/path/step.py
+++ b/checkpoint/orbax/checkpoint/_src/path/step.py
@@ -395,7 +395,7 @@ class _StandardNameFormat(NameFormat[Metadata]):
       return [
           epath.Path(f'gs://{bucket_name}/{folder}')
           for folder in result.prefixes
-          if folder.startswith(os.path.join(path_prefix, self.step_prefix))
+          if folder.startswith(os.path.join(path_prefix, step_prefix_with_underscore(self.step_prefix)))
       ]
     else:
       return list(


### PR DESCRIPTION
Seems like there was an oversight in the case where HNS is enabled, but no `step_prefix` is provided. In that case, `step_prefix` is None, which results in an error when trying to join with another path.