### PR TITLE
Add Auto-Assignment GitHub Action for Issues

### DIFF
--- a/.github/workflows/auto-assignment.yml
+++ b/.github/workflows/auto-assignment.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 The Orbax Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: auto-assignment
 
 on:
@@ -7,16 +21,12 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Run auto-assignment script
         uses: actions/github-script@v7
         with:

--- a/scripts/auto-assignment.mjs
+++ b/scripts/auto-assignment.mjs
@@ -1,16 +1,16 @@
-//  Copyright 2026 The Orbax Authors.
+// Copyright 2026 The Orbax Authors.
 
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 export default async function autoAssign({ github, context }) {
   console.log('Auto-assignment script started');


### PR DESCRIPTION
**Add Auto-Assignment GitHub Action**
This PR introduces a GitHub Actions workflow that automatically assigns new issues to a designated team member. It ensures that every new task gets immediate ownership and avoid unassigned work items.

**How It Works**

**1. Trigger Events**

- The workflow runs whenever a new issue is opened.

**2. Determine Assignees**

- The assignee is selected using round-robin logic based on the issue number, so work is distributed consistently.

**3. Automatic Assignment**

- Once selected, the workflow assigns the issue via the GitHub API.

**Why This Is Needed**

- Prevents new issues from being unassigned.
- Ensures even distribution of tasks among team members.
- Saves manual effort in assigning every new item.