### PR TITLE
Security: Thread Safety Issue in Asyncio Utils

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/asyncio_utils.py
+++ b/checkpoint/orbax/checkpoint/_src/asyncio_utils.py
@@ -68,4 +68,6 @@ def run_sync(coro: Coroutine[Any, Any, _T]) -> _T:
         return asyncio.run_coroutine_threadsafe(coro, event_loop).result()
       finally:
         event_loop.call_soon_threadsafe(event_loop.stop)
-        thread.join()
+        thread.join(timeout=30)
+        if thread.is_alive():
+          raise RuntimeError('Event loop thread did not stop cleanly.')


### PR DESCRIPTION
## Summary

Security: Thread Safety Issue in Asyncio Utils

## Problem

**Severity**: `Medium` | **File**: `checkpoint/orbax/checkpoint/_src/asyncio_utils.py:L58`

The `run_sync` function in `asyncio_utils.py` creates a new event loop in a daemon thread when `uvloop` is available. The `finally` block calls `event_loop.call_soon_threadsafe(event_loop.stop)` and then `thread.join()`, but there's a race condition where the thread might not stop cleanly. Additionally, if `nest_asyncio` is used, it patches the running event loop which can have global side effects.

## Solution

Add proper exception handling for thread cleanup, ensure thread.join() has a timeout, and consider the implications of globally patching asyncio with nest_asyncio. Document that this function may have side effects on the global event loop state.

## Changes

- `checkpoint/orbax/checkpoint/_src/asyncio_utils.py` (modified)