### PR TITLE
fix(path): fix Windows path compatibility in recursively_copy_files

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/path/utils.py
+++ b/checkpoint/orbax/checkpoint/_src/path/utils.py
@@ -73,18 +73,19 @@ def recursively_copy_files(
 
   for root, dirs, files in os.walk(src_path):
     relative_path = str(root)[len(str(src_path)) :].lstrip(os.sep)
+    relative_path = relative_path.replace(os.sep, '/')
     if relative_path in skip_paths_set:
       continue
     # Prune dirs that are in skip_paths to prevent traversal.
     dirs[:] = [
-        d for d in dirs if os.path.join(relative_path, d) not in skip_paths_set
+        d for d in dirs if f"{relative_path}/{d}".lstrip('/') not in skip_paths_set
     ]
 
     dst_root = dst_path / relative_path
     dst_root.mkdir(parents=True, exist_ok=True)
 
     for file in files:
-      relative_file_path = os.path.join(relative_path, file)
+      relative_file_path = f"{relative_path}/{file}".lstrip('/')
       if relative_file_path in skip_paths_set:
         continue
 


### PR DESCRIPTION
## Description

This PR fixes a Windows path compatibility bug in `recursively_copy_files` where the directory traverser fails to match skip paths containing Unix style separators (`/`) against Windows style separators (`\`).

When copying files recursively on Windows, `os.walk` yields paths with backslashes. Consequently, `relative_file_path` constructed via `os.path.join` contains backslashes (e.g. `b\file2.txt`), which fails to match against `skip_paths` typically provided with forward slashes (e.g. `b/file2.txt`). 

We normalize all intermediate relative paths to use forward slashes (`/`), ensuring cross-platform correctness for all file and directory exclusion checks.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or a public API)
- [ ] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover this change and pass locally.
- [ ] Public APIs and non-trivial functions are documented.
- [ ] **If this change is user-facing, I have updated [`CHANGELOG.md`](CHANGELOG.md)** under the `[Unreleased]` section (or the relevant `checkpoint/` / `export/` changelog).
