### PR TITLE
Add HParams summary + per-operation profile traces to benchmark runs

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core.py
@@ -15,12 +15,12 @@
 """Core classes and functions for benchmarking Orbax."""
 
 import abc
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 import dataclasses
 import hashlib
 import itertools
 import sys
-from typing import Any, Callable
+from typing import Any
 
 from absl import logging
 from etils import epath
@@ -48,7 +48,7 @@ class BenchmarkOptions:
 
 
 def benchmark_options(options_cls):
-  """Decorator to associate a BenchmarkOptions subclass with a BenchmarksGenerator."""
+  """Associates a BenchmarkOptions subclass with a BenchmarksGenerator."""
   if not issubclass(options_cls, BenchmarkOptions):
     raise TypeError(
         "Decorating class must be a subclass of BenchmarkOptions, got"
@@ -70,7 +70,7 @@ def benchmark_options(options_cls):
 
 @dataclasses.dataclass
 class TestContext:
-  """Input object passed to each test function, providing pre-configured components for the test run.
+  """Input passed to each test function with pre-configured components.
 
   Attributes:
     pytree: The generated or loaded checkpoint data. May be None.
@@ -80,6 +80,10 @@ class TestContext:
     repeat_index: The index of the repeat run, if this test is run multiple
       times.
     local_path: The local path to store the checkpoint data.
+    output_dir: The suite-level output directory. Used by `trace_path` to
+      compose TB Profile-plugin-discoverable trace paths.
+    name: The benchmark's stable hashed name. Used by `trace_path` as the
+      Profile-plugin <run> segment so traces show up alongside scalars.
   """
 
   pytree: Any | None
@@ -88,11 +92,46 @@ class TestContext:
   mesh: jax.sharding.Mesh | None = None
   repeat_index: int | None = None
   local_path: epath.Path | None = None
+  output_dir: epath.Path | str | None = None
+  name: str | None = None
+
+  def trace_path(self, operation: str) -> epath.Path | None:
+    """Trace destination for an operation, or None if no trace is captured.
+
+    Routes `jax.profiler.start_trace` output into the layout the TB Profile
+    plugin discovers: `<output_dir>/tensorboard/plugins/profile/<run>/`. Each
+    operation becomes its own `<run>` segment (`<name>__<operation>`) so save
+    and load traces show up as separate Profile-tab entries.
+
+    Returns None when:
+      - `options.enable_trace` is missing or False.
+      - `repeat_index` > 0 and `options.trace_every_repeat` is missing or False
+        (first-repeat-only is the default; profile traces overflow Trace Viewer
+        otherwise).
+      - `output_dir` or `name` is missing (no Profile root to route into).
+    """
+    if not getattr(self.options, "enable_trace", False):
+      return None
+    if (
+        self.repeat_index is not None
+        and self.repeat_index > 0
+        and not getattr(self.options, "trace_every_repeat", False)
+    ):
+      return None
+    if self.output_dir is None or self.name is None:
+      return None
+    return (
+        epath.Path(self.output_dir)
+        / "tensorboard"
+        / "plugins"
+        / "profile"
+        / f"{self.name}__{operation}"
+    )
 
 
 @dataclasses.dataclass
 class TestResult:
-  """Output object returned by each test function, containing the results of the test run, including collected metrics."""
+  """Output returned by each test function with results and metrics."""
 
   metrics: metric_lib.Metrics
   error: Exception | None = (
@@ -107,7 +146,7 @@ class TestResult:
 
 
 class Benchmark(abc.ABC):
-  """An object that encapsulates a single, runnable benchmark test case, including its configuration and metadata."""
+  """A single runnable benchmark test case with config and metadata."""
 
   def __init__(
       self,
@@ -193,6 +232,8 @@ class Benchmark(abc.ABC):
         mesh=self.mesh,
         repeat_index=repeat_index,
         local_path=local_path,
+        output_dir=self.output_dir,
+        name=self.name,
     )
 
     test_context_summary = self._build_test_context_summary(context)
@@ -283,6 +324,7 @@ class BenchmarksGenerator(abc.ABC):
           " decorated with @benchmark_options to set the 'options_class'"
           " attribute."
       )
+    # pylint: disable-next=isinstance-second-argument-not-valid-type
     if not isinstance(options, self.options_class):
       raise TypeError(
           f"Expected options of type {self.options_class.__name__}, but got"
@@ -297,7 +339,7 @@ class BenchmarksGenerator(abc.ABC):
 
   @abc.abstractmethod
   def test_fn(self, test_context: TestContext) -> TestResult:
-    """A user-defined test function that will be run for every generated benchmark variant."""
+    """User-defined test function run for each generated benchmark variant."""
 
   def _get_options_product(self) -> Sequence[BenchmarkOptions]:
     """Computes the Cartesian product of all options in the dataclass."""
@@ -334,7 +376,7 @@ class BenchmarksGenerator(abc.ABC):
   def _get_meshes(
       self, skip_incompatible_mesh_configs: bool
   ) -> Sequence[jax.sharding.Mesh]:
-    """Returns a list of meshes for all mesh configs that are compatible with the runtime environment."""
+    """Returns meshes for mesh configs compatible with the runtime."""
     meshes = []
     for mesh_config in self._mesh_configs:
       try:
@@ -439,7 +481,6 @@ class TestSuite:
       path.rmtree()
     except FileNotFoundError:
       logging.warning("Repeat directory %s not found. Skipping removal.", path)
-
 
   def run(self) -> Sequence[TestResult]:
     """Runs all benchmarks in the suite sequentially."""

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core_trace_path_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core_trace_path_test.py
@@ -1,0 +1,105 @@
+# Copyright 2026 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for TestContext.trace_path — the TB Profile-plugin layout routing."""
+
+import dataclasses
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from etils import epath
+from orbax.checkpoint._src.testing.benchmarks.core import core
+
+
+@dataclasses.dataclass(frozen=True)
+class _TraceOpts:
+  enable_trace: bool = True
+  trace_every_repeat: bool = False
+
+
+class TestContextTracePathTest(parameterized.TestCase):
+
+  _OUTPUT_DIR = epath.Path('/tmp/bench')
+  _NAME = 'MyBench_abc123'
+  _EXPECTED_SAVE = (
+      _OUTPUT_DIR / 'tensorboard' / 'plugins' / 'profile' / f'{_NAME}__save'
+  )
+  _EXPECTED_LOAD = (
+      _OUTPUT_DIR / 'tensorboard' / 'plugins' / 'profile' / f'{_NAME}__load'
+  )
+
+  def _ctx(
+      self,
+      *,
+      repeat_index=None,
+      enable_trace=True,
+      trace_every_repeat=False,
+  ):
+    path = self._OUTPUT_DIR / self._NAME
+    if repeat_index is not None:
+      path = path / f'repeat_{repeat_index}'
+    return core.TestContext(
+        pytree=None,
+        path=path,
+        options=_TraceOpts(
+            enable_trace=enable_trace,
+            trace_every_repeat=trace_every_repeat,
+        ),
+        mesh=None,
+        repeat_index=repeat_index,
+        output_dir=self._OUTPUT_DIR,
+        name=self._NAME,
+    )
+
+  def test_no_repeat_returns_tb_profile_layout(self):
+    self.assertEqual(self._ctx().trace_path('save'), self._EXPECTED_SAVE)
+
+  def test_first_repeat_captures(self):
+    self.assertEqual(
+        self._ctx(repeat_index=0).trace_path('load'), self._EXPECTED_LOAD
+    )
+
+  def test_non_first_repeat_skipped_by_default(self):
+    self.assertIsNone(self._ctx(repeat_index=2).trace_path('save'))
+
+  def test_trace_every_repeat_captures_all(self):
+    self.assertEqual(
+        self._ctx(repeat_index=2, trace_every_repeat=True).trace_path('save'),
+        self._EXPECTED_SAVE,
+    )
+
+  def test_disabled_returns_none(self):
+    self.assertIsNone(self._ctx(enable_trace=False).trace_path('save'))
+
+  def test_disabled_overrides_trace_every_repeat(self):
+    self.assertIsNone(
+        self._ctx(
+            repeat_index=0,
+            enable_trace=False,
+            trace_every_repeat=True,
+        ).trace_path('save')
+    )
+
+  def test_missing_output_dir_returns_none(self):
+    ctx = core.TestContext(
+        pytree=None,
+        path=self._OUTPUT_DIR / self._NAME,
+        options=_TraceOpts(),
+        mesh=None,
+    )
+    self.assertIsNone(ctx.trace_path('save'))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
@@ -185,7 +185,7 @@ class TracemallocMetric(BaseMetric):
       top_n: int,
       peak: float,
   ):
-    """Compares two tracemalloc snapshots and logs the differences using logging.info.
+    """Compares two tracemalloc snapshots and logs the differences.
 
     Args:
         name: The name of the metric.
@@ -204,9 +204,7 @@ class TracemallocMetric(BaseMetric):
       return
 
     logging.info("--- Comparing tracemalloc snapshots for %s ---", name)
-    stats = snapshot2.compare_to(snapshot1, "lineno")
-
-    if not stats:
+    if not (stats := snapshot2.compare_to(snapshot1, "lineno")):
       logging.info(
           "[process_id=%s][name=%s] No memory differences found between"
           " snapshots.",
@@ -259,8 +257,7 @@ class TracemallocMetric(BaseMetric):
       )
 
       # Get the line from the source file
-      line = linecache.getline(frame.filename, frame.lineno).strip()
-      if line:
+      if line := linecache.getline(frame.filename, frame.lineno).strip():
         logging.info("      >> %s", line)
 
     logging.info(
@@ -352,8 +349,7 @@ class TensorstoreMetric(BaseMetric):
         if isinstance(start_v, (int, float)) and isinstance(
             end_v, (int, float)
         ):
-          val_diff = end_v - start_v
-          if val_diff != 0:
+          if (val_diff := end_v - start_v) != 0:
             diff["value"] = val_diff
 
       if "count" in end_vals or "count" in start_vals:
@@ -362,8 +358,7 @@ class TensorstoreMetric(BaseMetric):
         if isinstance(start_c, (int, float)) and isinstance(
             end_c, (int, float)
         ):
-          count_diff = end_c - start_c
-          if count_diff != 0:
+          if (count_diff := end_c - start_c) != 0:
             diff["count"] = count_diff
 
       if diff:
@@ -474,6 +469,28 @@ class _MetricsCollector:
 ################################################################################
 # Aggregation and Reporting
 ################################################################################
+
+
+def _options_to_hparams(options: Any) -> dict[str, bool | int | float | str]:
+  """Flattens a benchmark options object into a TB HParams-acceptable dict.
+
+  HParams values must be primitives (bool / int / float / str). Anything else
+  (None, list, tuple, nested) is rendered via str() so the run still appears
+  in the Parallel Coordinates view rather than getting dropped.
+  """
+  if dataclasses.is_dataclass(options):
+    raw = dataclasses.asdict(options)
+  elif isinstance(options, dict):
+    raw = dict(options)
+  else:
+    return {}
+  out: dict[str, bool | int | float | str] = {}
+  for k, v in raw.items():
+    if isinstance(v, (bool, int, float, str)):
+      out[k] = v
+    else:
+      out[k] = str(v)
+  return out
 
 
 @dataclasses.dataclass
@@ -619,6 +636,8 @@ class MetricsManager:
               "configuration": json.dumps(configuration),
           },
       )
+      if hparams_dict := _options_to_hparams(benchmark_options):
+        writer.write_hparams(hparams_dict)
     writer.flush()
 
   def _aggregate_metrics(
@@ -654,101 +673,101 @@ class MetricsManager:
       )
     return aggregated_stats_dict, metric_units
 
+  def _count_runs(self) -> tuple[int, int, int]:
+    total = passed = failed = 0
+    for _, results in self._runs.items():
+      total += len(results)
+      for _, error in results:
+        if error is None:
+          passed += 1
+        else:
+          failed += 1
+    return total, passed, failed
+
+  def _format_stats_lines(
+      self,
+      aggregated_stats_dict: dict[str, AggregatedStats],
+      metric_units: dict[str, str],
+      indent: str,
+  ) -> list[str]:
+    lines = []
+    for key, stats in aggregated_stats_dict.items():
+      unit = metric_units[key]
+      lines.append(
+          f"{indent}{key}: {stats.mean:.4f} +/- {stats.std:.4f} {unit} (min:"
+          f" {stats.min:.4f}, max: {stats.max:.4f}, n={stats.count})"
+      )
+    return lines
+
+  def _format_aggregated_report_section(self) -> list[str]:
+    lines = ["\n" + "-" * 80, "--- Aggregated Metrics per Benchmark ---"]
+    for benchmark_name, results in self._runs.items():
+      if not results:
+        continue
+      lines.append(f"\nBenchmark: {benchmark_name}")
+      aggregated_stats_dict, metric_units = self._aggregate_metrics(results)
+      if not aggregated_stats_dict:
+        lines.append("  No successful runs to aggregate.")
+        continue
+      lines.extend(
+          self._format_stats_lines(aggregated_stats_dict, metric_units, "  ")
+      )
+    return lines
+
+  def _format_failed_runs_section(self) -> list[str]:
+    lines = ["\n" + "-" * 80, "--- Failed Runs ---"]
+    for _, results in self._runs.items():
+      for metrics, error in results:
+        if error is None:
+          continue
+        error_repr = repr(error)
+        # Limit error length to avoid flooding logs.
+        if len(error_repr) > 1000:
+          error_repr = error_repr[:1000] + "..."
+        lines.append(f"Test: {metrics.name}, Error: {error_repr}")
+    return lines
+
+  def _write_aggregated_to_tensorboard(self) -> None:
+    logging.info("Writing aggregated metrics to TensorBoard...")
+    for benchmark_name, results in self._runs.items():
+      writer = self._get_writer(benchmark_name)
+      aggregated_stats_dict, metric_units = self._aggregate_metrics(results)
+      if not aggregated_stats_dict:
+        aggregated_metrics = ["No successful runs to aggregate."]
+      else:
+        aggregated_metrics = self._format_stats_lines(
+            aggregated_stats_dict, metric_units, ""
+        )
+      aggregated_metrics_str = "\n".join(aggregated_metrics)
+      writer.write_texts(
+          step=0,
+          texts={"aggregated_metrics": f"<pre>{aggregated_metrics_str}</pre>"},
+      )
+      writer.flush()
+      writer.close()
+    # Clear writers after closing to prevent reuse of closed writers if called
+    # again.
+    self._writers.clear()
+    logging.info("Finished writing metrics to TensorBoard.")
+
   def generate_report(self) -> None:
     """Generates a final string report containing aggregated metrics.
 
     And exports aggregated metrics to TensorBoard if configured.
     """
-    report_lines = []
     title = f" Test Suite Report: {self._name} "
-    report_lines.append(f"\n{title:=^80}")
-
-    total_runs = 0
-    passed_runs = 0
-    failed_runs = 0
-    for _, results in self._runs.items():
-      total_runs += len(results)
-      for _, error in results:
-        if error is None:
-          passed_runs += 1
-        else:
-          failed_runs += 1
-
+    report_lines = [f"\n{title:=^80}"]
+    total_runs, passed_runs, failed_runs = self._count_runs()
     report_lines.append(f"Total benchmark configurations: {len(self._runs)}")
     report_lines.append(
         f"Total runs ({self._num_repeats} repeats): {total_runs}, Passed:"
         f" {passed_runs}, Failed: {failed_runs}"
     )
-
-    # Aggregate metrics, add to report, and write aggregates to TensorBoard
     if self._num_repeats > 1:
-      report_lines.append("\n" + "-" * 80)
-      report_lines.append("--- Aggregated Metrics per Benchmark ---")
-      for benchmark_name, results in self._runs.items():
-        if not results:
-          continue
-        report_lines.append(f"\nBenchmark: {benchmark_name}")
-
-        aggregated_stats_dict, metric_units = self._aggregate_metrics(results)
-
-        if not aggregated_stats_dict:
-          report_lines.append("  No successful runs to aggregate.")
-          continue
-
-        for key, stats in aggregated_stats_dict.items():
-          unit = metric_units[key]
-          report_lines.append(
-              f"  {key}: {stats.mean:.4f} +/- {stats.std:.4f} {unit} (min:"
-              f" {stats.min:.4f}, max: {stats.max:.4f}, n={stats.count})"
-          )
-
-    # Report failed runs
+      report_lines.extend(self._format_aggregated_report_section())
     if failed_runs > 0:
-      report_lines.append("\n" + "-" * 80)
-      report_lines.append("--- Failed Runs ---")
-      for _, results in self._runs.items():
-        for metrics, error in results:
-          if error is not None:
-            error_repr = repr(error)
-            # Limit error length to avoid flooding logs.
-            if len(error_repr) > 1000:
-              error_repr = error_repr[:1000] + "..."
-            report_lines.append(f"Test: {metrics.name}, Error: {error_repr}")
-
+      report_lines.extend(self._format_failed_runs_section())
     report_lines.append("\n" + "=" * 80)
     logging.info("\n".join(report_lines))
-
     if self._tensorboard_dir:
-      logging.info("Writing aggregated metrics to TensorBoard...")
-      for benchmark_name, results in self._runs.items():
-        writer = self._get_writer(benchmark_name)
-
-        # Write Aggregated metrics as text
-        aggregated_metrics = []
-        aggregated_stats_dict, metric_units = self._aggregate_metrics(results)
-
-        if not aggregated_stats_dict:
-          aggregated_metrics.append("No successful runs to aggregate.")
-        else:
-          for key, stats in aggregated_stats_dict.items():
-            unit = metric_units[key]
-            aggregated_metrics.append(
-                f"{key}: {stats.mean:.4f} +/- {stats.std:.4f} {unit} (min:"
-                f" {stats.min:.4f}, max: {stats.max:.4f}, n={stats.count})"
-            )
-
-        aggregated_metrics_str = "\n".join(aggregated_metrics)
-        writer.write_texts(
-            step=0,
-            texts={
-                "aggregated_metrics": f"<pre>{aggregated_metrics_str}</pre>"
-            },
-        )
-
-        writer.flush()
-        writer.close()
-
-      # Clear writers after closing to prevent reuse of closed writers if called
-      # again.
-      self._writers.clear()
-      logging.info("Finished writing metrics to TensorBoard.")
+      self._write_aggregated_to_tensorboard()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import json
 import time
 import tracemalloc
@@ -367,6 +368,102 @@ class MetricsManagerTest(parameterized.TestCase):
         step=0, scalars={'acc_': 0.9}
     )
     mock_writer.flush.assert_called_once()
+
+
+@dataclasses.dataclass(frozen=True)
+class _HpOpts:
+  async_enabled: bool = True
+  chunk_byte_size: int | None = None
+  notes: str = 'baseline'
+
+
+class MetricsManagerHparamsTest(parameterized.TestCase):
+  """The HParams summary is emitted once per (benchmark, run) at step 0."""
+
+  @mock.patch(
+      'orbax.checkpoint._src.testing.benchmarks.core.metric.metric_writers.create_default_writer'
+  )
+  def test_first_result_writes_hparams_from_options(self, mock_create_writer):
+    mock_writer = mock.Mock()
+    mock_create_writer.return_value = mock_writer
+    temp_dir = epath.Path(self.create_tempdir().full_path)
+    manager = metric_lib.MetricsManager(
+        name='HpSuite', num_repeats=1, tensorboard_dir=temp_dir
+    )
+
+    m = metric_lib.Metrics()
+    m.results['load_time_duration'] = (1.0, 's')
+    manager.add_result(
+        'bench1',
+        m,
+        benchmark_options=_HpOpts(
+            async_enabled=False, chunk_byte_size=256, notes='x'
+        ),
+    )
+
+    mock_writer.write_hparams.assert_called_once_with(
+        {
+            'async_enabled': False,
+            'chunk_byte_size': 256,
+            'notes': 'x',
+        }
+    )
+
+  @mock.patch(
+      'orbax.checkpoint._src.testing.benchmarks.core.metric.metric_writers.create_default_writer'
+  )
+  def test_subsequent_results_do_not_rewrite_hparams(self, mock_create_writer):
+    mock_writer = mock.Mock()
+    mock_create_writer.return_value = mock_writer
+    temp_dir = epath.Path(self.create_tempdir().full_path)
+    manager = metric_lib.MetricsManager(
+        name='HpSuite', num_repeats=2, tensorboard_dir=temp_dir
+    )
+
+    opts = _HpOpts()
+    for _ in range(2):
+      m = metric_lib.Metrics()
+      m.results['load_time_duration'] = (1.0, 's')
+      manager.add_result('bench1', m, benchmark_options=opts)
+
+    mock_writer.write_hparams.assert_called_once()
+
+  @mock.patch(
+      'orbax.checkpoint._src.testing.benchmarks.core.metric.metric_writers.create_default_writer'
+  )
+  def test_no_options_does_not_call_write_hparams(self, mock_create_writer):
+    mock_writer = mock.Mock()
+    mock_create_writer.return_value = mock_writer
+    temp_dir = epath.Path(self.create_tempdir().full_path)
+    manager = metric_lib.MetricsManager(
+        name='HpSuite', num_repeats=1, tensorboard_dir=temp_dir
+    )
+
+    m = metric_lib.Metrics()
+    m.results['load_time_duration'] = (1.0, 's')
+    manager.add_result('bench1', m, benchmark_options=None)
+
+    mock_writer.write_hparams.assert_not_called()
+
+  @mock.patch(
+      'orbax.checkpoint._src.testing.benchmarks.core.metric.metric_writers.create_default_writer'
+  )
+  def test_none_field_value_serialized_as_string(self, mock_create_writer):
+    mock_writer = mock.Mock()
+    mock_create_writer.return_value = mock_writer
+    temp_dir = epath.Path(self.create_tempdir().full_path)
+    manager = metric_lib.MetricsManager(
+        name='HpSuite', num_repeats=1, tensorboard_dir=temp_dir
+    )
+
+    m = metric_lib.Metrics()
+    m.results['load_time_duration'] = (1.0, 's')
+    manager.add_result(
+        'bench1', m, benchmark_options=_HpOpts(chunk_byte_size=None)
+    )
+
+    args, _ = mock_writer.write_hparams.call_args
+    self.assertEqual(args[0]['chunk_byte_size'], 'None')
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
@@ -77,6 +77,7 @@ class BenchmarkOptions(benchmarks_core.BenchmarkOptions):
   enable_replica_parallel_separate_folder: bool | Sequence[bool] = False
   chunk_byte_size: int | None | Sequence[int | None] = None
   enable_trace: bool = False
+  trace_every_repeat: bool = False
 
   def is_valid(self) -> bool:
     assert isinstance(self.use_replica_parallel, bool)
@@ -89,6 +90,7 @@ class BenchmarkOptions(benchmarks_core.BenchmarkOptions):
 
   @property
   def context(self) -> ocp.Context:
+    separate_folder = self.enable_replica_parallel_separate_folder
     return ocp.Context(
         array_options=ocp.options.ArrayOptions(
             saving=ocp.options.ArrayOptions.Saving(
@@ -99,7 +101,7 @@ class BenchmarkOptions(benchmarks_core.BenchmarkOptions):
                 use_zarr3=self.use_zarr3,
                 use_replica_parallel=self.use_replica_parallel,
                 use_compression=self.use_compression,
-                enable_replica_parallel_separate_folder=self.enable_replica_parallel_separate_folder,
+                enable_replica_parallel_separate_folder=separate_folder,
             ),
             loading=ocp.options.ArrayOptions.Loading(
                 use_load_and_broadcast=self.use_load_and_broadcast,
@@ -159,9 +161,12 @@ class Benchmark(benchmarks_core.BenchmarksGenerator):
     logging.info("Benchmark options: %s", pprint.pformat(options))
     metrics_to_measure = get_metrics_to_measure(options)
 
+    save_trace = context.trace_path("save")
+    load_trace = context.trace_path("load")
+
     with ocp.Context(context=options.context):
-      if options.enable_trace:
-        jax.profiler.start_trace(context.path / "trace_save")
+      if save_trace is not None:
+        jax.profiler.start_trace(str(save_trace))
       if options.async_enabled:
         with metrics.measure("save_blocking", metrics_to_measure):
           f = ocp.save_async(save_path, pytree)
@@ -173,15 +178,15 @@ class Benchmark(benchmarks_core.BenchmarksGenerator):
         with metrics.measure("save_background", metrics_to_measure):
           pass
       context.pytree = clear_pytree(context.pytree)
-      if options.enable_trace:
+      if save_trace is not None:
         jax.profiler.stop_trace()
 
-      if options.enable_trace:
-        jax.profiler.start_trace(context.path / "trace_load")
+      if load_trace is not None:
+        jax.profiler.start_trace(str(load_trace))
       with metrics.measure("load", metrics_to_measure):
         restored_pytree = ocp.load(save_path, abstract_state=abstract_pytree)
       clear_pytree(restored_pytree)
-      if options.enable_trace:
+      if load_trace is not None:
         jax.profiler.stop_trace()
 
     return benchmarks_core.TestResult(metrics=metrics)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark.py
@@ -120,12 +120,14 @@ class ReplicaParallelMultislice(benchmarks_core.BenchmarksGenerator):
           reference_checkpoint_path, abstract_state=abstract_pytree
       )
 
+    save_trace = context.trace_path("save")
+
     for step in range(options.num_savings):
       logging.info("ReplicaParallelMultislice: Starting Step: %s", step)
       save_path = context.path / "ckpt" / str(step)
       with ocp.Context(context=options.context):
-        if options.enable_trace:
-          jax.profiler.start_trace(context.path / "trace_save")
+        if save_trace is not None:
+          jax.profiler.start_trace(str(save_trace))
         if options.async_enabled:
           with metrics.measure("save_blocking", metrics_to_measure):
             logging.info(
@@ -150,7 +152,7 @@ class ReplicaParallelMultislice(benchmarks_core.BenchmarksGenerator):
 
     # Clear the pytree to free up memory.
     context.pytree = benchmark.clear_pytree(loaded_pytree)
-    if options.enable_trace:
+    if save_trace is not None:
       jax.profiler.stop_trace()
 
     return benchmarks_core.TestResult(metrics=metrics)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/resharding_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/resharding_benchmark.py
@@ -88,12 +88,10 @@ class ReshardingBenchmark(benchmarks_core.BenchmarksGenerator):
 
     assert options.reference_checkpoint_path is not None
     assert options.reference_sharding_path is not None
-    reference_checkpoint_path = epath.Path(
-        options.reference_checkpoint_path
-    )
-    reference_sharding_path = epath.Path(
-        options.reference_sharding_path
-    )
+    reference_checkpoint_path = epath.Path(options.reference_checkpoint_path)
+    reference_sharding_path = epath.Path(options.reference_sharding_path)
+
+    load_trace = context.trace_path("load")
 
     with ocp.Context(context=options.context):
       metadata = ocp.metadata(reference_checkpoint_path)
@@ -105,14 +103,14 @@ class ReshardingBenchmark(benchmarks_core.BenchmarksGenerator):
           )
       )
 
-      if options.enable_trace:
-        jax.profiler.start_trace(context.path / "trace_load")
+      if load_trace is not None:
+        jax.profiler.start_trace(str(load_trace))
       with metrics.measure("load", metrics_to_measure):
         restored_pytree = ocp.load(
             reference_checkpoint_path, abstract_state=abstract_pytree
         )
       benchmark.clear_pytree(restored_pytree)
-      if options.enable_trace:
+      if load_trace is not None:
         jax.profiler.stop_trace()
 
     return benchmarks_core.TestResult(metrics=metrics)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/restore_and_broadcast_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/restore_and_broadcast_benchmark.py
@@ -94,12 +94,8 @@ class RestoreAndBroadcastBenchmark(benchmarks_core.BenchmarksGenerator):
     logging.info("Benchmark options: %s", pprint.pformat(options))
     metrics_to_measure = benchmark.get_metrics_to_measure(options)
 
-    reference_checkpoint_path = epath.Path(
-        options.reference_checkpoint_path
-    )
-    reference_sharding_path = epath.Path(
-        options.reference_sharding_path
-    )
+    reference_checkpoint_path = epath.Path(options.reference_checkpoint_path)
+    reference_sharding_path = epath.Path(options.reference_sharding_path)
 
     if context.mesh.devices.ndim != 2:
       raise ValueError(
@@ -118,15 +114,17 @@ class RestoreAndBroadcastBenchmark(benchmarks_core.BenchmarksGenerator):
         reference_sharding_path=reference_sharding_path,
     )
 
+    load_trace = context.trace_path("load")
+
     with ocp.Context(context=options.context):
-      if options.enable_trace:
-        jax.profiler.start_trace(context.path / "trace_load")
+      if load_trace is not None:
+        jax.profiler.start_trace(str(load_trace))
       with metrics.measure("load", metrics_to_measure):
         restored_pytree = ocp.load(
             reference_checkpoint_path, abstract_state=abstract_pytree
         )
       benchmark.clear_pytree(restored_pytree)
-      if options.enable_trace:
+      if load_trace is not None:
         jax.profiler.stop_trace()
 
     return benchmarks_core.TestResult(metrics=metrics)


### PR DESCRIPTION
## Summary

Adds two TensorBoard integrations to the Orbax v1 benchmark framework.

**HParams summary per benchmark run.** Each run emits a TensorBoard
HParams summary recording the benchmark's options. TB's Parallel
Coordinates view then renders option-value sweeps as a draggable
axis chart, replacing per-axis comparison by hand.

**Per-operation profile traces.** Each measured save/load operation
is wrapped in `jax.profiler.start_trace` / `stop_trace`, with trace
data written into the TB run directory. An open Profile tab can step
through any benchmark run without separate trace plumbing.