### PR TITLE
Surface jax.monitoring timings and namespaced metric tags in the benchmark suite

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -71,6 +71,7 @@ confidence=HIGH,INFERENCE,UNDEFINED
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=unused-wildcard-import,
+        unnecessary-default-type-args,
         no-name-in-module,
         method-hidden,
         access-member-before-definition,

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/array_handler_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/array_handler_benchmark_test.py
@@ -138,10 +138,10 @@ class ArrayHandlerBenchmarkTest(parameterized.TestCase):
     result = self._run_benchmark_workflow_test(options)
 
     self.assertIsInstance(result, benchmarks_core.TestResult)
-    self.assertIn('serialize_time_duration', result.metrics.results)
-    self.assertIn('metadata_validation_time_duration', result.metrics.results)
-    self.assertIn('deserialize_time_duration', result.metrics.results)
-    self.assertIn('correctness_check_time_duration', result.metrics.results)
+    self.assertIn('serialize_0_basics/time_s', result.metrics.results)
+    self.assertIn('metadata_validation_0_basics/time_s', result.metrics.results)
+    self.assertIn('deserialize_0_basics/time_s', result.metrics.results)
+    self.assertIn('correctness_check_0_basics/time_s', result.metrics.results)
 
   @parameterized.named_parameters(
       dict(
@@ -156,14 +156,14 @@ class ArrayHandlerBenchmarkTest(parameterized.TestCase):
   def test_benchmark_ocdbt_enabled_calls_merge(self, options):
     result = self._run_benchmark_workflow_test(options)
 
-    self.assertIn('merge_ocdbt_time_duration', result.metrics.results)
+    self.assertIn('merge_ocdbt_0_basics/time_s', result.metrics.results)
     self.mock_merge_ocdbt.assert_called_once()
 
   def test_benchmark_ocdbt_disabled_does_not_merge(self):
     options = ArrayHandlerBenchmarkOptions(use_ocdbt=False, use_zarr3=True)
     result = self._run_benchmark_workflow_test(options)
 
-    self.assertNotIn('merge_ocdbt_time_duration', result.metrics.results)
+    self.assertNotIn('merge_ocdbt_0_basics/time_s', result.metrics.results)
     self.mock_merge_ocdbt.assert_not_called()
 
   @parameterized.named_parameters(

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/array_handler_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/array_handler_benchmark_test.py
@@ -31,7 +31,6 @@ from orbax.checkpoint._src.testing.benchmarks import array_handler_benchmark
 from orbax.checkpoint._src.testing.benchmarks.core import configs as benchmarks_configs
 from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
 
-
 ArrayHandlerBenchmarkOptions = (
     array_handler_benchmark.ArrayHandlerBenchmarkOptions
 )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/checkpoint_manager_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/checkpoint_manager_benchmark_test.py
@@ -25,7 +25,6 @@ from orbax.checkpoint._src.testing.benchmarks import checkpoint_manager_benchmar
 from orbax.checkpoint._src.testing.benchmarks.core import configs as benchmarks_configs
 from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
 
-
 CheckpointManagerBenchmarkOptions = (
     checkpoint_manager_benchmark.CheckpointManagerBenchmarkOptions
 )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/checkpoint_manager_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/checkpoint_manager_benchmark_test.py
@@ -110,10 +110,10 @@ class CheckpointManagerBenchmarkTest(parameterized.TestCase):
     self.assertIsInstance(result, benchmarks_core.TestResult)
     self.assertContainsSubset(
         {
-            'save_0_time_duration',
-            'wait_until_finished_0_time_duration',
-            'restore_0_time_duration',
-            'correctness_check_time_duration',
+            'save_0_0_basics/time_s',
+            'wait_until_finished_0_0_basics/time_s',
+            'restore_0_0_basics/time_s',
+            'correctness_check_0_basics/time_s',
         },
         result.metrics.results.keys(),
     )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
@@ -36,7 +36,16 @@ import tensorstore as ts
 
 
 class BaseMetric:
-  """Base class for a metric type."""
+  """Base class for a metric type.
+
+  Subclass override knobs:
+    OMIT_REGISTRY_KEY_PREFIX: when True, the metric's result keys are taken
+      as final and the METRIC_REGISTRY key (e.g. "jax_monitoring") is NOT
+      spliced into the TB tag. Use when the metric already namespaces its
+      own keys (e.g. JaxMonitoringMetric returns "2_save_breakdown/...").
+  """
+
+  OMIT_REGISTRY_KEY_PREFIX: bool = False
 
   def __init__(self, name: str):
     self.name = name
@@ -66,16 +75,19 @@ class BaseMetric:
 class TimeMetric(BaseMetric):
   """Measures execution time."""
 
+  OMIT_REGISTRY_KEY_PREFIX = True
+
   def stop(self) -> dict[str, tuple[Any, str]]:
     duration = time.perf_counter() - self._start_time
     results = super().stop()
-    results["duration"] = (duration, "s")
+    results["0_basics/time_s"] = (duration, "s")
     return results
 
 
 class RssMetric(BaseMetric):
   """Measures RSS memory difference."""
 
+  OMIT_REGISTRY_KEY_PREFIX = True
   _start_rss: float = 0
 
   def start(self):
@@ -85,7 +97,7 @@ class RssMetric(BaseMetric):
   def stop(self) -> dict[str, tuple[Any, str]]:
     rss_diff = self._get_process_memory() - self._start_rss
     results = super().stop()
-    results["diff"] = (rss_diff, "MB")
+    results["0_basics/host_rss_diff_mb"] = (rss_diff, "MB")
     return results
 
   def _get_process_memory(self):
@@ -93,49 +105,10 @@ class RssMetric(BaseMetric):
     return process.memory_info().rss / (1024 * 1024)
 
 
-class IOBytesMetric(BaseMetric):
-  """Measures process I/O read/write bytes and throughput."""
-
-  _process: psutil.Process
-  _start_io: Any = None
-
-  def start(self):
-    super().start()
-    self._process = psutil.Process(os.getpid())
-    try:
-      self._start_io = self._process.io_counters()  # pytype: disable=attribute-error
-    except Exception as e:  # pylint: disable=broad-exception-caught
-      logging.warning("Failed to get initial IO counters: %s", e)
-      self._start_io = None
-
-  def stop(self) -> dict[str, tuple[Any, str]]:
-    results = super().stop()
-    if not self._start_io:
-      return results
-
-    try:
-      end_io = self._process.io_counters()  # pytype: disable=attribute-error
-      duration = time.perf_counter() - self._start_time
-
-      read_bytes = end_io.read_bytes - self._start_io.read_bytes
-      write_bytes = end_io.write_bytes - self._start_io.write_bytes
-
-      results["read_bytes"] = (read_bytes, "bytes")
-      results["write_bytes"] = (write_bytes, "bytes")
-
-      if duration > 0:
-        read_mb_s = (read_bytes / (1024 * 1024)) / duration
-        write_mb_s = (write_bytes / (1024 * 1024)) / duration
-        results["read_throughput"] = (read_mb_s, "MB/s")
-        results["write_throughput"] = (write_mb_s, "MB/s")
-    except Exception as e:  # pylint: disable=broad-exception-caught
-      logging.warning("Failed to get final IO counters: %s", e)
-    return results
-
-
 class TracemallocMetric(BaseMetric):
   """Measures memory allocation differences using tracemalloc."""
 
+  OMIT_REGISTRY_KEY_PREFIX = True
   _lock = threading.Lock()
   _active_count = 0
   _start_snapshot: Any = None
@@ -164,7 +137,7 @@ class TracemallocMetric(BaseMetric):
         tracemalloc.stop()
 
     peak_diff = end_peak - self._start_peak
-    results["peak_diff"] = (peak_diff / (1024**2), "MB")
+    results["7_memory/tracemalloc_peak_diff_mb"] = (peak_diff / (1024**2), "MB")
 
     self._log_tracemalloc_snapshot_diff(
         self.name,
@@ -273,6 +246,7 @@ class TracemallocMetric(BaseMetric):
 class TensorstoreMetric(BaseMetric):
   """Measures tensorstore metrics."""
 
+  OMIT_REGISTRY_KEY_PREFIX = True
   _start_metrics: dict[str, dict[str, Any]]
 
   def start(self):
@@ -309,7 +283,7 @@ class TensorstoreMetric(BaseMetric):
       )
 
     # Log the number of metrics that have a non-zero diff.
-    results["diff_count"] = (len(diff), f"{self.name}_diff_cnt")
+    results["6_tensorstore/diff_count"] = (len(diff), "count")
     return results
 
   def _collect_metrics(self) -> dict[str, dict[str, Any]]:
@@ -376,7 +350,6 @@ class TensorstoreMetric(BaseMetric):
 METRIC_REGISTRY: dict[str, type[BaseMetric]] = {
     "time": TimeMetric,
     "rss": RssMetric,
-    "io": IOBytesMetric,
     "tracemalloc": TracemallocMetric,
     "tensorstore": TensorstoreMetric,
 }
@@ -400,7 +373,10 @@ class Metrics:
       metric_results: dict[str, tuple[Any, str]],
   ):
     for key, (value, unit) in metric_results.items():
-      full_key = f"{metric_name}_{metric_key}_{key}"
+      if metric_key:
+        full_key = f"{metric_name}_{metric_key}_{key}"
+      else:
+        full_key = f"{metric_name}_{key}"
       self.results[full_key] = (value, unit)
 
   @contextlib.contextmanager
@@ -466,7 +442,8 @@ class _MetricsCollector:
     for key, metric in self._metrics.items():
       try:
         metric_results = metric.stop()
-        self.metrics_obj._add_results(metric.name, key, metric_results)
+        tag_key = "" if metric.OMIT_REGISTRY_KEY_PREFIX else key
+        self.metrics_obj._add_results(metric.name, tag_key, metric_results)
       except Exception as e:  # pylint: disable=broad-exception-caught
         logging.exception("Error stopping metric %s: %s", metric.name, e)
 
@@ -503,6 +480,95 @@ def _options_to_hparams(options: Any) -> dict[str, bool | int | float | str]:
     else:
       out[k] = str(v)
   return out
+
+
+def _render_configuration_markdown(
+    benchmark_name: str,
+    benchmark_options: dict[str, Any] | None,
+    checkpoint_config: dict[str, Any] | None,
+) -> str:
+  """Renders the run configuration as readable markdown.
+
+  Options + checkpoint_config become two field/value tables; any nested
+  dict in checkpoint_config (typically `spec`) is split out into its own
+  fenced-JSON block. Replaces the single-line `json.dumps` blob the
+  Text-tab card used to show.
+  """
+  lines = [f"## {benchmark_name}", ""]
+
+  def _table(title: str, items: list[tuple[str, Any]]) -> None:
+    lines.append(f"### {title}")
+    lines.append("")
+    lines.append("| field | value |")
+    lines.append("|---|---|")
+    for k, v in items:
+      lines.append(f"| `{k}` | `{v}` |")
+    lines.append("")
+
+  if benchmark_options:
+    _table(
+        "Benchmark options",
+        [(k, v) for k, v in sorted(benchmark_options.items())],
+    )
+
+  if checkpoint_config:
+    scalar_items = []
+    nested_items = []
+    for k, v in sorted(checkpoint_config.items()):
+      if isinstance(v, dict):
+        nested_items.append((k, v))
+      else:
+        scalar_items.append((k, v))
+    if scalar_items:
+      _table("Checkpoint config", scalar_items)
+    for k, v in nested_items:
+      lines.append(f"### Checkpoint config — `{k}`")
+      lines.append("")
+      lines.append("```json")
+      lines.append(json.dumps(v, indent=2, sort_keys=True))
+      lines.append("```")
+      lines.append("")
+  return "\n".join(lines)
+
+
+def _render_aggregated_metrics_markdown(
+    benchmark_name: str,
+    aggregated_stats_dict: dict[str, "AggregatedStats"],
+    metric_units: dict[str, str],
+) -> str:
+  """Renders the aggregated metrics as a markdown table grouped by `/` prefix.
+
+  TB's Text dashboard renders markdown — a proper table is dramatically
+  more readable than the previous `<pre>` raw dump, and grouping by
+  numbered prefix (`1_overview/`, `2_save_breakdown/`, …) mirrors the
+  Scalars-view navigation so a reader can locate a metric the same way
+  in both surfaces.
+  """
+  if not aggregated_stats_dict:
+    return "_No successful runs to aggregate._"
+
+  groups: dict[str, list[str]] = collections.defaultdict(list)
+  for key in sorted(aggregated_stats_dict):
+    head, _, _ = key.partition("/")
+    section = head if "/" in key else "_other_"
+    groups[section].append(key)
+
+  lines = [f"## {benchmark_name} — aggregated metrics", ""]
+  for section in sorted(groups):
+    lines.append(f"### {section}")
+    lines.append("")
+    lines.append("| metric | mean | ± std | min | max | n | unit |")
+    lines.append("|---|---:|---:|---:|---:|---:|---|")
+    for key in groups[section]:
+      stats = aggregated_stats_dict[key]
+      unit = metric_units.get(key, "")
+      leaf = key.split("/", 1)[1] if "/" in key else key
+      lines.append(
+          f"| `{leaf}` | {stats.mean:.4f} | {stats.std:.4f} |"
+          f" {stats.min:.4f} | {stats.max:.4f} | {stats.count} | {unit} |"
+      )
+    lines.append("")
+  return "\n".join(lines)
 
 
 @dataclasses.dataclass
@@ -615,7 +681,14 @@ class MetricsManager:
     writer = self._get_writer(benchmark_name)
     if error is None:
       for key, (value, unit) in metrics.results.items():
-        tag = f'{key}_{unit.replace("/", "_")}'
+        # Hierarchical keys (e.g. "2_save_breakdown/blocking_s") already
+        # encode the unit in their suffix; appending "_s" again gives the
+        # ugly "..._blocking_s_s". Skip the suffix for those; flat legacy
+        # keys keep the existing "{key}_{unit}" shape.
+        if "/" in key:
+          tag = key
+        else:
+          tag = f'{key}_{unit.replace("/", "_")}'
         if isinstance(value, (int, float)):
           writer.write_scalars(step=step, scalars={tag: value})
         else:
@@ -633,19 +706,17 @@ class MetricsManager:
 
       if dataclasses.is_dataclass(checkpoint_config):
         config_dict = dataclasses.asdict(checkpoint_config)
-      else:
+      elif isinstance(checkpoint_config, dict):
         config_dict = checkpoint_config
-
-      configuration = {
-          "benchmark_name": benchmark_name,
-          "benchmark_options": opt_dict,
-          "checkpoint_config": config_dict,
-      }
+      else:
+        config_dict = None
 
       writer.write_texts(
           step=0,
           texts={
-              "configuration": json.dumps(configuration),
+              "configuration": _render_configuration_markdown(
+                  benchmark_name, opt_dict, config_dict
+              ),
           },
       )
       if hparams_dict := _options_to_hparams(benchmark_options):
@@ -747,16 +818,12 @@ class MetricsManager:
     for benchmark_name, results in self._runs.items():
       writer = self._get_writer(benchmark_name)
       aggregated_stats_dict, metric_units = self._aggregate_metrics(results)
-      if not aggregated_stats_dict:
-        aggregated_metrics = ["No successful runs to aggregate."]
-      else:
-        aggregated_metrics = self._format_stats_lines(
-            aggregated_stats_dict, metric_units, ""
-        )
-      aggregated_metrics_str = "\n".join(aggregated_metrics)
+      aggregated_metrics_str = _render_aggregated_metrics_markdown(
+          benchmark_name, aggregated_stats_dict, metric_units
+      )
       writer.write_texts(
           step=0,
-          texts={"aggregated_metrics": f"<pre>{aggregated_metrics_str}</pre>"},
+          texts={"aggregated_metrics": aggregated_metrics_str},
       )
       writer.flush()
       writer.close()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
@@ -493,6 +493,15 @@ def _render_configuration_markdown(
   dict in checkpoint_config (typically `spec`) is split out into its own
   fenced-JSON block. Replaces the single-line `json.dumps` blob the
   Text-tab card used to show.
+
+  Args:
+    benchmark_name: Title rendered as the top-level `##` heading.
+    benchmark_options: Flat option name/value pairs, or None to omit the table.
+    checkpoint_config: Checkpoint config; scalar entries form a table and each
+      nested dict becomes its own fenced-JSON block.
+
+  Returns:
+    The configuration rendered as a markdown string.
   """
   lines = [f"## {benchmark_name}", ""]
 
@@ -543,6 +552,14 @@ def _render_aggregated_metrics_markdown(
   numbered prefix (`1_overview/`, `2_save_breakdown/`, …) mirrors the
   Scalars-view navigation so a reader can locate a metric the same way
   in both surfaces.
+
+  Args:
+    benchmark_name: Title rendered as the top-level heading.
+    aggregated_stats_dict: Metric tag -> aggregated stats to tabulate.
+    metric_units: Metric tag -> unit string shown alongside each value.
+
+  Returns:
+    The aggregated metrics rendered as a markdown string.
   """
   if not aggregated_stats_dict:
     return "_No successful runs to aggregate._"

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_jax_monitoring.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_jax_monitoring.py
@@ -27,7 +27,6 @@ from absl import logging
 import jax
 from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 
-
 _PREFIX_FILTER = (
     "/jax/orbax/",
     "/jax/checkpoint/",
@@ -174,6 +173,12 @@ def _default_tag(event: str) -> str:
   Routes into 9_other/ so unmapped events stay visible (queryable in the
   dashboard) without polluting the curated 2_/3_/4_/5_ namespaces. The
   leading "/jax/" is redundant (every captured event has it) so it's stripped.
+
+  Args:
+    event: The raw jax.monitoring event name (e.g. `/jax/.../duration`).
+
+  Returns:
+    The `9_other/`-prefixed dashboard tag for the event.
   """
   stripped = event.removeprefix("/jax/").lstrip("/")
   return "9_other/" + stripped.replace("/", "_")

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_jax_monitoring.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_jax_monitoring.py
@@ -1,0 +1,229 @@
+# Copyright 2026 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JaxMonitoringMetric — subscribes to jax.monitoring during a measure() block.
+
+Orbax-checkpoint emits ~30 named events through `jax.monitoring` covering
+every save/load stage. Subscribing during a measure() block re-publishes
+them as TB scalars under stable, navigable tag groups (`2_save_breakdown/`,
+`3_load_breakdown/`, `4_throughput/`, `5_inventory/`) without changing any
+production code.
+"""
+
+from typing import Any
+
+from absl import logging
+import jax
+from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
+
+
+_PREFIX_FILTER = (
+    "/jax/orbax/",
+    "/jax/checkpoint/",
+    "/jax/compilation_cache/",
+)
+
+
+_TAG_MAP: dict[str, tuple[str, str]] = {
+    # ─── 2_save_breakdown — per-stage save timings ────────────────────────
+    "/jax/orbax/write/blocking_duration_secs": (
+        "2_save_breakdown/blocking_s",
+        "s",
+    ),
+    "/jax/checkpoint/write/async/blocking_duration_secs": (
+        "2_save_breakdown/blocking_async_s",
+        "s",
+    ),
+    "/jax/orbax/write/total_duration_secs": (
+        "2_save_breakdown/total_s",
+        "s",
+    ),
+    "/jax/checkpoint/write/async/total_duration_secs": (
+        "2_save_breakdown/total_async_s",
+        "s",
+    ),
+    "/jax/orbax/write/directory_creation_secs": (
+        "2_save_breakdown/directory_creation_s",
+        "s",
+    ),
+    "/jax/orbax/write/async_directory_creation_secs": (
+        "2_save_breakdown/async_directory_creation_s",
+        "s",
+    ),
+    "/jax/checkpoint/write/async/metadata_write_duration_secs": (
+        "2_save_breakdown/metadata_write_s",
+        "s",
+    ),
+    "/jax/checkpoint/write/async/commit_duration_sec": (
+        "2_save_breakdown/commit_s",
+        "s",
+    ),
+    "/jax/checkpoint/write/async/thread_duration_sec": (
+        "2_save_breakdown/thread_duration_s",
+        "s",
+    ),
+    "/jax/checkpoint/write/async/commit_future_count": (
+        "2_save_breakdown/commit_future_count",
+        "count",
+    ),
+    "/jax/checkpoint/write/duration_since_last_checkpoint_secs": (
+        "2_save_breakdown/duration_since_last_save_s",
+        "s",
+    ),
+    "/jax/checkpoint/write/async/ocdbt_merge_duration_secs": (
+        "2_save_breakdown/ocdbt_merge_s",
+        "s",
+    ),
+    # ─── 3_load_breakdown — per-stage load timings ────────────────────────
+    "/jax/orbax/read/blocking_duration_secs": (
+        "3_load_breakdown/blocking_s",
+        "s",
+    ),
+    "/jax/orbax/read/async/blocking_duration_secs": (
+        "3_load_breakdown/blocking_async_s",
+        "s",
+    ),
+    "/jax/orbax/read/total_duration_secs": (
+        "3_load_breakdown/total_s",
+        "s",
+    ),
+    "/jax/orbax/read/async/total_duration_secs": (
+        "3_load_breakdown/total_async_s",
+        "s",
+    ),
+    "/jax/orbax/read/worker/total_duration_secs": (
+        "3_load_breakdown/worker_io_s",
+        "s",
+    ),
+    "/jax/checkpoint/read/primary_replica_deserialization_duration_secs": (
+        "3_load_breakdown/primary_deserialization_s",
+        "s",
+    ),
+    "/jax/checkpoint/read/broadcast_duration_secs": (
+        "3_load_breakdown/broadcast_s",
+        "s",
+    ),
+    # ─── 4_throughput — effective bandwidth ───────────────────────────────
+    "/jax/orbax/write/blocking_gbytes_per_sec": (
+        "4_throughput/save_blocking_gbps",
+        "GiB/s",
+    ),
+    "/jax/orbax/write/gbytes_per_sec": (
+        "4_throughput/save_total_gbps",
+        "GiB/s",
+    ),
+    "/jax/orbax/read/worker/io/requested/throughput/gbytes_per_sec": (
+        "4_throughput/load_per_host_gbps",
+        "GiB/s",
+    ),
+    "/jax/checkpoint/read/gbytes_per_sec": (
+        "4_throughput/load_total_gbps",
+        "GiB/s",
+    ),
+    # ─── 5_inventory — bytes / shapes ─────────────────────────────────────
+    "/jax/orbax/write/gbytes": (
+        "5_inventory/save_total_gb",
+        "GiB",
+    ),
+    "/jax/orbax/write/replicated_array_gb": (
+        "5_inventory/replicated_array_gb",
+        "GiB",
+    ),
+    "/jax/orbax/write/sharded_array_gb": (
+        "5_inventory/sharded_array_gb",
+        "GiB",
+    ),
+    "/jax/orbax/read/worker/io/requested/gbytes": (
+        "5_inventory/load_requested_gb",
+        "GiB",
+    ),
+    "/jax/checkpoint/read/gbytes": (
+        "5_inventory/load_total_gb",
+        "GiB",
+    ),
+    # ─── 7_overhead — auxiliary costs (coordination, lifecycle) ───────────
+    "/jax/checkpoint/sync_global_devices_duration_sec": (
+        "7_overhead/sync_global_devices_s",
+        "s",
+    ),
+    "/jax/orbax/checkpoint_manager/threaded_checkpoint_deleter/duration": (
+        "7_overhead/delete_threaded_s",
+        "s",
+    ),
+    "/jax/orbax/checkpoint_manager/standard_checkpoint_deleter/duration": (
+        "7_overhead/delete_standard_s",
+        "s",
+    ),
+}
+
+
+def _default_tag(event: str) -> str:
+  """Tag for an in-prefix event we don't have an explicit mapping for.
+
+  Routes into 9_other/ so unmapped events stay visible (queryable in the
+  dashboard) without polluting the curated 2_/3_/4_/5_ namespaces. The
+  leading "/jax/" is redundant (every captured event has it) so it's stripped.
+  """
+  stripped = event.removeprefix("/jax/").lstrip("/")
+  return "9_other/" + stripped.replace("/", "_")
+
+
+class JaxMonitoringMetric(metric_lib.BaseMetric):
+  """Captures jax.monitoring emissions during a measure() block.
+
+  Result keys are the final, curated TB tags (`2_save_breakdown/blocking_s`,
+  …). Splicing the registry key in between would just create
+  `..._jax_monitoring_2_save_breakdown/...` for no benefit, so this class
+  opts out via OMIT_REGISTRY_KEY_PREFIX.
+  """
+
+  OMIT_REGISTRY_KEY_PREFIX = True
+
+  def start(self) -> None:
+    super().start()
+    self._records: list[tuple[str, Any, str]] = []
+
+    def _on_scalar(event: str, value: float, **_kwargs):
+      if any(event.startswith(p) for p in _PREFIX_FILTER):
+        self._records.append((event, value, "scalar"))
+
+    def _on_duration(event: str, duration: float, **_kwargs):
+      if any(event.startswith(p) for p in _PREFIX_FILTER):
+        self._records.append((event, duration, "duration"))
+
+    self._scalar_cb = _on_scalar
+    self._duration_cb = _on_duration
+    jax.monitoring.register_scalar_listener(_on_scalar)
+    jax.monitoring.register_event_duration_secs_listener(_on_duration)
+
+  def stop(self) -> dict[str, tuple[Any, str]]:
+    results = super().stop()
+    try:
+      jax.monitoring.unregister_scalar_listener(self._scalar_cb)
+      jax.monitoring.unregister_event_duration_listener(self._duration_cb)
+    except (ValueError, AttributeError) as e:
+      logging.warning("Failed to unregister jax.monitoring listener: %s", e)
+
+    for event, value, kind in self._records:
+      tag_unit = _TAG_MAP.get(event)
+      if tag_unit is None:
+        tag = _default_tag(event)
+        unit = "s" if kind == "duration" else ""
+      else:
+        tag, unit = tag_unit
+      results[tag] = (value, unit)
+    return results
+
+
+metric_lib.METRIC_REGISTRY["jax_monitoring"] = JaxMonitoringMetric

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_jax_monitoring_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_jax_monitoring_test.py
@@ -18,7 +18,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 import jax
 from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
-from orbax.checkpoint._src.testing.benchmarks.core import metric_jax_monitoring  # noqa: F401  (registers JaxMonitoringMetric in METRIC_REGISTRY)
+from orbax.checkpoint._src.testing.benchmarks.core import metric_jax_monitoring  # pylint: disable=unused-import
 
 
 class JaxMonitoringMetricTest(parameterized.TestCase):

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_jax_monitoring_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_jax_monitoring_test.py
@@ -1,0 +1,176 @@
+# Copyright 2026 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for JaxMonitoringMetric — subscribing to jax.monitoring during a measure() block."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
+from orbax.checkpoint._src.testing.benchmarks.core import metric_jax_monitoring  # noqa: F401  (registers JaxMonitoringMetric in METRIC_REGISTRY)
+
+
+class JaxMonitoringMetricTest(parameterized.TestCase):
+
+  def tearDown(self):
+    # Defensive: ensure no listener survives a test that fails mid-flight.
+    jax.monitoring.clear_event_listeners()
+    super().tearDown()
+
+  def test_captures_duration_with_known_event_name(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/orbax/write/blocking_duration_secs', 1.5
+      )
+    self.assertIn('op_2_save_breakdown/blocking_s', metrics.results)
+    value, unit = metrics.results['op_2_save_breakdown/blocking_s']
+    self.assertEqual(value, 1.5)
+    self.assertEqual(unit, 's')
+
+  def test_captures_scalar_with_known_event_name(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_scalar(
+          '/jax/orbax/write/blocking_gbytes_per_sec', 12.5
+      )
+    self.assertIn('op_4_throughput/save_blocking_gbps', metrics.results)
+    value, unit = metrics.results['op_4_throughput/save_blocking_gbps']
+    self.assertEqual(value, 12.5)
+    self.assertEqual(unit, 'GiB/s')
+
+  def test_filters_out_events_with_non_orbax_prefix(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs('/jax/some/other/event', 7.7)
+    capture_keys = [k for k in metrics.results if 'other/event' in k]
+    self.assertEqual(capture_keys, [])
+
+  def test_unknown_orbax_event_falls_through_to_default_tag(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/orbax/write/some_unknown_event_secs', 0.3
+      )
+    self.assertIn(
+        'op_9_other/orbax_write_some_unknown_event_secs',
+        metrics.results,
+    )
+
+  def test_storage_type_label_ignored_for_tag(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/orbax/write/blocking_duration_secs', 2.0, storage_type='gs'
+      )
+    self.assertIn('op_2_save_breakdown/blocking_s', metrics.results)
+    value, _ = metrics.results['op_2_save_breakdown/blocking_s']
+    self.assertEqual(value, 2.0)
+
+  def test_does_not_capture_after_block_exits(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      pass
+    jax.monitoring.record_event_duration_secs(
+        '/jax/orbax/write/blocking_duration_secs', 99.0
+    )
+    leaked = [
+        k
+        for k in metrics.results
+        if 'blocking_s' in k and metrics.results[k][0] == 99.0
+    ]
+    self.assertEqual(leaked, [])
+
+  def test_two_blocks_do_not_cross_contaminate(self):
+    m_a = metric_lib.Metrics()
+    m_b = metric_lib.Metrics()
+    with m_a.measure('op_a', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/orbax/write/blocking_duration_secs', 1.0
+      )
+    with m_b.measure('op_b', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/orbax/read/blocking_duration_secs', 2.0
+      )
+    self.assertEqual(m_a.results['op_a_2_save_breakdown/blocking_s'][0], 1.0)
+    self.assertEqual(m_b.results['op_b_3_load_breakdown/blocking_s'][0], 2.0)
+    self.assertNotIn('op_b_2_save_breakdown/blocking_s', m_b.results)
+    self.assertNotIn('op_a_3_load_breakdown/blocking_s', m_a.results)
+
+  def test_ocdbt_merge_tagged_under_save_breakdown(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/checkpoint/write/async/ocdbt_merge_duration_secs', 0.7
+      )
+    self.assertIn('op_2_save_breakdown/ocdbt_merge_s', metrics.results)
+
+  def test_sync_global_devices_tagged_under_overhead(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/checkpoint/sync_global_devices_duration_sec', 0.05
+      )
+    self.assertIn(
+        'op_7_overhead/sync_global_devices_s',
+        metrics.results,
+    )
+
+  def test_threaded_delete_tagged_under_overhead(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/orbax/checkpoint_manager/threaded_checkpoint_deleter/duration',
+          0.12,
+      )
+    self.assertIn('op_7_overhead/delete_threaded_s', metrics.results)
+
+  def test_checkpoint_read_gbytes_per_sec_tagged_under_throughput(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_scalar('/jax/checkpoint/read/gbytes_per_sec', 18.9)
+    self.assertIn('op_4_throughput/load_total_gbps', metrics.results)
+
+  def test_checkpoint_read_gbytes_tagged_under_inventory(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_scalar('/jax/checkpoint/read/gbytes', 140.2)
+    self.assertIn('op_5_inventory/load_total_gb', metrics.results)
+
+  def test_standard_delete_tagged_under_overhead(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/orbax/checkpoint_manager/standard_checkpoint_deleter/duration',
+          0.08,
+      )
+    self.assertIn('op_7_overhead/delete_standard_s', metrics.results)
+
+  def test_multiple_events_in_one_block_all_captured(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/orbax/write/blocking_duration_secs', 1.0
+      )
+      jax.monitoring.record_event_duration_secs(
+          '/jax/checkpoint/read/broadcast_duration_secs', 0.5
+      )
+      jax.monitoring.record_scalar('/jax/orbax/write/gbytes', 100.0)
+    self.assertIn('op_2_save_breakdown/blocking_s', metrics.results)
+    self.assertIn('op_3_load_breakdown/broadcast_s', metrics.results)
+    self.assertIn('op_5_inventory/save_total_gb', metrics.results)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import dataclasses
-import json
 import time
 import tracemalloc
 from unittest import mock

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
@@ -36,7 +36,9 @@ class MetricsTest(parameterized.TestCase):
       with metrics.measure('test_metric', ['time']):
         pass
 
-    self.assertEqual(metrics.results, {'test_metric_time_duration': (2.0, 's')})
+    self.assertEqual(
+        metrics.results, {'test_metric_0_basics/time_s': (2.0, 's')}
+    )
 
   @mock.patch(
       'orbax.checkpoint._src.testing.benchmarks.core.metric.psutil.Process'
@@ -49,7 +51,9 @@ class MetricsTest(parameterized.TestCase):
     metrics = metric_lib.Metrics()
     with metrics.measure('test_metric', ['rss']):
       pass
-    self.assertEqual(metrics.results, {'test_metric_rss_diff': (2.0, 'MB')})
+    self.assertEqual(
+        metrics.results, {'test_metric_0_basics/host_rss_diff_mb': (2.0, 'MB')}
+    )
 
   @mock.patch(
       'orbax.checkpoint._src.testing.benchmarks.core.metric.tracemalloc'
@@ -70,20 +74,12 @@ class MetricsTest(parameterized.TestCase):
     with metrics.measure('test_metric', ['tracemalloc']):
       self.assertEqual(metric_lib.TracemallocMetric._active_count, 1)
     self.assertEqual(
-        metrics.results, {'test_metric_tracemalloc_peak_diff': (2.0, 'MB')}
+        metrics.results,
+        {'test_metric_7_memory/tracemalloc_peak_diff_mb': (2.0, 'MB')},
     )
     self.assertEqual(metric_lib.TracemallocMetric._active_count, 0)
     mock_tracemalloc.start.assert_called_once()
     mock_tracemalloc.stop.assert_called_once()
-
-  def test_io_metrics(self):
-    metrics = metric_lib.Metrics()
-    with metrics.measure('test_metric', ['io']):
-      pass
-    self.assertIn('test_metric_io_read_bytes', metrics.results)
-    self.assertIn('test_metric_io_write_bytes', metrics.results)
-    self.assertIn('test_metric_io_read_throughput', metrics.results)
-    self.assertIn('test_metric_io_write_throughput', metrics.results)
 
   def test_generate_report(self):
     metrics = metric_lib.Metrics(name='TestMetrics')
@@ -119,7 +115,7 @@ metric2: 4.5600 s
       ).result()
       ts_store.write(np.asarray(range(10)).astype(np.int32)).result()
 
-    self.assertIn('test_metric_tensorstore_diff_count', metrics.results)
+    self.assertIn('test_metric_6_tensorstore/diff_count', metrics.results)
 
   def test_all_metrics(self):
     metric_lib.TracemallocMetric._active_count = 0
@@ -144,14 +140,12 @@ metric2: 4.5600 s
       ).result()
       ts_store.write(np.asarray(range(10)).astype(np.int32)).result()
 
-    self.assertIn('test_metric_time_duration', metrics.results)
-    self.assertIn('test_metric_rss_diff', metrics.results)
-    self.assertIn('test_metric_tracemalloc_peak_diff', metrics.results)
-    self.assertIn('test_metric_io_read_bytes', metrics.results)
-    self.assertIn('test_metric_io_write_bytes', metrics.results)
-    self.assertIn('test_metric_io_read_throughput', metrics.results)
-    self.assertIn('test_metric_io_write_throughput', metrics.results)
-    self.assertIn('test_metric_tensorstore_diff_count', metrics.results)
+    self.assertIn('test_metric_0_basics/time_s', metrics.results)
+    self.assertIn('test_metric_0_basics/host_rss_diff_mb', metrics.results)
+    self.assertIn(
+        'test_metric_7_memory/tracemalloc_peak_diff_mb', metrics.results
+    )
+    self.assertIn('test_metric_6_tensorstore/diff_count', metrics.results)
 
 
 class MetricsManagerTest(parameterized.TestCase):
@@ -301,37 +295,30 @@ class MetricsManagerTest(parameterized.TestCase):
         step=0, scalars={'loss_none': 0.5}
     )
 
-    # Check configuration texts
-    benchmark_configs = {}
-    for call in mock_writer.write_texts.call_args_list:
-      _, kwargs = call
-      if 'texts' in kwargs and 'configuration' in kwargs['texts']:
-        config_str = kwargs['texts']['configuration']
-        try:
-          config = json.loads(config_str)
-          benchmark_configs[config['benchmark_name']] = config
-        except json.JSONDecodeError:
-          self.fail(f'Configuration string is not JSON loadable: {config_str}')
+    # Configuration is now rendered as markdown; verify the benchmark name
+    # header and each field/value row appears.
+    configuration_blobs = [
+        kwargs['texts']['configuration']
+        for _, kwargs in mock_writer.write_texts.call_args_list
+        if 'texts' in kwargs and 'configuration' in kwargs['texts']
+    ]
+    self.assertLen(configuration_blobs, 2)
 
-    self.assertLen(benchmark_configs, 2)
-    self.assertIn(bench1_name, benchmark_configs)
-    self.assertEqual(
-        benchmark_configs[bench1_name],
-        {
-            'benchmark_name': bench1_name,
-            'benchmark_options': bench1_opts,
-            'checkpoint_config': bench1_ckpt_config,
-        },
-    )
-    self.assertIn(bench2_name, benchmark_configs)
-    self.assertEqual(
-        benchmark_configs[bench2_name],
-        {
-            'benchmark_name': bench2_name,
-            'benchmark_options': bench2_opts,
-            'checkpoint_config': bench2_ckpt_config,
-        },
-    )
+    by_name = {}
+    for blob in configuration_blobs:
+      header_line = blob.splitlines()[0]
+      name = header_line.removeprefix('## ').strip()
+      by_name[name] = blob
+
+    self.assertIn(bench1_name, by_name)
+    self.assertIn('| `opt1` | `1` |', by_name[bench1_name])
+    self.assertIn('| `ckpt1` | `path1` |', by_name[bench1_name])
+
+    self.assertIn(bench2_name, by_name)
+    self.assertIn('| `opt2` | `2` |', by_name[bench2_name])
+    # bench2 has no checkpoint_config — the "Checkpoint config" section
+    # is omitted entirely.
+    self.assertNotIn('Checkpoint config', by_name[bench2_name])
 
     # Check that flush and close were called for each writer instance
     self.assertEqual(mock_writer.flush.call_count, 5)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/emergency_checkpoint_manager_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/emergency_checkpoint_manager_benchmark_test.py
@@ -30,7 +30,6 @@ from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 from orbax.checkpoint._src.testing.benchmarks.core import pytree_utils
 from orbax.checkpoint.experimental.emergency import checkpoint_manager as emergency_checkpoint_manager
 
-
 EcmBenchmarkOptions = emergency_checkpoint_manager_benchmark.EcmBenchmarkOptions
 EmergencyCheckpointManagerBenchmark = (
     emergency_checkpoint_manager_benchmark.EmergencyCheckpointManagerBenchmark

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/emergency_checkpoint_manager_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/emergency_checkpoint_manager_benchmark_test.py
@@ -119,21 +119,25 @@ class EmergencyCheckpointManagerBenchmarkTest(parameterized.TestCase):
     with self.subTest('benchmark result type'):
       self.assertIsInstance(result, benchmarks_core.TestResult)
     with self.subTest('metrics timings'):
-      self.assertIn('create_directories_time_duration', result.metrics.results)
       self.assertIn(
-          'create_abstract_pytree_time_duration', result.metrics.results
-      )
-      self.assertIn('create_restore_args_time_duration', result.metrics.results)
-      self.assertIn(
-          'create_checkpoint_manager_time_duration', result.metrics.results
-      )
-      self.assertIn('train_loop_time_duration', result.metrics.results)
-      self.assertIn('save_0_time_duration', result.metrics.results)
-      self.assertIn(
-          'wait_until_finished_0_time_duration', result.metrics.results
+          'create_directories_0_basics/time_s', result.metrics.results
       )
       self.assertIn(
-          'sync_global_processes_0_time_duration', result.metrics.results
+          'create_abstract_pytree_0_basics/time_s', result.metrics.results
+      )
+      self.assertIn(
+          'create_restore_args_0_basics/time_s', result.metrics.results
+      )
+      self.assertIn(
+          'create_checkpoint_manager_0_basics/time_s', result.metrics.results
+      )
+      self.assertIn('train_loop_0_basics/time_s', result.metrics.results)
+      self.assertIn('save_0_0_basics/time_s', result.metrics.results)
+      self.assertIn(
+          'wait_until_finished_0_0_basics/time_s', result.metrics.results
+      )
+      self.assertIn(
+          'sync_global_processes_0_0_basics/time_s', result.metrics.results
       )
     with self.subTest('checkpoint manager calls'):
       mock_checkpoint_manager_cls.assert_called_once()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/lustre_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/lustre_benchmark.py
@@ -30,7 +30,6 @@ from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_cor
 from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 from orbax.checkpoint.experimental.caching import client
 
-
 SERVICE_URL = "http://service-dns/"
 LUSTRE_PATH_PREFIX = "/lustre/"
 GCS_PATH_PREFIX = "gs://"

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/lustre_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/lustre_benchmark.py
@@ -39,8 +39,7 @@ GCS_PATH_PREFIX = "gs://"
 def _metrics_to_measure(options: LustreBenchmarkOptions) -> list[str]:
   """Returns the list of metrics to measure."""
   del options
-  metrics = ["time", "rss", "io"]
-  return metrics
+  return ["time", "rss"]
 
 
 # ==============================================================================

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/lustre_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/lustre_benchmark_test.py
@@ -93,10 +93,10 @@ class LustreBenchmarkTest(parameterized.TestCase):
     # Verify result
     self.assertIsInstance(result, benchmarks_core.TestResult)
     expected_metrics = {
-        'resolve_cache_time_duration',
-        'save_cache_time_duration',
-        'finalize_cache_time_duration',
-        'save_time_duration',
+        'resolve_cache_0_basics/time_s',
+        'save_cache_0_basics/time_s',
+        'finalize_cache_0_basics/time_s',
+        'save_0_basics/time_s',
     }
     self.assertContainsSubset(expected_metrics, result.metrics.results.keys())
 
@@ -171,10 +171,10 @@ class LustreBenchmarkTest(parameterized.TestCase):
     # Verify result
     self.assertIsInstance(result, benchmarks_core.TestResult)
     expected_metrics = {
-        'prefetch_cache_time_duration',
-        'wait_prefetch_cache_time_duration',
-        'restore_cache_time_duration',
-        'restore_time_duration',
+        'prefetch_cache_0_basics/time_s',
+        'wait_prefetch_cache_0_basics/time_s',
+        'restore_cache_0_basics/time_s',
+        'restore_0_basics/time_s',
     }
     self.assertContainsSubset(expected_metrics, result.metrics.results.keys())
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/multihost_dispatchers_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/multihost_dispatchers_benchmark_test.py
@@ -149,11 +149,11 @@ class MultihostDispatchersBenchmarkTest(parameterized.TestCase):
     self.assertIsInstance(result, core.TestResult)
     self.assertContainsSubset(
         {
-            'dispatch_without_result_specs_time_duration',
-            'dispatch_without_result_specs_block_until_ready_time_duration',
-            'dispatch_with_dummy_result_array_time_duration',
-            'dispatch_with_dummy_result_array_block_until_ready_time_duration',
-            'dispatch_with_result_specs_time_duration',
+            'dispatch_without_result_specs_0_basics/time_s',
+            'dispatch_without_result_specs_block_until_ready_0_basics/time_s',
+            'dispatch_with_dummy_result_array_0_basics/time_s',
+            'dispatch_with_dummy_result_array_block_until_ready_0_basics/time_s',
+            'dispatch_with_result_specs_0_basics/time_s',
         },
         result.metrics.results.keys(),
     )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/multihost_dispatchers_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/multihost_dispatchers_benchmark_test.py
@@ -25,7 +25,6 @@ from orbax.checkpoint._src.testing.benchmarks import multihost_dispatchers_bench
 from orbax.checkpoint._src.testing.benchmarks.core import configs
 from orbax.checkpoint._src.testing.benchmarks.core import core
 
-
 MultihostDispatchersBenchmarkOptions = (
     multihost_dispatchers_benchmark.MultihostDispatchersBenchmarkOptions
 )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/p2p_checkpoint_manager_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/p2p_checkpoint_manager_benchmark_test.py
@@ -29,7 +29,6 @@ from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 from orbax.checkpoint.experimental.emergency.p2p import checkpoint_manager as p2p_checkpoint_manager
 from orbax.checkpoint.experimental.emergency.p2p import options as p2p_options
 
-
 P2pBenchmarkOptions = p2p_checkpoint_manager_benchmark.P2pBenchmarkOptions
 P2pCheckpointManagerBenchmark = (
     p2p_checkpoint_manager_benchmark.P2pCheckpointManagerBenchmark

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/p2p_checkpoint_manager_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/p2p_checkpoint_manager_benchmark_test.py
@@ -128,36 +128,39 @@ class P2pCheckpointManagerBenchmarkTest(parameterized.TestCase):
       self.assertIsInstance(result, benchmarks_core.TestResult)
     with self.subTest('metrics timings'):
       self.assertIn(
-          'create_abstract_pytree_time_duration', result.metrics.results
+          'create_abstract_pytree_0_basics/time_s', result.metrics.results
       )
-      self.assertIn('create_restore_args_time_duration', result.metrics.results)
       self.assertIn(
-          'test_local_restore_create_directories_time_duration',
+          'create_restore_args_0_basics/time_s', result.metrics.results
+      )
+      self.assertIn(
+          'test_local_restore_create_directories_0_basics/time_s',
           result.metrics.results,
       )
       self.assertIn(
-          'test_local_restore_create_checkpoint_manager_time_duration',
+          'test_local_restore_create_checkpoint_manager_0_basics/time_s',
           result.metrics.results,
       )
       self.assertIn(
-          'test_local_restore_train_loop_time_duration', result.metrics.results
-      )
-      self.assertIn(
-          'test_local_restore_save_0_time_duration', result.metrics.results
-      )
-      self.assertIn(
-          'test_local_restore_wait_until_finished_0_time_duration',
+          'test_local_restore_train_loop_0_basics/time_s',
           result.metrics.results,
       )
       self.assertIn(
-          'test_local_restore_save_1_time_duration', result.metrics.results
+          'test_local_restore_save_0_0_basics/time_s', result.metrics.results
       )
       self.assertIn(
-          'test_local_restore_wait_until_finished_1_time_duration',
+          'test_local_restore_wait_until_finished_0_0_basics/time_s',
           result.metrics.results,
       )
       self.assertIn(
-          'test_local_restore_restore_and_validate_1_time_duration',
+          'test_local_restore_save_1_0_basics/time_s', result.metrics.results
+      )
+      self.assertIn(
+          'test_local_restore_wait_until_finished_1_0_basics/time_s',
+          result.metrics.results,
+      )
+      self.assertIn(
+          'test_local_restore_restore_and_validate_1_0_basics/time_s',
           result.metrics.results,
       )
     with self.subTest('checkpoint manager calls'):

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark.py
@@ -21,7 +21,7 @@ import dataclasses
 import gc
 import io
 import os
-from typing import Any, Union, cast
+from typing import Any, cast
 
 from absl import logging
 from etils import epath
@@ -29,8 +29,8 @@ from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_cor
 from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 import safetensors
 import torch
-import torch.distributed as dist
 from torch.distributed import device_mesh
+import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
 import torch.distributed.tensor
 
@@ -41,6 +41,7 @@ try:
   from dataflux_pytorch.lightning.gcs_filesystem import GCSDistributedWriter
   from dataflux_pytorch.lightning.path_utils import parse_gcs_path
   from dataflux_pytorch.multipart_upload.multipart import upload_chunks_concurrently_from_bytesio as upload
+
   # pylint: enable=g-import-not-at-top
 except ImportError:
   GCSDistributedReader = None
@@ -61,7 +62,8 @@ BlockingAsyncStager = dcp.staging.BlockingAsyncStager
 try:
   # PyTorch 2.6.0+ usually requires explicit import of the internal module
   # pylint: disable=g-import-not-at-top
-  import torch.distributed.checkpoint._fsspec_filesystem as dcp_fsspec_internal
+  import torch.distributed.checkpoint._fsspec_filesystem as dcp_fsspec_internal  # pylint: disable=ungrouped-imports
+
   # pylint: enable=g-import-not-at-top
   FsspecReader = dcp_fsspec_internal.FsspecReader
   FsspecWriter = dcp_fsspec_internal.FsspecWriter
@@ -116,7 +118,7 @@ class ProtectedBytesIO(io.BytesIO):
 
 @contextlib.contextmanager
 def buffered_fsspec_create_stream(
-    path: Union[str, os.PathLike[str]], mode: str
+    path: str | os.PathLike[str], mode: str
 ) -> Generator[io.IOBase, None, None]:
   """Buffered create_stream to support torch.save on non-POSIX filesystems."""
   if mode == "wb":
@@ -151,11 +153,11 @@ if GCSDistributedWriter is not None and GCSDistributedReader:
         cache_staged_state_dict: bool = True,
         **kwargs,
     ):
-      super().__init__(path, project_name=project_name, **kwargs)
+      super().__init__(path, project_name=project_name, **kwargs)  # pytype: disable=attribute-error
       self._stager = BlockingAsyncStager(
           cache_staged_state_dict=cache_staged_state_dict
       )
-      self.fs.create_stream = self._fixed_create_stream
+      self.fs.create_stream = self._fixed_create_stream  # pytype: disable=attribute-error
 
     @contextlib.contextmanager
     def _fixed_create_stream(

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark.py
@@ -78,7 +78,7 @@ except (ImportError, AttributeError):
 
 def _metrics_to_measure(options: "PyTorchCheckpointOptions") -> list[str]:
   """Returns the list of metrics to measure."""
-  metrics = ["time", "rss", "io"]
+  metrics = ["time", "rss"]
   if options.metric_tracemalloc_enabled:
     metrics.append("tracemalloc")
   return metrics

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark.py
@@ -29,7 +29,6 @@ from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_cor
 from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 import safetensors
 import torch
-from torch.distributed import device_mesh
 import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
 import torch.distributed.tensor
@@ -205,7 +204,7 @@ class PyTorchCheckpointBenchmark(benchmarks_core.BenchmarksGenerator):
   def _build_benchmark_state_dict(
       self,
       path: epath.Path,
-      mesh: device_mesh.DeviceMesh,
+      mesh: dist.device_mesh.DeviceMesh,
       rank: int,
       device: torch.device,
       shard_dim: int = 0,
@@ -262,7 +261,7 @@ class PyTorchCheckpointBenchmark(benchmarks_core.BenchmarksGenerator):
 
     # 1. Initialize Mesh (Cached)
     if self._cached_mesh is None:
-      self._cached_mesh = device_mesh.init_device_mesh("cuda", (world_size,))
+      self._cached_mesh = dist.device_mesh.init_device_mesh("cuda", (world_size,))
 
     safetensor_path = epath.Path(options.reference_checkpoint_path)
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark_test.py
@@ -116,9 +116,7 @@ class PyTorchCheckpointBenchmarkTest(parameterized.TestCase):
       self,
   ):
     safetensor_dir = epath.Path(self.create_tempdir('safetensors').full_path)
-    save_file(
-        {'a': torch.arange(10)}, safetensor_dir / 'a.safetensors'
-    )
+    save_file({'a': torch.arange(10)}, safetensor_dir / 'a.safetensors')
     test_path = epath.Path(self.create_tempdir().full_path)
     generator = PyTorchCheckpointBenchmark(
         checkpoint_configs=[benchmarks_configs.CheckpointConfig()],
@@ -148,8 +146,8 @@ class PyTorchCheckpointBenchmarkTest(parameterized.TestCase):
     self.assertIsInstance(result, benchmarks_core.TestResult)
     self.assertContainsSubset(
         {
-            'save_time_duration',
-            'restore_time_duration',
+            'save_0_basics/time_s',
+            'restore_0_basics/time_s',
         },
         result.metrics.results.keys(),
     )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark_test.py
@@ -24,7 +24,6 @@ from safetensors.torch import save_file
 import torch
 import torch.distributed.checkpoint as dcp
 
-
 PyTorchCheckpointOptions = pytorch_checkpoint_benchmark.PyTorchCheckpointOptions
 
 PyTorchCheckpointBenchmark = (

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark.py
@@ -16,10 +16,8 @@
 
 from collections.abc import Sequence
 import dataclasses
-import functools
 import pprint
 from typing import Any
-from unittest import mock
 
 from absl import logging
 import jax

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark.py
@@ -30,7 +30,7 @@ from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 
 def _metrics_to_measure(options: "PyTreeCheckpointOptions") -> list[str]:
   """Returns the list of metrics to measure."""
-  metrics = ["time", "rss", "io"]
+  metrics = ["time", "rss"]
   if options.metric_tracemalloc_enabled:
     metrics.append("tracemalloc")
   if options.metric_tensorstore_enabled:

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark_test.py
@@ -142,9 +142,9 @@ class PyTreeCheckpointBenchmarkTest(parameterized.TestCase):
     self.assertIsInstance(result, benchmarks_core.TestResult)
     self.assertContainsSubset(
         {
-            'save_time_duration',
-            'wait_until_finished_time_duration',
-            'restore_time_duration',
+            'save_0_basics/time_s',
+            'wait_until_finished_0_basics/time_s',
+            'restore_0_basics/time_s',
         },
         result.metrics.results.keys(),
     )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark_test.py
@@ -23,7 +23,6 @@ from orbax.checkpoint._src.testing.benchmarks import pytree_checkpoint_benchmark
 from orbax.checkpoint._src.testing.benchmarks.core import configs as benchmarks_configs
 from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
 
-
 PyTreeCheckpointOptions = pytree_checkpoint_benchmark.PyTreeCheckpointOptions
 
 PyTreeCheckpointBenchmark = (

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/single_replica_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/single_replica_benchmark_test.py
@@ -141,11 +141,11 @@ class SingleReplicaBenchmarkTest(parameterized.TestCase):
     mock_is_runtime_to_distributed_ids_initialized.assert_called_once()
     register_pathways_handlers.assert_called_once()
     self.assertIsInstance(result, benchmarks_core.TestResult)
-    self.assertIn('save_time_duration', result.metrics.results)
-    self.assertIn('wait_until_finished_time_duration', result.metrics.results)
-    self.assertIn('restore_time_duration', result.metrics.results)
+    self.assertIn('save_0_basics/time_s', result.metrics.results)
+    self.assertIn('wait_until_finished_0_basics/time_s', result.metrics.results)
+    self.assertIn('restore_0_basics/time_s', result.metrics.results)
     self.assertIn(
-        'construct_restore_args_time_duration', result.metrics.results
+        'construct_restore_args_0_basics/time_s', result.metrics.results
     )
     mock_checkpointer.save.assert_called_once()
     mock_checkpointer.wait_until_finished.assert_called_once()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
@@ -26,7 +26,7 @@ import jax
 from orbax.checkpoint import v1 as ocp
 from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
 from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
-from orbax.checkpoint._src.testing.benchmarks.core import metric_jax_monitoring  # noqa: F401  (registers jax_monitoring in METRIC_REGISTRY)
+from orbax.checkpoint._src.testing.benchmarks.core import metric_jax_monitoring  # pylint: disable=unused-import
 
 
 def get_metrics_to_measure(options: BenchmarkOptions) -> list[str]:

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
@@ -26,11 +26,12 @@ import jax
 from orbax.checkpoint import v1 as ocp
 from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
 from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
+from orbax.checkpoint._src.testing.benchmarks.core import metric_jax_monitoring  # noqa: F401  (registers jax_monitoring in METRIC_REGISTRY)
 
 
 def get_metrics_to_measure(options: BenchmarkOptions) -> list[str]:
   """Returns the list of metrics to measure."""
-  metrics = ["time", "rss", "io"]
+  metrics = ["time", "rss", "jax_monitoring"]
   if options.metric_tracemalloc_enabled:
     metrics.append("tracemalloc")
   if options.metric_tensorstore_enabled:

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark_test.py
@@ -115,20 +115,12 @@ class BenchmarkTest(parameterized.TestCase):
     result = generator.test_fn(context)
 
     self.assertIsInstance(result, benchmarks_core.TestResult)
-    # Check for expected metrics keys based on _metrics_to_measure
-    # in benchmark.py and the metric.measure calls.
-    # The benchmark records "save_blocking", "save_background", "load".
-    # Metric "time" is always added.
-
-    # We expect roughly:
-    # save_blocking_time_duration
-    # save_background_time_duration
-    # load_time_duration
-
+    # The benchmark records "save_blocking", "save_background", "load"
+    # measure() blocks. Each block writes a 0_basics/time_s key.
     metrics = result.metrics.results
-    self.assertIn('save_blocking_time_duration', metrics)
-    self.assertIn('save_background_time_duration', metrics)
-    self.assertIn('load_time_duration', metrics)
+    self.assertIn('save_blocking_0_basics/time_s', metrics)
+    self.assertIn('save_background_0_basics/time_s', metrics)
+    self.assertIn('load_0_basics/time_s', metrics)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark_test.py
@@ -20,7 +20,6 @@ from orbax.checkpoint._src.testing.benchmarks.core import configs as benchmarks_
 from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
 from orbax.checkpoint._src.testing.benchmarks.v1 import benchmark
 
-
 BenchmarkOptions = benchmark.BenchmarkOptions
 Benchmark = benchmark.Benchmark
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark_test.py
@@ -131,8 +131,8 @@ class ReplicaParallelMultisliceBenchmarkTest(parameterized.TestCase):
     result = generator.test_fn(context)
     self.assertIsInstance(result, benchmarks_core.TestResult)
     metrics = result.metrics.results
-    self.assertIn('save_blocking_time_duration', metrics)
-    self.assertIn('save_background_time_duration', metrics)
+    self.assertIn('save_blocking_0_basics/time_s', metrics)
+    self.assertIn('save_background_0_basics/time_s', metrics)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark_test.py
@@ -26,7 +26,6 @@ from orbax.checkpoint._src.testing.benchmarks.core import configs as benchmarks_
 from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
 from orbax.checkpoint._src.testing.benchmarks.v1 import replica_parallel_multislice_benchmark
 
-
 ReplicaParallelMultisliceBenchmarkOptions = (
     replica_parallel_multislice_benchmark.ReplicaParallelMultisliceBenchmarkOptions
 )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/resharding_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/resharding_benchmark_test.py
@@ -24,7 +24,6 @@ from orbax.checkpoint._src.testing.benchmarks.core import configs as benchmarks_
 from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
 from orbax.checkpoint._src.testing.benchmarks.v1 import resharding_benchmark
 
-
 ReshardingBenchmarkOptions = resharding_benchmark.ReshardingBenchmarkOptions
 ReshardingBenchmark = resharding_benchmark.ReshardingBenchmark
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/resharding_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/resharding_benchmark_test.py
@@ -25,9 +25,7 @@ from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_cor
 from orbax.checkpoint._src.testing.benchmarks.v1 import resharding_benchmark
 
 
-ReshardingBenchmarkOptions = (
-    resharding_benchmark.ReshardingBenchmarkOptions
-)
+ReshardingBenchmarkOptions = resharding_benchmark.ReshardingBenchmarkOptions
 ReshardingBenchmark = resharding_benchmark.ReshardingBenchmark
 
 
@@ -111,7 +109,7 @@ class ReshardingBenchmarkTest(parameterized.TestCase):
 
     self.assertIsInstance(result, benchmarks_core.TestResult)
     metrics = result.metrics.results
-    self.assertIn('load_time_duration', metrics)
+    self.assertIn('load_0_basics/time_s', metrics)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/restore_and_broadcast_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/restore_and_broadcast_benchmark_test.py
@@ -135,7 +135,7 @@ class RestoreAndBroadcastBenchmarkTest(parameterized.TestCase):
     result = generator.test_fn(context)
     self.assertIsInstance(result, benchmarks_core.TestResult)
     metrics = result.metrics.results
-    self.assertIn('load_time_duration', metrics)
+    self.assertIn('load_0_basics/time_s', metrics)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/restore_and_broadcast_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/restore_and_broadcast_benchmark_test.py
@@ -26,7 +26,6 @@ from orbax.checkpoint._src.testing.benchmarks.core import configs as benchmarks_
 from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
 from orbax.checkpoint._src.testing.benchmarks.v1 import restore_and_broadcast_benchmark
 
-
 RestoreAndBroadcastBenchmarkOptions = (
     restore_and_broadcast_benchmark.RestoreAndBroadcastBenchmarkOptions
 )


### PR DESCRIPTION
## Description

Subscribe to `jax.monitoring` during the benchmark `measure()` block to surface
Orbax's internal save/load stage timings as TensorBoard scalars; reorganize the
TB dashboard with namespaced tags (`2_save_breakdown/`, `3_load_breakdown/`,
`4_throughput/`, `5_inventory/`, …) and markdown summary cards; drop the broken
IO metric; and update the sibling benchmark tests for the renamed metric keys.

Scope is the benchmarking/testing tree only
(`checkpoint/orbax/checkpoint/_src/testing/benchmarks/`) — no production code or
public API changes. The branch also brings the touched files up to the repo's
pre-commit standards (isort / pylint / pytype / docstrings).

## Type of change

- [x] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the contribution guidelines.
- [x] Tests cover this change (new `metric_jax_monitoring_test.py` plus updated sibling benchmark tests).
- [x] Public APIs and non-trivial functions are documented.
- [x] Not user-facing — no `CHANGELOG.md` entry needed (changes are confined to the internal benchmark suite).
