### PR TITLE
Add HParams summary + per-operation profile traces to benchmark runs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,8 @@ repos:
         name: pylint
         types: [python]
         verbose: true
+        additional_dependencies:
+          - pylint-per-file-ignores
         args:
           - --rcfile=.pylintrc
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -20,7 +20,7 @@ persistent=no
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=pylint.extensions.docparams,pylint.extensions.code_style,pylint.extensions.typing,pylint.extensions.mccabe
+load-plugins=pylint.extensions.docparams,pylint.extensions.code_style,pylint.extensions.typing,pylint.extensions.mccabe,pylint.extensions.bad_builtin,pylint_per_file_ignores
 
 # Use multiple processes to speed up Pylint.
 jobs=4
@@ -40,14 +40,20 @@ extension-pkg-whitelist=
 # Default docstring format.
 default-docstring-type=google
 
+# Set to 'yes' to ignore missing 'raises' documentation
+accept-no-raise-doc=yes
+
 
 
 
 [MESSAGES CONTROL]
 
+per-file-ignores =
+    **/*_test.py:missing-module-docstring,missing-class-docstring,missing-function-docstring,missing-any-param-doc,protected-access
+
 # Only show warnings with the listed confidence levels. Leave empty to show
 # all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
-confidence=
+confidence=HIGH,INFERENCE,UNDEFINED
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -64,7 +70,26 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=apply-builtin,
+disable=unused-wildcard-import,
+        no-name-in-module,
+        method-hidden,
+        access-member-before-definition,
+        interface-is-not-class,
+        missing-interface-method,
+        unresolved-interface,
+        no-init,
+        maybe-no-member,
+        implicit-str-concat,
+        misplaced-comparison-constant,
+        basestring-builtin,
+        superfluous-parens,
+        pointless-except,
+        redundant-u-string-prefix,
+        unspecified-encoding,
+        unsubscriptable-object,
+        useless-object-inheritance,
+        wrong-import-position,
+        apply-builtin,
         arguments-differ,
         attribute-defined-outside-init,
         backtick,
@@ -183,9 +208,6 @@ disable=apply-builtin,
         wrong-import-order,
         xrange-builtin,
         zip-builtin-not-iterating,
-        missing-module-docstring,
-        missing-function-docstring,
-        missing-class-docstring,
         protected-access,
         invalid-name,
         redefined-outer-name,
@@ -232,25 +254,34 @@ include-naming-hint=no
 
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.
-property-classes=abc.abstractproperty,cached_property.cached_property,cached_property.threaded_cached_property,cached_property.cached_property_with_ttl,cached_property.threaded_cached_property_with_ttl
+property-classes=abc.abstractproperty,cached_property.cached_property,cached_property.threaded_cached_property,cached_property.cached_property_with_ttl,cached_property.threaded_cached_property_with_ttl,functools.cached_property
 
 # Regular expression matching correct function names
 function-rgx=^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
 
-# Regular expression matching correct variable names
-variable-rgx=^[a-z][a-z0-9_]*$
+# Regular expression matching correct variable names (sanctioned leading underscore for private variables)
+variable-rgx=^[a-z_][a-z0-9_]*$
+
+# Regular expression which should only match correct TypeVar names
+typevar-rgx=^_{0,2}(?:[^\W\da-z_]+|(?:[^\W\da-z_]+[^\WA-Z_]+)+T?)(?:_co(?:ntra)?)?$
+
+# Regular expression which should only match correct TypeAlias names
+typealias-rgx=^_?[A-Z][a-zA-Z0-9]*$
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=input,apply,reduce
 
 # Regular expression matching correct constant names
 const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
 
-# Regular expression matching correct attribute names
-attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
+# Regular expression matching correct attribute names (allows unittest2 base attributes)
+attr-rgx=^(_{0,2}[a-z][a-z0-9_]*|maxDiff|longMessage|failureException)$
 
 # Regular expression matching correct argument names
 argument-rgx=^[a-z][a-z0-9_]*$
 
-# Regular expression matching correct class attribute names
-class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+# Regular expression matching correct class attribute names (allows unittest2 base attributes)
+class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*|maxDiff|longMessage|failureException)$
 
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=^[a-z][a-z0-9_]*$
@@ -266,11 +297,11 @@ method-rgx=(?x)^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=(__.*__|main|test.*|.*test|.*Test|_.*)$
+no-docstring-rgx=(__.*__|main|test.*|.*test|.*Test)$
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
-docstring-min-length=10
+docstring-min-length=12
 
 
 [TYPECHECK]
@@ -369,6 +400,18 @@ redefining-builtins-modules=six,six.moves,past.builtins,future.builtins,functool
 # Logging modules to check that the string format arguments are in logging
 # function parameter format
 logging-modules=logging,absl.logging
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=yes
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=yes
 
 
 [SIMILARITIES]

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core.py
@@ -15,12 +15,12 @@
 """Core classes and functions for benchmarking Orbax."""
 
 import abc
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 import dataclasses
 import hashlib
 import itertools
 import sys
-from typing import Any, Callable
+from typing import Any
 
 from absl import logging
 from etils import epath
@@ -33,9 +33,23 @@ from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 from orbax.checkpoint._src.testing.benchmarks.core import multihost
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class BenchmarkOptions:
-  """Base class for benchmark generator options."""
+  """Base class for benchmark generator options.
+
+  Attributes:
+    enable_trace: Whether to capture a per-operation `jax.profiler` trace for
+      each measured save/load. Off by default.
+    trace_every_repeat: Whether to capture traces on every repeat, or only the
+      first repeat (the default); traces on every repeat overflow the Trace
+      Viewer.
+  """
+
+  # Keyword-only so subclasses keep their own positional / required fields
+  # (e.g. PyTorchCheckpointOptions.reference_checkpoint_path) without tripping
+  # the "non-default argument follows default argument" rule.
+  enable_trace: bool = False
+  trace_every_repeat: bool = False
 
   @classmethod
   def from_dict(cls, options_dict: dict[str, Any]) -> "BenchmarkOptions":
@@ -80,6 +94,10 @@ class TestContext:
     repeat_index: The index of the repeat run, if this test is run multiple
       times.
     local_path: The local path to store the checkpoint data.
+    output_dir: The suite-level output directory. Used by `trace_path` to
+      compose TB Profile-plugin-discoverable trace paths.
+    name: The benchmark's stable hashed name. Used by `trace_path` as the
+      Profile-plugin <run> segment so traces show up alongside scalars.
   """
 
   pytree: Any | None
@@ -88,6 +106,41 @@ class TestContext:
   mesh: jax.sharding.Mesh | None = None
   repeat_index: int | None = None
   local_path: epath.Path | None = None
+  output_dir: epath.Path | str | None = None
+  name: str | None = None
+
+  def trace_path(self, operation: str) -> epath.Path | None:
+    """Trace destination for an operation, or None if no trace is captured.
+
+    Args:
+      operation: The operation label (e.g. `save`, `load`) used as the
+        Profile-plugin run segment so each operation traces as a distinct run.
+
+    Returns:
+      The per-operation run directory under the suite's TensorBoard logdir
+      (`<output_dir>/tensorboard/<name>__<operation>`), beneath which
+      `jax.profiler` writes its `plugins/profile/<timestamp>/` tree so each
+      operation surfaces as a separate Profile-tab run alongside the scalar
+      runs. None when `options.enable_trace` is False, when `repeat_index` > 0
+      and `options.trace_every_repeat` is False (first-repeat-only is the
+      default; traces on every repeat overflow the Trace Viewer), or when
+      `output_dir` or `name` is missing.
+    """
+    if not self.options.enable_trace:
+      return None
+    if (
+        self.repeat_index is not None
+        and self.repeat_index > 0
+        and not self.options.trace_every_repeat
+    ):
+      return None
+    if self.output_dir is None or self.name is None:
+      return None
+    return (
+        epath.Path(self.output_dir)
+        / "tensorboard"
+        / f"{self.name}__{operation}"
+    )
 
 
 @dataclasses.dataclass
@@ -193,6 +246,8 @@ class Benchmark(abc.ABC):
         mesh=self.mesh,
         repeat_index=repeat_index,
         local_path=local_path,
+        output_dir=self.output_dir,
+        name=self.name,
     )
 
     test_context_summary = self._build_test_context_summary(context)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core_test.py
@@ -14,7 +14,6 @@
 
 import dataclasses
 import os
-from typing import List
 from unittest import mock
 
 from absl import logging
@@ -36,8 +35,8 @@ import torch.distributed as dist
 
 @dataclasses.dataclass(frozen=True)
 class MyBenchmarkOptions(core.BenchmarkOptions):
-  opt1: int | List[int] = 1
-  opt2: str | List[str] = 'a'
+  opt1: int | list[int] = 1
+  opt2: str | list[str] = 'a'
 
   def is_valid(self) -> bool:
     return not (self.opt1 == 2 and self.opt2 == 'a')
@@ -248,9 +247,7 @@ class BenchmarkTest(parameterized.TestCase):
     )
 
     result = benchmark.run(repeat_index=0)
-    mock_setup_test_directory.assert_called_once_with(
-        'test_benchmark', None, 0
-    )
+    mock_setup_test_directory.assert_called_once_with('test_benchmark', None, 0)
     self.assertEqual(mock_metrics_report.call_count, 2)
     self.assertEqual(result.metrics.name, 'test_benchmark_repeat_0')
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core_trace_path_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core_trace_path_test.py
@@ -1,0 +1,93 @@
+# Copyright 2026 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for TestContext.trace_path — the TB Profile-plugin layout routing."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from etils import epath
+from orbax.checkpoint._src.testing.benchmarks.core import core
+
+
+class TestContextTracePathTest(parameterized.TestCase):
+
+  _OUTPUT_DIR = epath.Path('/tmp/bench')
+  _NAME = 'MyBench_abc123'
+  _EXPECTED_SAVE = _OUTPUT_DIR / 'tensorboard' / f'{_NAME}__save'
+  _EXPECTED_LOAD = _OUTPUT_DIR / 'tensorboard' / f'{_NAME}__load'
+
+  def _ctx(
+      self,
+      *,
+      repeat_index=None,
+      enable_trace=True,
+      trace_every_repeat=False,
+  ):
+    path = self._OUTPUT_DIR / self._NAME
+    if repeat_index is not None:
+      path = path / f'repeat_{repeat_index}'
+    return core.TestContext(
+        pytree=None,
+        path=path,
+        options=core.BenchmarkOptions(
+            enable_trace=enable_trace,
+            trace_every_repeat=trace_every_repeat,
+        ),
+        mesh=None,
+        repeat_index=repeat_index,
+        output_dir=self._OUTPUT_DIR,
+        name=self._NAME,
+    )
+
+  def test_no_repeat_returns_tb_profile_layout(self):
+    self.assertEqual(self._ctx().trace_path('save'), self._EXPECTED_SAVE)
+
+  def test_first_repeat_captures(self):
+    self.assertEqual(
+        self._ctx(repeat_index=0).trace_path('load'), self._EXPECTED_LOAD
+    )
+
+  def test_non_first_repeat_skipped_by_default(self):
+    self.assertIsNone(self._ctx(repeat_index=2).trace_path('save'))
+
+  def test_trace_every_repeat_captures_all(self):
+    self.assertEqual(
+        self._ctx(repeat_index=2, trace_every_repeat=True).trace_path('save'),
+        self._EXPECTED_SAVE,
+    )
+
+  def test_disabled_returns_none(self):
+    self.assertIsNone(self._ctx(enable_trace=False).trace_path('save'))
+
+  def test_disabled_overrides_trace_every_repeat(self):
+    self.assertIsNone(
+        self._ctx(
+            repeat_index=0,
+            enable_trace=False,
+            trace_every_repeat=True,
+        ).trace_path('save')
+    )
+
+  def test_missing_output_dir_returns_none(self):
+    ctx = core.TestContext(
+        pytree=None,
+        path=self._OUTPUT_DIR / self._NAME,
+        options=core.BenchmarkOptions(enable_trace=True),
+        mesh=None,
+    )
+    self.assertIsNone(ctx.trace_path('save'))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
@@ -476,6 +476,35 @@ class _MetricsCollector:
 ################################################################################
 
 
+def _options_to_hparams(options: Any) -> dict[str, bool | int | float | str]:
+  """Flattens a benchmark options object into a TB HParams-acceptable dict.
+
+  HParams values must be primitives (bool / int / float / str). Anything else
+  (None, list, tuple, nested) is rendered via str() so the run still appears
+  in the Parallel Coordinates view rather than getting dropped.
+
+  Args:
+    options: A dataclass instance or dict of benchmark options to flatten;
+      anything else yields an empty dict.
+
+  Returns:
+    A dict of primitive HParam values keyed by option name.
+  """
+  if dataclasses.is_dataclass(options):
+    raw = dataclasses.asdict(options)
+  elif isinstance(options, dict):
+    raw = dict(options)
+  else:
+    return {}
+  out: dict[str, bool | int | float | str] = {}
+  for k, v in raw.items():
+    if isinstance(v, (bool, int, float, str)):
+      out[k] = v
+    else:
+      out[k] = str(v)
+  return out
+
+
 @dataclasses.dataclass
 class AggregatedStats:
   """Statistics aggregated over multiple benchmark repetitions.
@@ -619,6 +648,8 @@ class MetricsManager:
               "configuration": json.dumps(configuration),
           },
       )
+      if hparams_dict := _options_to_hparams(benchmark_options):
+        writer.write_hparams(hparams_dict)
     writer.flush()
 
   def _aggregate_metrics(
@@ -654,101 +685,104 @@ class MetricsManager:
       )
     return aggregated_stats_dict, metric_units
 
+  def _count_runs(self) -> tuple[int, int, int]:
+    total = passed = failed = 0
+    for _, results in self._runs.items():
+      total += len(results)
+      for _, error in results:
+        if error is None:
+          passed += 1
+        else:
+          failed += 1
+    return total, passed, failed
+
+  def _format_stats_lines(
+      self,
+      aggregated_stats_dict: dict[str, AggregatedStats],
+      metric_units: dict[str, str],
+      indent: str,
+  ) -> list[str]:
+    """Formats aggregated stats into human-readable report lines."""
+    lines = []
+    for key, stats in aggregated_stats_dict.items():
+      unit = metric_units[key]
+      lines.append(
+          f"{indent}{key}: {stats.mean:.4f} +/- {stats.std:.4f} {unit} (min:"
+          f" {stats.min:.4f}, max: {stats.max:.4f}, n={stats.count})"
+      )
+    return lines
+
+  def _format_aggregated_report_section(self) -> list[str]:
+    """Builds the per-benchmark aggregated-metrics section of the report."""
+    lines = ["\n" + "-" * 80, "--- Aggregated Metrics per Benchmark ---"]
+    for benchmark_name, results in self._runs.items():
+      if not results:
+        continue
+      lines.append(f"\nBenchmark: {benchmark_name}")
+      aggregated_stats_dict, metric_units = self._aggregate_metrics(results)
+      if not aggregated_stats_dict:
+        lines.append("  No successful runs to aggregate.")
+        continue
+      lines.extend(
+          self._format_stats_lines(aggregated_stats_dict, metric_units, "  ")
+      )
+    return lines
+
+  def _format_failed_runs_section(self) -> list[str]:
+    lines = ["\n" + "-" * 80, "--- Failed Runs ---"]
+    for _, results in self._runs.items():
+      for metrics, error in results:
+        if error is None:
+          continue
+        error_repr = repr(error)
+        # Limit error length to avoid flooding logs.
+        if len(error_repr) > 1000:
+          error_repr = error_repr[:1000] + "..."
+        lines.append(f"Test: {metrics.name}, Error: {error_repr}")
+    return lines
+
+  def _write_aggregated_to_tensorboard(self) -> None:
+    """Writes each benchmark's aggregated metrics to TensorBoard as text."""
+    logging.info("Writing aggregated metrics to TensorBoard...")
+    for benchmark_name, results in self._runs.items():
+      writer = self._get_writer(benchmark_name)
+      aggregated_stats_dict, metric_units = self._aggregate_metrics(results)
+      if not aggregated_stats_dict:
+        aggregated_metrics = ["No successful runs to aggregate."]
+      else:
+        aggregated_metrics = self._format_stats_lines(
+            aggregated_stats_dict, metric_units, ""
+        )
+      aggregated_metrics_str = "\n".join(aggregated_metrics)
+      writer.write_texts(
+          step=0,
+          texts={"aggregated_metrics": f"<pre>{aggregated_metrics_str}</pre>"},
+      )
+      writer.flush()
+      writer.close()
+    # Clear writers after closing to prevent reuse of closed writers if called
+    # again.
+    self._writers.clear()
+    logging.info("Finished writing metrics to TensorBoard.")
+
   def generate_report(self) -> None:
     """Generates a final string report containing aggregated metrics.
 
     And exports aggregated metrics to TensorBoard if configured.
     """
-    report_lines = []
     title = f" Test Suite Report: {self._name} "
-    report_lines.append(f"\n{title:=^80}")
-
-    total_runs = 0
-    passed_runs = 0
-    failed_runs = 0
-    for _, results in self._runs.items():
-      total_runs += len(results)
-      for _, error in results:
-        if error is None:
-          passed_runs += 1
-        else:
-          failed_runs += 1
-
+    report_lines = [f"\n{title:=^80}"]
+    total_runs, passed_runs, failed_runs = self._count_runs()
     report_lines.append(f"Total benchmark configurations: {len(self._runs)}")
     report_lines.append(
         f"Total runs ({self._num_repeats} repeats): {total_runs}, Passed:"
         f" {passed_runs}, Failed: {failed_runs}"
     )
-
-    # Aggregate metrics, add to report, and write aggregates to TensorBoard
     if self._num_repeats > 1:
-      report_lines.append("\n" + "-" * 80)
-      report_lines.append("--- Aggregated Metrics per Benchmark ---")
-      for benchmark_name, results in self._runs.items():
-        if not results:
-          continue
-        report_lines.append(f"\nBenchmark: {benchmark_name}")
-
-        aggregated_stats_dict, metric_units = self._aggregate_metrics(results)
-
-        if not aggregated_stats_dict:
-          report_lines.append("  No successful runs to aggregate.")
-          continue
-
-        for key, stats in aggregated_stats_dict.items():
-          unit = metric_units[key]
-          report_lines.append(
-              f"  {key}: {stats.mean:.4f} +/- {stats.std:.4f} {unit} (min:"
-              f" {stats.min:.4f}, max: {stats.max:.4f}, n={stats.count})"
-          )
-
-    # Report failed runs
+      report_lines.extend(self._format_aggregated_report_section())
     if failed_runs > 0:
-      report_lines.append("\n" + "-" * 80)
-      report_lines.append("--- Failed Runs ---")
-      for _, results in self._runs.items():
-        for metrics, error in results:
-          if error is not None:
-            error_repr = repr(error)
-            # Limit error length to avoid flooding logs.
-            if len(error_repr) > 1000:
-              error_repr = error_repr[:1000] + "..."
-            report_lines.append(f"Test: {metrics.name}, Error: {error_repr}")
-
+      report_lines.extend(self._format_failed_runs_section())
     report_lines.append("\n" + "=" * 80)
     logging.info("\n".join(report_lines))
-
     if self._tensorboard_dir:
-      logging.info("Writing aggregated metrics to TensorBoard...")
-      for benchmark_name, results in self._runs.items():
-        writer = self._get_writer(benchmark_name)
-
-        # Write Aggregated metrics as text
-        aggregated_metrics = []
-        aggregated_stats_dict, metric_units = self._aggregate_metrics(results)
-
-        if not aggregated_stats_dict:
-          aggregated_metrics.append("No successful runs to aggregate.")
-        else:
-          for key, stats in aggregated_stats_dict.items():
-            unit = metric_units[key]
-            aggregated_metrics.append(
-                f"{key}: {stats.mean:.4f} +/- {stats.std:.4f} {unit} (min:"
-                f" {stats.min:.4f}, max: {stats.max:.4f}, n={stats.count})"
-            )
-
-        aggregated_metrics_str = "\n".join(aggregated_metrics)
-        writer.write_texts(
-            step=0,
-            texts={
-                "aggregated_metrics": f"<pre>{aggregated_metrics_str}</pre>"
-            },
-        )
-
-        writer.flush()
-        writer.close()
-
-      # Clear writers after closing to prevent reuse of closed writers if called
-      # again.
-      self._writers.clear()
-      logging.info("Finished writing metrics to TensorBoard.")
+      self._write_aggregated_to_tensorboard()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import json
 import time
 import tracemalloc
@@ -367,6 +368,102 @@ class MetricsManagerTest(parameterized.TestCase):
         step=0, scalars={'acc_': 0.9}
     )
     mock_writer.flush.assert_called_once()
+
+
+@dataclasses.dataclass(frozen=True)
+class _HpOpts:
+  async_enabled: bool = True
+  chunk_byte_size: int | None = None
+  notes: str = 'baseline'
+
+
+class MetricsManagerHparamsTest(parameterized.TestCase):
+  """The HParams summary is emitted once per (benchmark, run) at step 0."""
+
+  @mock.patch(
+      'orbax.checkpoint._src.testing.benchmarks.core.metric.metric_writers.create_default_writer'
+  )
+  def test_first_result_writes_hparams_from_options(self, mock_create_writer):
+    mock_writer = mock.Mock()
+    mock_create_writer.return_value = mock_writer
+    temp_dir = epath.Path(self.create_tempdir().full_path)
+    manager = metric_lib.MetricsManager(
+        name='HpSuite', num_repeats=1, tensorboard_dir=temp_dir
+    )
+
+    m = metric_lib.Metrics()
+    m.results['load_time_duration'] = (1.0, 's')
+    manager.add_result(
+        'bench1',
+        m,
+        benchmark_options=_HpOpts(
+            async_enabled=False, chunk_byte_size=256, notes='x'
+        ),
+    )
+
+    mock_writer.write_hparams.assert_called_once_with(
+        {
+            'async_enabled': False,
+            'chunk_byte_size': 256,
+            'notes': 'x',
+        }
+    )
+
+  @mock.patch(
+      'orbax.checkpoint._src.testing.benchmarks.core.metric.metric_writers.create_default_writer'
+  )
+  def test_subsequent_results_do_not_rewrite_hparams(self, mock_create_writer):
+    mock_writer = mock.Mock()
+    mock_create_writer.return_value = mock_writer
+    temp_dir = epath.Path(self.create_tempdir().full_path)
+    manager = metric_lib.MetricsManager(
+        name='HpSuite', num_repeats=2, tensorboard_dir=temp_dir
+    )
+
+    opts = _HpOpts()
+    for _ in range(2):
+      m = metric_lib.Metrics()
+      m.results['load_time_duration'] = (1.0, 's')
+      manager.add_result('bench1', m, benchmark_options=opts)
+
+    mock_writer.write_hparams.assert_called_once()
+
+  @mock.patch(
+      'orbax.checkpoint._src.testing.benchmarks.core.metric.metric_writers.create_default_writer'
+  )
+  def test_no_options_does_not_call_write_hparams(self, mock_create_writer):
+    mock_writer = mock.Mock()
+    mock_create_writer.return_value = mock_writer
+    temp_dir = epath.Path(self.create_tempdir().full_path)
+    manager = metric_lib.MetricsManager(
+        name='HpSuite', num_repeats=1, tensorboard_dir=temp_dir
+    )
+
+    m = metric_lib.Metrics()
+    m.results['load_time_duration'] = (1.0, 's')
+    manager.add_result('bench1', m, benchmark_options=None)
+
+    mock_writer.write_hparams.assert_not_called()
+
+  @mock.patch(
+      'orbax.checkpoint._src.testing.benchmarks.core.metric.metric_writers.create_default_writer'
+  )
+  def test_none_field_value_serialized_as_string(self, mock_create_writer):
+    mock_writer = mock.Mock()
+    mock_create_writer.return_value = mock_writer
+    temp_dir = epath.Path(self.create_tempdir().full_path)
+    manager = metric_lib.MetricsManager(
+        name='HpSuite', num_repeats=1, tensorboard_dir=temp_dir
+    )
+
+    m = metric_lib.Metrics()
+    m.results['load_time_duration'] = (1.0, 's')
+    manager.add_result(
+        'bench1', m, benchmark_options=_HpOpts(chunk_byte_size=None)
+    )
+
+    args, _ = mock_writer.write_hparams.call_args
+    self.assertEqual(args[0]['chunk_byte_size'], 'None')
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
@@ -61,7 +61,6 @@ class BenchmarkOptions(benchmarks_core.BenchmarkOptions):
     use_replica_parallel: Whether to use replica parallel.
     enable_replica_parallel_separate_folder: Whether to enable replica parallel
       separate folder.
-    enable_trace: Whether to enable trace.
   """
 
   async_enabled: bool | Sequence[bool] = True
@@ -76,7 +75,6 @@ class BenchmarkOptions(benchmarks_core.BenchmarkOptions):
   use_replica_parallel: bool | Sequence[bool] = False
   enable_replica_parallel_separate_folder: bool | Sequence[bool] = False
   chunk_byte_size: int | None | Sequence[int | None] = None
-  enable_trace: bool = False
 
   def is_valid(self) -> bool:
     assert isinstance(self.use_replica_parallel, bool)
@@ -155,9 +153,12 @@ class Benchmark(benchmarks_core.BenchmarksGenerator):
     logging.info("Benchmark options: %s", pprint.pformat(options))
     metrics_to_measure = get_metrics_to_measure(options)
 
+    save_trace = context.trace_path("save")
+    load_trace = context.trace_path("load")
+
     with ocp.Context(context=options.context):
-      if options.enable_trace:
-        jax.profiler.start_trace(context.path / "trace_save")
+      if save_trace is not None:
+        jax.profiler.start_trace(str(save_trace))
       if options.async_enabled:
         with metrics.measure("save_blocking", metrics_to_measure):
           f = ocp.save_async(save_path, pytree)
@@ -169,15 +170,15 @@ class Benchmark(benchmarks_core.BenchmarksGenerator):
         with metrics.measure("save_background", metrics_to_measure):
           pass
       context.pytree = clear_pytree(context.pytree)
-      if options.enable_trace:
+      if save_trace is not None:
         jax.profiler.stop_trace()
 
-      if options.enable_trace:
-        jax.profiler.start_trace(context.path / "trace_load")
+      if load_trace is not None:
+        jax.profiler.start_trace(str(load_trace))
       with metrics.measure("load", metrics_to_measure):
         restored_pytree = ocp.load(save_path, abstract_state=abstract_pytree)
       clear_pytree(restored_pytree)
-      if options.enable_trace:
+      if load_trace is not None:
         jax.profiler.stop_trace()
 
     return benchmarks_core.TestResult(metrics=metrics)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark.py
@@ -120,12 +120,14 @@ class ReplicaParallelMultislice(benchmarks_core.BenchmarksGenerator):
           reference_checkpoint_path, abstract_state=abstract_pytree
       )
 
+    save_trace = context.trace_path("save")
+
     for step in range(options.num_savings):
       logging.info("ReplicaParallelMultislice: Starting Step: %s", step)
       save_path = context.path / "ckpt" / str(step)
       with ocp.Context(context=options.context):
-        if options.enable_trace:
-          jax.profiler.start_trace(context.path / "trace_save")
+        if save_trace is not None:
+          jax.profiler.start_trace(str(save_trace))
         if options.async_enabled:
           with metrics.measure("save_blocking", metrics_to_measure):
             logging.info(
@@ -150,7 +152,7 @@ class ReplicaParallelMultislice(benchmarks_core.BenchmarksGenerator):
 
     # Clear the pytree to free up memory.
     context.pytree = benchmark.clear_pytree(loaded_pytree)
-    if options.enable_trace:
+    if save_trace is not None:
       jax.profiler.stop_trace()
 
     return benchmarks_core.TestResult(metrics=metrics)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/resharding_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/resharding_benchmark.py
@@ -95,6 +95,8 @@ class ReshardingBenchmark(benchmarks_core.BenchmarksGenerator):
         options.reference_sharding_path
     )
 
+    load_trace = context.trace_path("load")
+
     with ocp.Context(context=options.context):
       metadata = ocp.metadata(reference_checkpoint_path)
       abstract_pytree = (
@@ -105,14 +107,14 @@ class ReshardingBenchmark(benchmarks_core.BenchmarksGenerator):
           )
       )
 
-      if options.enable_trace:
-        jax.profiler.start_trace(context.path / "trace_load")
+      if load_trace is not None:
+        jax.profiler.start_trace(str(load_trace))
       with metrics.measure("load", metrics_to_measure):
         restored_pytree = ocp.load(
             reference_checkpoint_path, abstract_state=abstract_pytree
         )
       benchmark.clear_pytree(restored_pytree)
-      if options.enable_trace:
+      if load_trace is not None:
         jax.profiler.stop_trace()
 
     return benchmarks_core.TestResult(metrics=metrics)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/restore_and_broadcast_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/restore_and_broadcast_benchmark.py
@@ -118,15 +118,17 @@ class RestoreAndBroadcastBenchmark(benchmarks_core.BenchmarksGenerator):
         reference_sharding_path=reference_sharding_path,
     )
 
+    load_trace = context.trace_path("load")
+
     with ocp.Context(context=options.context):
-      if options.enable_trace:
-        jax.profiler.start_trace(context.path / "trace_load")
+      if load_trace is not None:
+        jax.profiler.start_trace(str(load_trace))
       with metrics.measure("load", metrics_to_measure):
         restored_pytree = ocp.load(
             reference_checkpoint_path, abstract_state=abstract_pytree
         )
       benchmark.clear_pytree(restored_pytree)
-      if options.enable_trace:
+      if load_trace is not None:
         jax.profiler.stop_trace()
 
     return benchmarks_core.TestResult(metrics=metrics)


### PR DESCRIPTION
## Summary

Two enhancements to the v1 benchmark framework's TensorBoard integration:

- **HParams summary per run.** Every benchmark run emits a TensorBoard HParams
  summary recording the run's options, so option-value sweeps surface in
  TensorBoard's HParams / Parallel Coordinates views instead of being compared
  by hand.

- **Per-operation profile traces.** Each measured save/load operation is wrapped
  in `jax.profiler.start_trace` / `stop_trace`, writing trace data into the run's
  TensorBoard directory so the Profile (XProf) tab can step through any benchmark
  run with no extra trace plumbing. A new `trace_every_repeat` option controls
  whether traces are captured on every repeat or only the first; capture stays
  gated by the existing `enable_trace` (off by default).

## Testing

Adds `core_trace_path_test.py` covering the trace-path routing into the
TensorBoard Profile-plugin layout, plus cases in `core_test.py` and
`metric_test.py` for the metric / HParams writing.
