### PR TITLE
Add device-memory, compile-cache, and per-bucket TensorStore benchmark metrics

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/jax_monitoring_tags.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/jax_monitoring_tags.py
@@ -142,6 +142,15 @@ TAG_MAP: dict[str, tuple[str, str]] = {
         "5_inventory/load_total_gb",
         "GiB",
     ),
+    # ─── 8_jax — compile-cache durations ──────────────────────────────────
+    "/jax/compilation_cache/cache_retrieval_time_sec": (
+        "8_jax/cache_retrieval_s",
+        "s",
+    ),
+    "/jax/compilation_cache/compile_time_saved_sec": (
+        "8_jax/compile_time_saved_s",
+        "s",
+    ),
     # ─── 7_overhead — auxiliary costs (coordination, lifecycle) ───────────
     "/jax/checkpoint/sync_global_devices_duration_sec": (
         "7_overhead/sync_global_devices_s",
@@ -154,6 +163,21 @@ TAG_MAP: dict[str, tuple[str, str]] = {
     "/jax/orbax/checkpoint_manager/standard_checkpoint_deleter/duration": (
         "7_overhead/delete_standard_s",
         "s",
+    ),
+}
+
+
+# /jax/compilation_cache/* events have no value — we count occurrences per
+# event name during the measure block and emit as a scalar.
+EVENT_TAG_MAP: dict[str, str] = {
+    "/jax/compilation_cache/cache_hits": "8_jax/cache_hits_count",
+    "/jax/compilation_cache/cache_misses": "8_jax/cache_misses_count",
+    "/jax/compilation_cache/compile_requests_use_cache": (
+        "8_jax/compile_requests_use_cache_count"
+    ),
+    "/jax/compilation_cache/tasks_using_cache": "8_jax/tasks_using_cache_count",
+    "/jax/compilation_cache/task_disabled_cache": (
+        "8_jax/task_disabled_cache_count"
     ),
 }
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/jax_monitoring_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/jax_monitoring_test.py
@@ -156,6 +156,64 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
       )
     self.assertIn('op_7_overhead/delete_standard_s', metrics.results)
 
+  def test_compile_cache_hits_counted(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      for _ in range(3):
+        jax.monitoring.record_event('/jax/compilation_cache/cache_hits')
+    self.assertIn('op_8_jax/cache_hits_count', metrics.results)
+    self.assertEqual(metrics.results['op_8_jax/cache_hits_count'][0], 3)
+
+  def test_compile_cache_misses_counted(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event('/jax/compilation_cache/cache_misses')
+      jax.monitoring.record_event('/jax/compilation_cache/cache_misses')
+    self.assertEqual(metrics.results['op_8_jax/cache_misses_count'][0], 2)
+
+  def test_compile_cache_hit_rate_derived(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      for _ in range(3):
+        jax.monitoring.record_event('/jax/compilation_cache/cache_hits')
+      jax.monitoring.record_event('/jax/compilation_cache/cache_misses')
+    self.assertIn('op_8_jax/cache_hit_rate', metrics.results)
+    rate, _ = metrics.results['op_8_jax/cache_hit_rate']
+    self.assertAlmostEqual(rate, 0.75)
+
+  def test_compile_cache_durations_mapped(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/compilation_cache/cache_retrieval_time_sec', 0.42
+      )
+      jax.monitoring.record_event_duration_secs(
+          '/jax/compilation_cache/compile_time_saved_sec', 1.7
+      )
+    self.assertEqual(metrics.results['op_8_jax/cache_retrieval_s'], (0.42, 's'))
+    self.assertEqual(
+        metrics.results['op_8_jax/compile_time_saved_s'], (1.7, 's')
+    )
+
+  def test_unmapped_discrete_events_are_dropped(self):
+    """orbax lifecycle events (write/start, checkpointer/init, ...) are
+    discrete events we don't surface as scalars; they shouldn't pollute
+    9_other/."""
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event('/jax/orbax/write/start')
+      jax.monitoring.record_event('/jax/orbax/write/success')
+      jax.monitoring.record_event('/jax/orbax/checkpointer/init')
+    bloat = [k for k in metrics.results if '9_other' in k]
+    self.assertEqual(bloat, [], msg=f'unmapped events leaked: {bloat}')
+
+  def test_compile_cache_events_outside_prefix_ignored(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['jax_monitoring']):
+      jax.monitoring.record_event('/jax/some/other/event')
+    leaked = [k for k in metrics.results if 'other_event' in k]
+    self.assertEqual(leaked, [])
+
   def test_multiple_events_in_one_block_all_captured(self):
     metrics = metric_lib.Metrics()
     with metrics.measure('op', ['jax_monitoring']):

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
@@ -240,6 +240,14 @@ class TracemallocMetric(BaseMetric):
     )
 
 
+_TS_WHITELIST_PREFIXES: tuple[str, ...] = (
+    "/tensorstore/kvstore/",
+    "/tensorstore/cache/",
+    "/tcmalloc/current_allocated_bytes",
+    "/tcmalloc/peak_memory_usage",
+)
+
+
 class TensorstoreMetric(BaseMetric):
   """Measures tensorstore metrics."""
 
@@ -279,8 +287,18 @@ class TensorstoreMetric(BaseMetric):
           "TensorstoreMetric[%s] diff for %s: %s", self.name, key, values
       )
 
-    # Log the number of metrics that have a non-zero diff.
-    results["6_tensorstore/diff_count"] = (len(diff), "count")
+    # Emit per-bucket scalars for whitelisted metric prefixes. The whitelist
+    # keeps the tensorstore internal-counter firehose from flooding the
+    # dashboard while still surfacing the metrics that diagnose orbax
+    # checkpoint behaviour (kvstore op counts, cache hit/miss, tcmalloc
+    # current allocation).
+    results["6_tensorstore/changed_metric_count"] = (len(diff), "count")
+    for name, diff_vals in diff.items():
+      if not any(name.startswith(p) for p in _TS_WHITELIST_PREFIXES):
+        continue
+      flat = name.lstrip("/").replace("/", "_")
+      for stat_name, value in diff_vals.items():
+        results[f"6_tensorstore/{flat}_{stat_name}_diff"] = (value, "count")
     return results
 
   def _collect_metrics(self) -> dict[str, dict[str, Any]]:
@@ -351,6 +369,11 @@ class JaxMonitoringMetric(BaseMetric):
   `..._jax_monitoring_2_save_breakdown/...` for no benefit, so this class opts
   out via OMIT_REGISTRY_KEY_PREFIX. Event-name → tag mappings live in
   jax_monitoring_tags.py.
+
+  Three listener kinds: scalars (`record_scalar`), durations
+  (`record_event_duration_secs`), and discrete events (`record_event`).
+  Discrete events are counted by name — used for compile-cache hit/miss
+  tallies that JAX emits without a value.
   """
 
   OMIT_REGISTRY_KEY_PREFIX = True
@@ -358,6 +381,7 @@ class JaxMonitoringMetric(BaseMetric):
   def start(self) -> None:
     super().start()
     self._records: list[tuple[str, Any, str]] = []
+    self._event_counts: dict[str, int] = {}
 
     def _on_scalar(event: str, value: float, **unused_kwargs):
       if any(event.startswith(p) for p in jax_monitoring_tags.PREFIX_FILTER):
@@ -367,16 +391,23 @@ class JaxMonitoringMetric(BaseMetric):
       if any(event.startswith(p) for p in jax_monitoring_tags.PREFIX_FILTER):
         self._records.append((event, duration, "duration"))
 
+    def _on_event(event: str, **unused_kwargs):
+      if any(event.startswith(p) for p in jax_monitoring_tags.PREFIX_FILTER):
+        self._event_counts[event] = self._event_counts.get(event, 0) + 1
+
     self._scalar_cb = _on_scalar
     self._duration_cb = _on_duration
+    self._event_cb = _on_event
     jax.monitoring.register_scalar_listener(_on_scalar)
     jax.monitoring.register_event_duration_secs_listener(_on_duration)
+    jax.monitoring.register_event_listener(_on_event)
 
   def stop(self) -> dict[str, tuple[Any, str]]:
     results = super().stop()
     try:
       jax.monitoring.unregister_scalar_listener(self._scalar_cb)
       jax.monitoring.unregister_event_duration_listener(self._duration_cb)
+      jax.monitoring.unregister_event_listener(self._event_cb)
     except (ValueError, AttributeError) as e:
       logging.warning("Failed to unregister jax.monitoring listener: %s", e)
 
@@ -388,6 +419,65 @@ class JaxMonitoringMetric(BaseMetric):
       else:
         tag, unit = tag_unit
       results[tag] = (value, unit)
+
+    for event, count in self._event_counts.items():
+      tag = jax_monitoring_tags.EVENT_TAG_MAP.get(event)
+      if tag is not None:
+        results[tag] = (count, "count")
+
+    # Derived cache hit rate. Useful headline; cheap to compute when both
+    # counts are present.
+    hits = self._event_counts.get("/jax/compilation_cache/cache_hits", 0)
+    misses = self._event_counts.get("/jax/compilation_cache/cache_misses", 0)
+    if hits + misses > 0:
+      results["8_jax/cache_hit_rate"] = (hits / (hits + misses), "")
+    return results
+
+
+def _capture_peaks() -> list[int] | None:
+  """Returns the per-local-device peak_bytes_in_use, or None if unsupported."""
+  peaks: list[int] = []
+  for d in jax.local_devices():
+    try:
+      stats = d.memory_stats()
+    except (AttributeError, TypeError):
+      return None
+    if not stats or "peak_bytes_in_use" not in stats:
+      return None
+    peaks.append(int(stats["peak_bytes_in_use"]))
+  return peaks
+
+
+class DeviceMemoryMetric(BaseMetric):
+  """Captures jax.live_arrays delta + per-device HBM peak diff.
+
+  Two readings per measure() block: jax_live_arrays_count_delta (change in
+  len(jax.live_arrays()) — a cheap leak canary on every backend) and
+  device_hbm_peak_diff_gb (max over local devices of the peak_bytes_in_use
+  delta from device.memory_stats(), skipped where memory_stats is None, e.g.
+  CPU).
+  """
+
+  OMIT_REGISTRY_KEY_PREFIX = True
+
+  def start(self) -> None:
+    super().start()
+    self._start_live = len(jax.live_arrays())
+    self._start_peaks = _capture_peaks()
+
+  def stop(self) -> dict[str, tuple[Any, str]]:
+    results = super().stop()
+    end_live = len(jax.live_arrays())
+    results["7_memory/jax_live_arrays_count_delta"] = (
+        end_live - self._start_live,
+        "count",
+    )
+    end_peaks = _capture_peaks()
+    if self._start_peaks is not None and end_peaks is not None:
+      diffs = [e - s for s, e in zip(self._start_peaks, end_peaks)]
+      if diffs:
+        peak_gb = max(diffs) / (1024**3)
+        results["7_memory/device_hbm_peak_diff_gb"] = (peak_gb, "GiB")
     return results
 
 
@@ -398,6 +488,7 @@ METRIC_REGISTRY: dict[str, type[BaseMetric]] = {
     "tracemalloc": TracemallocMetric,
     "tensorstore": TensorstoreMetric,
     "jax_monitoring": JaxMonitoringMetric,
+    "device_memory": DeviceMemoryMetric,
 }
 
 DEFAULT_METRICS = ["time"]

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
@@ -112,7 +112,46 @@ metric2: 4.5600 s
       ).result()
       ts_store.write(np.asarray(range(10)).astype(np.int32)).result()
 
-    self.assertIn('test_metric_6_tensorstore/diff_count', metrics.results)
+    self.assertIn(
+        'test_metric_6_tensorstore/changed_metric_count', metrics.results
+    )
+
+  @mock.patch.object(metric_lib.TensorstoreMetric, '_collect_metrics')
+  def test_tensorstore_whitelisted_metrics_emit_per_bucket_scalars(
+      self, mock_collect
+  ):
+    # Simulate two collections — start (baseline) then stop. The kvstore
+    # metric grew by 5 (from 10→15) so the diff should be 5; the cache
+    # metric grew by 100 bytes. The internal/thread metric is OUTSIDE the
+    # whitelist and gets filtered out.
+    start = {
+        '/tensorstore/kvstore/file/read': {'count': 10},
+        '/tensorstore/cache/bytes': {'value': 100},
+        '/tensorstore/internal/thread/foo': {'value': 1},
+    }
+    stop = {
+        '/tensorstore/kvstore/file/read': {'count': 15},
+        '/tensorstore/cache/bytes': {'value': 200},
+        '/tensorstore/internal/thread/foo': {'value': 99},  # filtered out
+    }
+    mock_collect.side_effect = [start, stop]
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['tensorstore']):
+      pass
+    self.assertEqual(
+        metrics.results[
+            'op_6_tensorstore/tensorstore_kvstore_file_read_count_diff'
+        ][0],
+        5,
+    )
+    self.assertEqual(
+        metrics.results['op_6_tensorstore/tensorstore_cache_bytes_value_diff'][
+            0
+        ],
+        100,
+    )
+    # Internal metric outside the whitelist not exported.
+    self.assertFalse(any('internal_thread_foo' in k for k in metrics.results))
 
   def test_all_metrics(self):
     metric_lib.TracemallocMetric._active_count = 0
@@ -142,7 +181,77 @@ metric2: 4.5600 s
     self.assertIn(
         'test_metric_7_memory/tracemalloc_peak_diff_mb', metrics.results
     )
-    self.assertIn('test_metric_6_tensorstore/diff_count', metrics.results)
+    self.assertIn(
+        'test_metric_6_tensorstore/changed_metric_count', metrics.results
+    )
+
+
+def _fake_device(peak_bytes):
+  d = mock.Mock()
+  if peak_bytes is None:
+    d.memory_stats.return_value = None
+  else:
+    d.memory_stats.return_value = {
+        'peak_bytes_in_use': peak_bytes,
+        'bytes_in_use': peak_bytes // 2,
+    }
+  return d
+
+
+class DeviceMemoryMetricTest(parameterized.TestCase):
+
+  @mock.patch('jax.live_arrays')
+  @mock.patch('jax.local_devices')
+  def test_live_arrays_delta_captured(self, mock_devices, mock_live):
+    mock_devices.return_value = [_fake_device(None)]
+    mock_live.side_effect = [
+        [mock.Mock()] * 3,
+        [mock.Mock()] * 5,
+    ]
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['device_memory']):
+      pass
+    self.assertIn('op_7_memory/jax_live_arrays_count_delta', metrics.results)
+    val, _ = metrics.results['op_7_memory/jax_live_arrays_count_delta']
+    self.assertEqual(val, 2)
+
+  @mock.patch('jax.live_arrays', return_value=[])
+  @mock.patch('jax.local_devices')
+  def test_hbm_peak_diff_when_memory_stats_available(
+      self, mock_devices, unused_mock_live
+  ):
+    gb = 1024**3
+    d0 = mock.Mock()
+    d0.memory_stats.side_effect = [
+        {'peak_bytes_in_use': 4 * gb},
+        {'peak_bytes_in_use': 5 * gb},
+    ]
+    d1 = mock.Mock()
+    d1.memory_stats.side_effect = [
+        {'peak_bytes_in_use': 4 * gb},
+        {'peak_bytes_in_use': 6 * gb},
+    ]
+    mock_devices.return_value = [d0, d1]
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['device_memory']):
+      pass
+    self.assertIn('op_7_memory/device_hbm_peak_diff_gb', metrics.results)
+    val, unit = metrics.results['op_7_memory/device_hbm_peak_diff_gb']
+    self.assertAlmostEqual(val, 2.0)
+    self.assertEqual(unit, 'GiB')
+
+  @mock.patch('jax.live_arrays', return_value=[])
+  @mock.patch('jax.local_devices')
+  def test_cpu_no_memory_stats_skips_hbm_tag(
+      self, mock_devices, unused_mock_live
+  ):
+    mock_devices.return_value = [_fake_device(None), _fake_device(None)]
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['device_memory']):
+      pass
+    self.assertNotIn('op_7_memory/device_hbm_peak_diff_gb', metrics.results)
+    self.assertIn('op_7_memory/jax_live_arrays_count_delta', metrics.results)
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/lustre_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/lustre_benchmark.py
@@ -36,9 +36,20 @@ GCS_PATH_PREFIX = "gs://"
 
 
 def _metrics_to_measure(options: LustreBenchmarkOptions) -> list[str]:
-  """Returns the list of metrics to measure."""
+  """Returns the list of metrics to measure.
+
+  Exercises orbax v1 free-functions through a Lustre/GCS caching path,
+  so the JAX-tier captures (jax_monitoring, device_memory, tensorstore)
+  apply just like the v1 benchmark.
+
+  Args:
+    options: Unused; this benchmark always measures the same metric set.
+
+  Returns:
+    The metric names to capture for each measured operation.
+  """
   del options
-  return ["time", "rss"]
+  return ["time", "rss", "jax_monitoring", "device_memory", "tensorstore"]
 
 
 # ==============================================================================

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark.py
@@ -78,7 +78,12 @@ except (ImportError, AttributeError):
 
 
 def _metrics_to_measure(options: "PyTorchCheckpointOptions") -> list[str]:
-  """Returns the list of metrics to measure."""
+  """Returns the list of metrics to measure.
+
+  Pure torch / DCP benchmark — the JAX-tier captures (jax_monitoring,
+  device_memory, tensorstore) wouldn't emit anything here, so we keep
+  the metric set scoped to time/rss + opt-in tracemalloc.
+  """
   metrics = ["time", "rss"]
   if options.metric_tracemalloc_enabled:
     metrics.append("tracemalloc")
@@ -322,7 +327,9 @@ class PyTorchCheckpointBenchmark(benchmarks_core.BenchmarksGenerator):
             state_dict,
             storage_writer=writer,
             planner=planner,
-            async_checkpointer_type=dcp.state_dict_saver.AsyncCheckpointerType.THREAD,
+            async_checkpointer_type=(
+                dcp.state_dict_saver.AsyncCheckpointerType.THREAD
+            ),
         )
         response = cast(futures.Future[Any], future)
       else:

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark.py
@@ -25,13 +25,30 @@ import orbax.checkpoint as ocp
 from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
 from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 
+
 def _metrics_to_measure(options: "PyTreeCheckpointOptions") -> list[str]:
-  """Returns the list of metrics to measure."""
-  metrics = ["time", "rss"]
+  """Returns the list of metrics to measure.
+
+  Cheap captures (time, rss, jax_monitoring, device_memory, tensorstore)
+  are always on. Tracemalloc is opt-in because its per-allocation
+  snapshots have measurable runtime overhead.
+
+  Args:
+    options: Benchmark options; tracemalloc is added when
+      metric_tracemalloc_enabled is set.
+
+  Returns:
+    The metric names to capture for each measured operation.
+  """
+  metrics = [
+      "time",
+      "rss",
+      "jax_monitoring",
+      "device_memory",
+      "tensorstore",
+  ]
   if options.metric_tracemalloc_enabled:
     metrics.append("tracemalloc")
-  if options.metric_tensorstore_enabled:
-    metrics.append("tensorstore")
   return metrics
 
 
@@ -52,8 +69,8 @@ class PyTreeCheckpointOptions(benchmarks_core.BenchmarkOptions):
     use_compression: Whether to use compression for checkpointing.
     save_concurrent_gb: The number of concurrent GB to use for saving.
     restore_concurrent_gb: The number of concurrent GB to use for restoring.
-    metric_tracemalloc_enabled: Whether to enable tracemalloc metrics.
-    metric_tensorstore_enabled: Whether to enable tensorstore metrics.
+    metric_tracemalloc_enabled: Whether to enable the tracemalloc metric
+      (opt-in because per-allocation snapshots are expensive).
   """
 
   async_enabled: bool | Sequence[bool] = True
@@ -63,7 +80,6 @@ class PyTreeCheckpointOptions(benchmarks_core.BenchmarkOptions):
   save_concurrent_gb: int | None | Sequence[int | None] = None
   restore_concurrent_gb: int | None | Sequence[int | None] = None
   metric_tracemalloc_enabled: bool = False
-  metric_tensorstore_enabled: bool = False
   use_replica_parallel: bool | Sequence[bool] = False
   enable_replica_parallel_separate_folder: bool | Sequence[bool] = False
   use_colocated_python: bool | Sequence[bool] = False
@@ -104,7 +120,9 @@ class PyTreeCheckpointBenchmark(benchmarks_core.BenchmarksGenerator):
     if not ocp.multihost.is_pathways_backend():
       array_handler = ocp.type_handlers.ArrayHandler(
           use_replica_parallel=options.use_replica_parallel,
-          enable_replica_parallel_separate_folder=options.enable_replica_parallel_separate_folder,
+          enable_replica_parallel_separate_folder=(
+              options.enable_replica_parallel_separate_folder
+          ),
       )
       logging.info("Registering MC-JAX array type handler")
       ocp.type_handlers.register_type_handler(
@@ -119,7 +137,9 @@ class PyTreeCheckpointBenchmark(benchmarks_core.BenchmarksGenerator):
       ocp.pathways.register_type_handlers(
           checkpointing_impl=checkpointing_impl,
           use_replica_parallel=options.use_replica_parallel,
-          enable_replica_parallel_separate_folder=options.enable_replica_parallel_separate_folder,
+          enable_replica_parallel_separate_folder=(
+              options.enable_replica_parallel_separate_folder
+          ),
       )
 
   def test_fn(

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
@@ -29,12 +29,28 @@ from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 
 
 def get_metrics_to_measure(options: BenchmarkOptions) -> list[str]:
-  """Returns the list of metrics to measure."""
-  metrics = ["time", "rss", "jax_monitoring"]
+  """Returns the list of metrics to measure.
+
+  Cheap captures (time, rss, jax_monitoring, device_memory, tensorstore)
+  are always on. Tracemalloc is opt-in because its per-allocation
+  snapshots have measurable runtime overhead.
+
+  Args:
+    options: Benchmark options; tracemalloc is added when
+      metric_tracemalloc_enabled is set.
+
+  Returns:
+    The metric names to capture for each measured operation.
+  """
+  metrics = [
+      "time",
+      "rss",
+      "jax_monitoring",
+      "device_memory",
+      "tensorstore",
+  ]
   if options.metric_tracemalloc_enabled:
     metrics.append("tracemalloc")
-  if options.metric_tensorstore_enabled:
-    metrics.append("tensorstore")
   return metrics
 
 
@@ -55,8 +71,8 @@ class BenchmarkOptions(benchmarks_core.BenchmarkOptions):
     use_compression: Whether to use compression.
     save_concurrent_gb: The number of concurrent GB to use for saving.
     restore_concurrent_gb: The number of concurrent GB to use for restoring.
-    metric_tracemalloc_enabled: Whether to enable tracemalloc metric.
-    metric_tensorstore_enabled: Whether to enable tensorstore metric.
+    metric_tracemalloc_enabled: Whether to enable the tracemalloc metric
+      (opt-in because per-allocation snapshots are expensive).
     use_load_and_broadcast: Whether to use load and broadcast.
     use_replica_parallel: Whether to use replica parallel.
     enable_replica_parallel_separate_folder: Whether to enable replica parallel
@@ -70,7 +86,6 @@ class BenchmarkOptions(benchmarks_core.BenchmarkOptions):
   save_concurrent_gb: int | None | Sequence[int | None] = None
   restore_concurrent_gb: int | None | Sequence[int | None] = None
   metric_tracemalloc_enabled: bool = False
-  metric_tensorstore_enabled: bool = False
   use_load_and_broadcast: bool | Sequence[bool] = False
   use_replica_parallel: bool | Sequence[bool] = False
   enable_replica_parallel_separate_folder: bool | Sequence[bool] = False


### PR DESCRIPTION
## Description

Adds three JAX-tier captures to the benchmark metric registry as always-on
built-ins, so a benchmark opts in by name rather than through a
side-effect registration import:

- **device_memory** — the per-measure `jax.live_arrays()` delta (a cheap,
  cross-backend leak canary) and the largest per-local-device HBM
  `peak_bytes_in_use` diff. Skipped where `memory_stats()` is unavailable.
- **compile-cache** — discrete `jax.monitoring` events (compile-cache
  hits / misses and the derived hit rate). Events with no tag mapping are
  dropped rather than bucketed into a catch-all.
- **tensorstore** — per-bucket bytes/op scalars.

`jax_monitoring`, `device_memory`, and `tensorstore` are promoted to
always-on for the v1, pytree, and lustre benchmarks, and the per-benchmark
`metric_tensorstore_enabled` flag is removed in favour of registering by
name.

Builds on the per-host / cross-host summary work in #3306.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or a public API)
- [x] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover this change and pass locally.
- [x] Public APIs and non-trivial functions are documented.
- [ ] **If this change is user-facing, I have updated [`CHANGELOG.md`](CHANGELOG.md)** under the `[Unreleased]` section (or the relevant `checkpoint/` / `export/` changelog).

This change is confined to the internal benchmark suite
(`checkpoint/orbax/checkpoint/_src/testing/benchmarks/`); no
user-facing API or behavior changes, so no `CHANGELOG.md` entry. Verified
locally against the full `benchmarks/` test tree: 346 passed, 5 skipped
(multi-host-only).
