### PR TITLE
Install pytype in the lint CI runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,8 +26,12 @@ jobs:
           python-version-file: '.python-version'
           cache: 'pip'
 
-      - name: Install Pre-commit
-        run: pip install pre-commit
+      - name: Install Pre-commit and Pytype
+        # pytype is declared as a `language: system` pre-commit hook, so it
+        # must be on the runner's PATH before the hook can be invoked. The
+        # version is pinned to match the rev in .pre-commit-config.yaml so
+        # CI and local runs agree on the same pytype.
+        run: pip install pre-commit pytype==2024.10.11
 
       - name: Execute Code Formatting & Lint Validation on PR Delta
         run: pre-commit run --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }} --show-diff-on-failure


### PR DESCRIPTION
## Summary

The pytype pre-commit hook is declared `language: system`, so the
hook driver expects `pytype` on the runner's `PATH` at execution
time. The current `lint.yml` installs only `pre-commit`, so the
hook fails on every PR with:

```
pytype...................................................................Failed
- hook id: pytype
- exit code: 1

Executable `pytype` not found
```

Adds pytype to the install step, pinned to the same rev the hook
config uses (`2024.10.11`) so CI and local runs agree on the same
pytype version.