### PR TITLE
Add a benchmark baseline registry and pytree correctness helpers

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/baseline.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/baseline.py
@@ -1,0 +1,186 @@
+# Copyright 2026 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark baselines — schema, recorder, and comparer.
+
+A `Baseline` is the captured state of one benchmark run that future runs
+diff against. The schema versioning is intentional — a captured baseline
+may outlive several benchmark-framework changes, and `BaselineComparer`
+refuses silently-incompatible payloads rather than mis-aligning.
+
+`BaselineRecorder` writes a payload to a sink; `BaselineComparer` reads one
+back and diffs metrics against a current run. Paths are resolved with
+`etils.epath`, so local and `gs://` sinks work transparently.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import pathlib
+from typing import Any
+
+from etils import epath
+
+_SCHEMA_VERSION = 1
+
+
+@dataclasses.dataclass
+class Baseline:
+  """Snapshot of a benchmark run that future runs compare against.
+
+  Field semantics:
+    benchmark_name: Stable identifier matching the generator's class name.
+    captured_at:    ISO 8601 UTC timestamp.
+    captured_at_sha: Code SHA at capture time (from the run manifest).
+    fixture:        Path / repo id of the input the benchmark was driven by.
+    config:         Full options + ckpt_config + mesh_config dict.
+    metrics:        Per-metric-key → {stat: value} cross-host aggregate
+                    (max/min/mean across hosts; p50/p99 with >1 host).
+    digests:        Per-leaf SHA-256 hex (for L2 digest-mode comparison).
+                    Empty dict if the benchmark didn't capture digests.
+    inventory:      CheckpointInventory snapshot dict (post-save).
+    manifest:       RunManifest snapshot dict (code SHA, library versions,
+                    env, topology).
+  """
+
+  benchmark_name: str
+  captured_at: str
+  captured_at_sha: str
+  fixture: str
+  config: dict[str, Any]
+  metrics: dict[str, dict[str, float]]
+  digests: dict[str, str] = dataclasses.field(default_factory=dict)
+  inventory: dict[str, Any] = dataclasses.field(default_factory=dict)
+  manifest: dict[str, Any] = dataclasses.field(default_factory=dict)
+  schema_version: int = _SCHEMA_VERSION
+
+  def to_json(self, *, indent: int | None = 2) -> str:
+    return json.dumps(dataclasses.asdict(self), indent=indent, sort_keys=True)
+
+  @classmethod
+  def from_json(cls, payload: str) -> "Baseline":
+    """Parses a Baseline from JSON, rejecting incompatible schema versions."""
+    raw = json.loads(payload)
+    version = raw.pop("schema_version", None)
+    if version != _SCHEMA_VERSION:
+      raise ValueError(
+          f"Baseline schema_version {version} != supported {_SCHEMA_VERSION}; "
+          "regenerate the baseline against the current framework."
+      )
+    # Coerce metric values to float — JSON parses ints as ints which would
+    # otherwise propagate and confuse the speedup ratio calculations.
+    raw["metrics"] = {
+        key: {stat: float(v) for stat, v in stats.items()}
+        for key, stats in raw.get("metrics", {}).items()
+    }
+    return cls(**raw)
+
+
+class BaselineRecorder:
+  """Writes Baseline payloads to a chosen sink (local path or gs://-mirror)."""
+
+  def __init__(self, sink_path: str):
+    """`sink_path` is a directory; baselines land at `<dir>/<sha>.json`."""
+    self._sink = epath.Path(sink_path)
+
+  def write(self, baseline: Baseline) -> pathlib.Path:
+    self._sink.mkdir(parents=True, exist_ok=True)
+    sha = baseline.captured_at_sha or "unknown"
+    out = self._sink / f"{sha}.json"
+    out.write_text(baseline.to_json())
+    return pathlib.Path(str(out))
+
+
+@dataclasses.dataclass(frozen=True)
+class MetricDelta:
+  """Per-metric diff between a current value and a baseline value.
+
+  `ratio` is "speedup" for time-shaped metrics — baseline_value / current_value
+  when smaller is better (the usual case). The caller renders it: 2.0 means
+  the current run took half as long, displayed as "2.0× faster".
+  We don't know per-metric which direction is "better" — that judgement is
+  the caller's. The Comparer just reports the raw ratio + diff.
+  """
+
+  key: str
+  baseline: float
+  current: float
+  delta_abs: float
+  ratio: float | None  # None when baseline is 0 (avoids divide-by-zero)
+
+
+@dataclasses.dataclass
+class ComparisonReport:
+  baseline: Baseline
+  deltas: list[MetricDelta]
+  missing_in_current: list[str]
+  missing_in_baseline: list[str]
+
+
+class BaselineComparer:
+  """Loads a stored baseline and produces deltas against a current run."""
+
+  def __init__(self, source_path: str):
+    """`source_path` is the full path to a baseline JSON file."""
+    self._source = epath.Path(source_path)
+
+  def load(self) -> Baseline:
+    return Baseline.from_json(self._source.read_text())
+
+  def compare(
+      self,
+      current_metrics: dict[str, dict[str, float]],
+      baseline: Baseline | None = None,
+      *,
+      stat: str = "mean",
+  ) -> ComparisonReport:
+    """Diffs `current_metrics` against the baseline on one stat per key.
+
+    Args:
+      current_metrics: Per-metric-key → {stat: value} for the current run.
+      baseline: Baseline to compare against; loaded from disk if None.
+      stat: Which cross-host stat to diff (e.g. "mean", "max").
+
+    Returns:
+      A ComparisonReport with one MetricDelta per shared key that carries the
+      requested stat on both sides.
+    """
+    if baseline is None:
+      baseline = self.load()
+    deltas: list[MetricDelta] = []
+    common = sorted(set(baseline.metrics) & set(current_metrics))
+    for key in common:
+      if stat not in baseline.metrics[key] or stat not in current_metrics[key]:
+        continue
+      b = float(baseline.metrics[key][stat])
+      c = float(current_metrics[key][stat])
+      ratio = (b / c) if c != 0 else None
+      deltas.append(
+          MetricDelta(
+              key=key,
+              baseline=b,
+              current=c,
+              delta_abs=c - b,
+              ratio=ratio,
+          )
+      )
+    return ComparisonReport(
+        baseline=baseline,
+        deltas=deltas,
+        missing_in_current=sorted(set(baseline.metrics) - set(current_metrics)),
+        missing_in_baseline=sorted(
+            set(current_metrics) - set(baseline.metrics)
+        ),
+    )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/baseline_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/baseline_test.py
@@ -1,0 +1,212 @@
+# Copyright 2026 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Baseline schema, recorder, and comparer."""
+
+import json
+import tempfile
+
+from absl.testing import absltest
+from orbax.checkpoint._src.testing.benchmarks.core import baseline as baseline_lib
+
+
+def _example() -> baseline_lib.Baseline:
+  return baseline_lib.Baseline(
+      benchmark_name="MyBench",
+      captured_at="2026-05-26T10:00:00Z",
+      captured_at_sha="abc1234",
+      fixture="/tmp/fixture",
+      config={"async_enabled": True, "use_ocdbt": True},
+      metrics={
+          "save_0_basics/time_s": {"max": 1.6, "mean": 1.5},
+          "load_0_basics/time_s": {"max": 2.1, "mean": 2.0},
+      },
+      digests={"layer0/W": "deadbeef" * 8},
+      inventory={"total_bytes": 1234},
+      manifest={"jax_version": "0.4.99"},
+  )
+
+
+def _baseline(sha: str = "abc1234", **overrides) -> baseline_lib.Baseline:
+  defaults = dict(
+      benchmark_name="MyBench",
+      captured_at="2026-05-26T10:00:00Z",
+      captured_at_sha=sha,
+      fixture="/tmp/fixture",
+      config={"async_enabled": True},
+      metrics={
+          "save_0_basics/time_s": {"mean": 2.0},
+          "load_0_basics/time_s": {"mean": 4.0},
+      },
+  )
+  defaults.update(overrides)
+  return baseline_lib.Baseline(**defaults)
+
+
+class BaselineRoundTripTest(absltest.TestCase):
+
+  def test_to_from_json_round_trip(self):
+    original = _example()
+    restored = baseline_lib.Baseline.from_json(original.to_json())
+    self.assertEqual(restored, original)
+
+  def test_json_is_sorted_for_diffable_writes(self):
+    payload = _example().to_json()
+    parsed = json.loads(payload)
+    # sort_keys=True must place 'benchmark_name' alphabetically.
+    self.assertEqual(list(parsed.keys())[0], "benchmark_name")
+
+  def test_metrics_coerced_to_float_on_load(self):
+    raw = json.loads(_example().to_json())
+    raw["metrics"]["save_0_basics/time_s"]["mean"] = 3  # int, not float
+    restored = baseline_lib.Baseline.from_json(json.dumps(raw))
+    self.assertIsInstance(
+        restored.metrics["save_0_basics/time_s"]["mean"], float
+    )
+
+  def test_unsupported_schema_version_raises(self):
+    raw = json.loads(_example().to_json())
+    raw["schema_version"] = 99
+    with self.assertRaises(ValueError):
+      baseline_lib.Baseline.from_json(json.dumps(raw))
+
+  def test_missing_optional_fields_defaults(self):
+    minimal = baseline_lib.Baseline(
+        benchmark_name="X",
+        captured_at="2026-05-26T10:00:00Z",
+        captured_at_sha="x",
+        fixture="x",
+        config={},
+        metrics={"a": {"mean": 1.0}},
+    )
+    self.assertEqual(minimal.digests, {})
+    self.assertEqual(minimal.inventory, {})
+    self.assertEqual(minimal.manifest, {})
+
+  def test_schema_version_persisted_in_payload(self):
+    payload = json.loads(_example().to_json())
+    self.assertEqual(payload["schema_version"], 1)
+
+
+class BaselineRecorderTest(absltest.TestCase):
+
+  def test_writes_named_by_sha(self):
+    with tempfile.TemporaryDirectory() as d:
+      r = baseline_lib.BaselineRecorder(d)
+      written = r.write(_baseline(sha="abc1234"))
+      self.assertTrue(written.exists())
+      self.assertEqual(written.name, "abc1234.json")
+
+  def test_round_trip_via_recorder_and_comparer(self):
+    with tempfile.TemporaryDirectory() as d:
+      r = baseline_lib.BaselineRecorder(d)
+      original = _baseline(sha="xyz9999")
+      written = r.write(original)
+      restored = baseline_lib.BaselineComparer(str(written)).load()
+      self.assertEqual(restored, original)
+
+  def test_unknown_sha_persists_under_unknown(self):
+    with tempfile.TemporaryDirectory() as d:
+      r = baseline_lib.BaselineRecorder(d)
+      written = r.write(_baseline(sha=""))
+      self.assertEqual(written.name, "unknown.json")
+
+
+class BaselineComparerTest(absltest.TestCase):
+
+  def test_speedup_ratio_for_faster_run(self):
+    with tempfile.TemporaryDirectory() as d:
+      r = baseline_lib.BaselineRecorder(d)
+      written = r.write(_baseline(sha="abc"))
+      c = baseline_lib.BaselineComparer(str(written))
+      report = c.compare({
+          "save_0_basics/time_s": {"mean": 1.0},
+          "load_0_basics/time_s": {"mean": 2.0},
+      })
+      ratios = {d.key: d.ratio for d in report.deltas}
+      # Baseline 2.0 / current 1.0 → 2.0× speedup
+      self.assertAlmostEqual(ratios["save_0_basics/time_s"], 2.0)
+      self.assertAlmostEqual(ratios["load_0_basics/time_s"], 2.0)
+
+  def test_slowdown_ratio_for_slower_run(self):
+    with tempfile.TemporaryDirectory() as d:
+      r = baseline_lib.BaselineRecorder(d)
+      written = r.write(_baseline(sha="abc"))
+      c = baseline_lib.BaselineComparer(str(written))
+      report = c.compare({
+          "save_0_basics/time_s": {"mean": 4.0},
+          "load_0_basics/time_s": {"mean": 8.0},
+      })
+      ratios = {d.key: d.ratio for d in report.deltas}
+      # Baseline 2.0 / current 4.0 → 0.5 (we got slower)
+      self.assertAlmostEqual(ratios["save_0_basics/time_s"], 0.5)
+
+  def test_missing_metrics_reported(self):
+    with tempfile.TemporaryDirectory() as d:
+      r = baseline_lib.BaselineRecorder(d)
+      written = r.write(_baseline(sha="abc"))
+      c = baseline_lib.BaselineComparer(str(written))
+      report = c.compare({
+          "save_0_basics/time_s": {"mean": 1.0},
+          "new_only_in_current": {"mean": 5.0},
+      })
+      self.assertIn("load_0_basics/time_s", report.missing_in_current)
+      self.assertIn("new_only_in_current", report.missing_in_baseline)
+
+  def test_zero_current_returns_none_ratio(self):
+    with tempfile.TemporaryDirectory() as d:
+      r = baseline_lib.BaselineRecorder(d)
+      written = r.write(_baseline(sha="abc"))
+      c = baseline_lib.BaselineComparer(str(written))
+      report = c.compare({
+          "save_0_basics/time_s": {"mean": 0.0},
+          "load_0_basics/time_s": {"mean": 1.0},
+      })
+      ratios = {d.key: d.ratio for d in report.deltas}
+      self.assertIsNone(ratios["save_0_basics/time_s"])
+      self.assertAlmostEqual(ratios["load_0_basics/time_s"], 4.0)
+
+  def test_delta_abs_signed_against_baseline(self):
+    with tempfile.TemporaryDirectory() as d:
+      r = baseline_lib.BaselineRecorder(d)
+      written = r.write(_baseline(sha="abc"))
+      c = baseline_lib.BaselineComparer(str(written))
+      report = c.compare({
+          "save_0_basics/time_s": {"mean": 2.5},
+          "load_0_basics/time_s": {"mean": 3.0},
+      })
+      deltas = {d.key: d.delta_abs for d in report.deltas}
+      self.assertAlmostEqual(deltas["save_0_basics/time_s"], 0.5)
+      self.assertAlmostEqual(deltas["load_0_basics/time_s"], -1.0)
+
+  def test_stat_selects_aggregate_column(self):
+    with tempfile.TemporaryDirectory() as d:
+      r = baseline_lib.BaselineRecorder(d)
+      written = r.write(
+          _baseline(
+              sha="abc",
+              metrics={"save_0_basics/time_s": {"mean": 2.0, "max": 3.0}},
+          )
+      )
+      c = baseline_lib.BaselineComparer(str(written))
+      report = c.compare(
+          {"save_0_basics/time_s": {"mean": 1.0, "max": 1.0}}, stat="max"
+      )
+      ratios = {d.key: d.ratio for d in report.deltas}
+      # max column: baseline 3.0 / current 1.0 → 3.0
+      self.assertAlmostEqual(ratios["save_0_basics/time_s"], 3.0)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core.py
@@ -25,6 +25,7 @@ from typing import Any
 from absl import logging
 from etils import epath
 import jax
+from orbax.checkpoint._src.testing.benchmarks.core import baseline as baseline_lib
 from orbax.checkpoint._src.testing.benchmarks.core import checkpoint_generation
 from orbax.checkpoint._src.testing.benchmarks.core import configs
 from orbax.checkpoint._src.testing.benchmarks.core import device_mesh
@@ -39,19 +40,25 @@ from orbax.checkpoint._src.testing.benchmarks.core import multihost
 class BenchmarkOptions:
   """Base class for benchmark generator options.
 
+  The baseline_* fields are orchestration switches configured once per run
+  (not swept); subclasses inherit them automatically.
+
   Attributes:
     enable_trace: Whether to capture a per-operation `jax.profiler` trace for
       each measured save/load. Off by default.
     trace_every_repeat: Whether to capture traces on every repeat, or only the
       first repeat (the default); traces on every repeat overflow the Trace
       Viewer.
+    baseline_path: Path to a stored baseline to compare this run against, or
+      None to skip comparison.
+    baseline_capture_path: Path to write this run's baseline to, or None to
+      skip capture.
   """
 
-  # Keyword-only so subclasses keep their own positional / required fields
-  # (e.g. PyTorchCheckpointOptions.reference_checkpoint_path) without tripping
-  # the "non-default argument follows default argument" rule.
   enable_trace: bool = False
   trace_every_repeat: bool = False
+  baseline_path: str | None = None
+  baseline_capture_path: str | None = None
 
   @classmethod
   def from_dict(cls, options_dict: dict[str, Any]) -> "BenchmarkOptions":
@@ -515,6 +522,7 @@ class TestSuite:
     )
 
     all_results = []
+    all_benchmarks: list[Benchmark] = []
     for i, generator in enumerate(self._benchmarks_generators):
       logging.info(
           "\n%s Running Generator %d: %s %s",
@@ -534,6 +542,7 @@ class TestSuite:
         continue
 
       for benchmark in generated_benchmarks:
+        all_benchmarks.append(benchmark)
         for i in range(self._num_repeats):
           repeat_index = i if self._num_repeats > 1 else None
           logging.info(
@@ -560,6 +569,97 @@ class TestSuite:
     if not all_results:
       logging.warning("No benchmarks were run for this suite.")
 
+    # Aggregate first (the cross-host gather runs here), then capture/compare
+    # baselines from that aggregate.
     self._suite_metrics.generate_report()
+    for benchmark in all_benchmarks:
+      self._handle_baseline(benchmark)
     multihost.sync_global_processes("test_suite:run_end")
     return all_results
+
+  def _handle_baseline(self, benchmark: "Benchmark") -> None:
+    """Captures and/or compares a baseline for one benchmark, post-aggregation.
+
+    Runs after generate_report, so it reads the cross-host metric aggregate the
+    suite gather produced. Only the primary host writes/reads.
+
+    Args:
+      benchmark: The benchmark whose options select the capture/compare paths
+        and whose name keys the baseline + its aggregated metrics.
+    """
+    if multihost.get_process_index() != 0:
+      return
+    options = benchmark.options
+    capture = options.baseline_capture_path
+    compare = options.baseline_path
+    if not capture and not compare:
+      return
+    metrics = self._baseline_metrics(benchmark.name)
+    if capture:
+      manifest = self._suite_metrics.run_manifest
+      baseline = baseline_lib.Baseline(
+          benchmark_name=benchmark.name,
+          captured_at=manifest.captured_at,
+          captured_at_sha=manifest.git_sha,
+          fixture=str(benchmark.checkpoint_config.path or "generated"),
+          config=dataclasses.asdict(options),
+          metrics=metrics,
+          manifest=dataclasses.asdict(manifest),
+      )
+      out = baseline_lib.BaselineRecorder(capture).write(baseline)
+      logging.info("Wrote baseline for %s to %s", benchmark.name, out)
+    if compare:
+      try:
+        report = baseline_lib.BaselineComparer(compare).compare(metrics)
+      except FileNotFoundError:
+        logging.warning(
+            "baseline_path=%s missing for %s; skipping compare.",
+            compare,
+            benchmark.name,
+        )
+        return
+      lines = [_format_baseline_delta(d) for d in report.deltas]
+      logging.info(
+          "[baseline] %s vs %s:\n%s",
+          benchmark.name,
+          report.baseline.captured_at_sha,
+          "\n".join(lines) if lines else "  (no overlapping metrics)",
+      )
+
+  def _baseline_metrics(
+      self, benchmark_name: str
+  ) -> dict[str, dict[str, float]]:
+    """Cross-host metric aggregate for a benchmark, falling back to rank 0.
+
+    Args:
+      benchmark_name: The benchmark to aggregate.
+
+    Returns:
+      Metric key -> {stat: value}. Uses the all-host gather when available;
+      otherwise wraps rank-0's per-repeat means as a `{"mean": value}` fallback.
+    """
+    aggregate = self._suite_metrics.cross_host_aggregates(benchmark_name)
+    if aggregate is not None:
+      return aggregate
+    logging.warning(
+        "Baseline for %s reflects rank-0 only; enable TensorBoard for the "
+        "cross-host aggregate.",
+        benchmark_name,
+    )
+    means = self._suite_metrics.mean_metrics(benchmark_name)
+    return {key: {"mean": value} for key, value in means.items()}
+
+
+def _format_baseline_delta(d: baseline_lib.MetricDelta) -> str:
+  """Formats one baseline metric delta as a single report line.
+
+  Args:
+    d: The metric delta to render.
+
+  Returns:
+    A line with baseline/current values, plus the speedup ratio when defined.
+  """
+  line = f"  {d.key}: baseline={d.baseline:.4f} current={d.current:.4f}"
+  if d.ratio is not None:
+    line += f" ratio={d.ratio:.3f}x"
+  return line

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metrics_manager.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metrics_manager.py
@@ -132,9 +132,17 @@ class MetricsManager:
     self._writers: dict[str, Any] = {}
     # Suite-level: first non-None inventory per benchmark wins.
     self._inventories: dict[str, Any] = {}
+    # Cross-host metric aggregate per benchmark; filled by the primary during
+    # generate_report's gather, read by baseline capture/compare.
+    self._cross_host_aggregates: dict[str, dict[str, dict[str, float]]] = {}
     # Captured once so the manifest reflects the reported run, not the machine
     # state at generate_report time.
     self._suite_run_manifest = run_manifest_lib.capture_run_manifest()
+
+  @property
+  def run_manifest(self) -> run_manifest_lib.RunManifest:
+    """The environment snapshot captured once when this manager was created."""
+    return self._suite_run_manifest
 
   def add_result(
       self,
@@ -270,6 +278,34 @@ class MetricsManager:
       )
     return aggregated_stats_dict, metric_units
 
+  def mean_metrics(self, benchmark_name: str) -> dict[str, float]:
+    """Returns each metric's mean across a benchmark's successful repeats.
+
+    Args:
+      benchmark_name: The benchmark configuration to aggregate.
+
+    Returns:
+      Mapping of metric key to its mean value over the successful repeats.
+    """
+    stats, _ = self._aggregate_metrics(self._runs[benchmark_name])
+    return {key: float(value.mean) for key, value in stats.items()}
+
+  def cross_host_aggregates(
+      self, benchmark_name: str
+  ) -> dict[str, dict[str, float]] | None:
+    """Returns the cross-host metric aggregate for a benchmark, if gathered.
+
+    Populated on the primary host during generate_report when a TensorBoard
+    dir is configured (the sidecar gather writes there); None otherwise.
+
+    Args:
+      benchmark_name: The benchmark to look up.
+
+    Returns:
+      Metric key -> {stat: value} across hosts, or None if not gathered.
+    """
+    return self._cross_host_aggregates.get(benchmark_name)
+
   def _count_runs(self) -> tuple[int, int, int]:
     total = passed = failed = 0
     for _, results in self._runs.items():
@@ -382,6 +418,7 @@ class MetricsManager:
     if multihost.get_process_index() == 0:
       aggregates = self._gather_cross_host_aggregates(benchmark_name)
       if aggregates:
+        self._cross_host_aggregates[benchmark_name] = aggregates
         self._write_summary_cards(benchmark_name, results, aggregates)
     # Final barrier so non-primaries don't exit while the primary writes —
     # otherwise the coordinator marks them gone and the shutdown barrier fails.

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/pytree_utils.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/pytree_utils.py
@@ -14,7 +14,10 @@
 
 """Utility functions for PyTree operations in benchmarks."""
 
+from collections.abc import Callable, Sequence
+import hashlib
 from typing import Any
+
 from absl import logging
 import jax
 import jax.numpy as jnp
@@ -81,3 +84,129 @@ def log_pytree(msg: str, pytree: Any):
       ),
       pytree,
   )
+
+
+def _leaf_path(keypath: tuple[Any, ...]) -> str:
+  """Formats a jax keypath as one string ('<root>' for the empty path)."""
+  parts = "".join(jax.tree_util.keystr((entry,)) for entry in keypath)
+  return parts or "<root>"
+
+
+def _leaf_to_numpy(leaf: Any) -> np.ndarray:
+  """Materialises a leaf to a contiguous numpy array for hashing.
+
+  Multi-host jax.Arrays span devices the local process can't reach, so we
+  hash only this process's addressable shards, concatenated in a stable
+  (sorted-by-index) order — each host hashes the slice it owns.
+
+  Args:
+    leaf: A pytree leaf — a numpy array, a jax.Array, or a scalar.
+
+  Returns:
+    A contiguous numpy array of this process's addressable data.
+  """
+  if isinstance(leaf, np.ndarray):
+    return np.ascontiguousarray(leaf)
+  if hasattr(leaf, "addressable_shards"):
+    shards = list(leaf.addressable_shards)
+    if not shards:
+      return np.ascontiguousarray(np.zeros((0,), dtype=np.float32))
+    shards.sort(key=lambda s: tuple(s.index or ()))
+    return np.ascontiguousarray(
+        np.concatenate([np.asarray(s.data).ravel() for s in shards])
+    )
+  return np.ascontiguousarray(np.asarray(leaf))
+
+
+def digest_pytree(pytree: Any) -> dict[str, str]:
+  """Computes a per-leaf SHA-256 digest keyed by leaf path.
+
+  Useful for load-only benchmarks, where no in-memory reference pytree
+  exists to pass to `assert_pytree_equal`: capture digests once, then check
+  future loads against them with `assert_digests_match`.
+
+  Args:
+    pytree: The pytree to digest.
+
+  Returns:
+    Mapping of leaf path to the hex SHA-256 of its (dtype, shape, bytes).
+  """
+  leaves = jax.tree_util.tree_flatten_with_path(pytree)[0]
+  digests: dict[str, str] = {}
+  for keypath, leaf in leaves:
+    arr = _leaf_to_numpy(leaf)
+    h = hashlib.sha256()
+    h.update(arr.dtype.str.encode("ascii"))
+    h.update(repr(arr.shape).encode("ascii"))
+    h.update(arr.tobytes())
+    digests[_leaf_path(keypath)] = h.hexdigest()
+  return digests
+
+
+def assert_digests_match(expected_digests: dict[str, str], pytree: Any):
+  """Asserts a pytree's per-leaf digests match a previously captured set.
+
+  Args:
+    expected_digests: Per-leaf SHA-256 from a prior `digest_pytree` call.
+    pytree: The pytree to check.
+
+  Raises:
+    AssertionError: If a leaf is missing, unexpected, or its digest differs.
+  """
+  actual = digest_pytree(pytree)
+  for path in sorted(set(expected_digests) ^ set(actual)):
+    where = "missing in pytree" if path in expected_digests else "unexpected"
+    raise AssertionError(f"Digest key mismatch at {path}: {where}")
+  for path, expected in expected_digests.items():
+    if actual[path] != expected:
+      raise AssertionError(
+          f"Digest mismatch at {path}: expected {expected}, got {actual[path]}"
+      )
+
+
+def assert_functional_equivalence(
+    model_apply_fn: Callable[[Any, Any], Any],
+    reference_inputs: Sequence[Any],
+    expected_params: Any,
+    actual_params: Any,
+    tolerance: float = 1e-6,
+):
+  """Asserts two parameter sets produce equivalent model outputs.
+
+  Runs `model_apply_fn(params, x)` for each reference input against both
+  parameter sets and compares the outputs. A NaN or shape mismatch fails
+  closed (the comparison is `not max_abs_diff <= tolerance`).
+
+  Args:
+    model_apply_fn: `apply(params, x) -> y`.
+    reference_inputs: Non-empty sequence of inputs to run through the model.
+    expected_params: Reference parameter set.
+    actual_params: Parameter set validated against the reference.
+    tolerance: Maximum allowed absolute output difference per input.
+
+  Raises:
+    ValueError: If `reference_inputs` is empty.
+    AssertionError: If any input's output diverges beyond `tolerance`.
+  """
+  if not reference_inputs:
+    raise ValueError("reference_inputs must be a non-empty sequence")
+  for idx, x in enumerate(reference_inputs):
+    expected_out = np.asarray(
+        model_apply_fn(expected_params, x), dtype=np.float64
+    )
+    actual_out = np.asarray(model_apply_fn(actual_params, x), dtype=np.float64)
+    if expected_out.shape != actual_out.shape:
+      raise AssertionError(
+          f"Output shape mismatch on input {idx}: "
+          f"{expected_out.shape} vs {actual_out.shape}"
+      )
+    diff = (
+        float(np.max(np.abs(expected_out - actual_out)))
+        if expected_out.size
+        else 0.0
+    )
+    if not diff <= tolerance:
+      raise AssertionError(
+          f"Functional divergence on input {idx}: "
+          f"max_abs_diff={diff} > tolerance={tolerance}"
+      )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/pytree_utils_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/pytree_utils_test.py
@@ -88,5 +88,107 @@ class PytreeUtilsTest(parameterized.TestCase):
     pytree_utils.assert_pytree_equal(v1, v2)
 
 
+class DigestPytreeTest(absltest.TestCase):
+
+  def test_matching_digests_pass(self):
+    tree = {'w': np.arange(16, dtype=np.float32)}
+    pytree_utils.assert_digests_match(pytree_utils.digest_pytree(tree), tree)
+
+  def test_digest_mismatch_raises(self):
+    ref = {'w': np.arange(16, dtype=np.float32)}
+    other = {'w': np.arange(16, dtype=np.float32)[::-1].copy()}
+    self.assertRaisesRegex(
+        AssertionError,
+        'Digest mismatch',
+        pytree_utils.assert_digests_match,
+        pytree_utils.digest_pytree(ref),
+        other,
+    )
+
+  def test_extra_leaf_raises(self):
+    digests = pytree_utils.digest_pytree({'a': np.zeros(4)})
+    self.assertRaisesRegex(
+        AssertionError,
+        'Digest key mismatch',
+        pytree_utils.assert_digests_match,
+        digests,
+        {'a': np.zeros(4), 'b': np.zeros(4)},
+    )
+
+  def test_digest_is_stable_across_calls(self):
+    tree = {'w': np.arange(16, dtype=np.int32)}
+    self.assertEqual(
+        pytree_utils.digest_pytree(tree), pytree_utils.digest_pytree(tree)
+    )
+
+  def test_digest_differs_for_dtype_change_only(self):
+    a = {'w': np.zeros(4, dtype=np.float32)}
+    b = {'w': np.zeros(4, dtype=np.float64)}
+    self.assertNotEqual(
+        pytree_utils.digest_pytree(a), pytree_utils.digest_pytree(b)
+    )
+
+
+def _linear_apply(params, x):
+  return params['W'] @ x
+
+
+class FunctionalEquivalenceTest(absltest.TestCase):
+
+  def test_identical_params_pass(self):
+    w = {'W': np.eye(4, dtype=np.float32)}
+    pytree_utils.assert_functional_equivalence(
+        _linear_apply, [np.arange(4, dtype=np.float32)], w, w
+    )
+
+  def test_divergence_raises(self):
+    ref = {'W': np.eye(4, dtype=np.float32)}
+    actual = {'W': np.eye(4, dtype=np.float32) * 2}
+    self.assertRaisesRegex(
+        AssertionError,
+        'Functional divergence',
+        pytree_utils.assert_functional_equivalence,
+        _linear_apply,
+        [np.arange(4, dtype=np.float32)],
+        ref,
+        actual,
+    )
+
+  def test_within_tolerance_passes(self):
+    ref = {'W': np.eye(4, dtype=np.float32)}
+    actual = {'W': np.eye(4, dtype=np.float32) + 1e-6}
+    pytree_utils.assert_functional_equivalence(
+        _linear_apply,
+        [np.arange(4, dtype=np.float32)],
+        ref,
+        actual,
+        tolerance=1e-3,
+    )
+
+  def test_shape_change_raises(self):
+    ref = {'W': np.eye(4, dtype=np.float32)}
+    actual = {'W': np.eye(5, 4, dtype=np.float32)}
+    self.assertRaisesRegex(
+        AssertionError,
+        'shape mismatch',
+        pytree_utils.assert_functional_equivalence,
+        _linear_apply,
+        [np.zeros(4, dtype=np.float32)],
+        ref,
+        actual,
+    )
+
+  def test_empty_inputs_raises(self):
+    self.assertRaisesRegex(
+        ValueError,
+        'non-empty',
+        pytree_utils.assert_functional_equivalence,
+        _linear_apply,
+        [],
+        {'W': np.eye(4)},
+        {'W': np.eye(4)},
+    )
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
## Description

Adds performance-regression **baselines** and **correctness helpers** to the
internal benchmark suite (`orbax/checkpoint/_src/testing/benchmarks/`). No
public Orbax API or user-facing behavior changes.

**Baselines** (`core/baseline.py`): a versioned-JSON `Baseline` schema with
`BaselineRecorder` (writer) and `BaselineComparer` (reader + per-metric diff)
in one module. Captured metrics are the cross-host aggregate the suite gather
already computes (max/min/mean, plus p50/p99 with >1 host), recorded at suite
end and keyed by the run-manifest git SHA. `BenchmarkOptions` gains
`baseline_path` / `baseline_capture_path`; `TestSuite` captures/compares each
benchmark after `generate_report`, reusing `MetricsManager`'s run manifest and
cross-host aggregation. The comparer diffs a chosen stat (default `mean`) into
per-metric speedup ratios.

**Correctness helpers** (`core/pytree_utils.py`): `digest_pytree` /
`assert_digests_match` for load-only validation where no in-memory reference
exists, and `assert_functional_equivalence` for model-output equivalence.
Round-trip save/load benchmarks continue to use the existing
`assert_pytree_equal`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or a public API)
- [x] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover this change and pass locally.
- [x] Public APIs and non-trivial functions are documented.
- [x] **If this change is user-facing, I have updated [`CHANGELOG.md`](CHANGELOG.md)** under the `[Unreleased]` section (or the relevant `checkpoint/` / `export/` changelog). — N/A: internal benchmark tooling, not user-facing.
