### PR TITLE
Add baseline capture/compare flags to the benchmark runner

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/config_parsing.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/config_parsing.py
@@ -43,7 +43,7 @@ benchmarks:
 """
 
 import importlib
-from typing import Any, Dict, List, Type
+from typing import Any
 
 from absl import logging
 from etils import epath
@@ -52,8 +52,7 @@ from orbax.checkpoint._src.testing.benchmarks.core import core
 import yaml
 
 
-
-def _import_class(class_path: str) -> Type[Any]:
+def _import_class(class_path: str) -> type[Any]:
   """Dynamically imports a class from a string path."""
   try:
     module_path, class_name = class_path.rsplit('.', 1)
@@ -63,7 +62,7 @@ def _import_class(class_path: str) -> Type[Any]:
     raise ImportError(f'Failed to import class {class_path}: {e}') from e
 
 
-def _load_yaml_config(config_path: str) -> Dict[str, Any]:
+def _load_yaml_config(config_path: str) -> dict[str, Any]:
   """Loads a YAML configuration file."""
   logging.info('Loading configuration from: %s', config_path)
   try:
@@ -77,7 +76,7 @@ def _load_yaml_config(config_path: str) -> Dict[str, Any]:
     raise
 
 
-def _validate_config(config: Dict[str, Any]) -> None:
+def _validate_config(config: dict[str, Any]) -> None:
   """Performs basic validation on the loaded YAML config."""
   required_keys = ['suite_name', 'benchmarks']
   for key in required_keys:
@@ -103,11 +102,37 @@ def _validate_config(config: Dict[str, Any]) -> None:
       )
 
 
+def _parse_checkpoint_configs(
+    config: dict[str, Any],
+) -> list[config_lib.CheckpointConfig]:
+  """Builds the checkpoint configs from the YAML; defaults to a single one."""
+  if 'checkpoint_configs' in config:
+    return [
+        config_lib.CheckpointConfig(**cc) for cc in config['checkpoint_configs']
+    ]
+  if 'checkpoint_config' in config:
+    return [config_lib.CheckpointConfig(**config['checkpoint_config'])]
+  return [config_lib.CheckpointConfig()]
+
+
+def _parse_mesh_configs(
+    config: dict[str, Any],
+) -> list[config_lib.MeshConfig] | None:
+  """Builds the mesh configs from the YAML, or None if unspecified."""
+  if 'mesh_configs' in config:
+    return [config_lib.MeshConfig(**mc) for mc in config['mesh_configs']]
+  if 'mesh_config' in config:
+    return [config_lib.MeshConfig(**config['mesh_config'])]
+  return None
+
+
 def create_test_suite_from_config(
     config_path: str,
     output_dir: str | None = None,
     local_directory: str | None = None,
     remove_repeated_dir: bool = False,
+    baseline_capture_path: str | None = None,
+    baseline_path: str | None = None,
 ) -> core.TestSuite:
   """Creates a single TestSuite object from the benchmark configuration.
 
@@ -119,38 +144,27 @@ def create_test_suite_from_config(
       used for ECM benchmarks.
     remove_repeated_dir: Whether to remove the generated repeat_* directories
       after execution.
+    baseline_capture_path: If set, the run captures a baseline into this
+      directory; overrides a `baseline_capture_path` key in the YAML.
+    baseline_path: If set, the run is compared against this stored baseline;
+      overrides a `baseline_path` key in the YAML.
 
   Returns:
     A TestSuite object containing all benchmarks generated from the config.
   """
-
   config = _load_yaml_config(config_path)
-
   _validate_config(config)
 
   suite_name = config['suite_name']
   num_repeats = config.get('num_repeats', 1)
-  if 'checkpoint_configs' in config:
-    checkpoint_configs = [
-        config_lib.CheckpointConfig(**cc) for cc in config['checkpoint_configs']
-    ]
-  elif 'checkpoint_config' in config:
-    checkpoint_configs = [
-        config_lib.CheckpointConfig(**config['checkpoint_config'])
-    ]
-  else:
-    checkpoint_configs = [config_lib.CheckpointConfig()]
+  checkpoint_configs = _parse_checkpoint_configs(config)
+  mesh_configs = _parse_mesh_configs(config)
+  baseline_capture_path = baseline_capture_path or config.get(
+      'baseline_capture_path'
+  )
+  baseline_path = baseline_path or config.get('baseline_path')
 
-  if 'mesh_configs' in config:
-    mesh_configs = [
-        config_lib.MeshConfig(**mc) for mc in config['mesh_configs']
-    ]
-  elif 'mesh_config' in config:
-    mesh_configs = [config_lib.MeshConfig(**config['mesh_config'])]
-  else:
-    mesh_configs = None
-
-  generators: List[core.BenchmarksGenerator] = []
+  generators: list[core.BenchmarksGenerator] = []
 
   for i, benchmark_group in enumerate(config['benchmarks']):
     generator_class_path = benchmark_group['generator']
@@ -204,4 +218,6 @@ def create_test_suite_from_config(
       output_dir=output_dir,
       local_directory=local_directory,
       remove_repeated_dir=remove_repeated_dir,
+      baseline_path=baseline_path,
+      baseline_capture_path=baseline_capture_path,
   )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/config_parsing_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/config_parsing_test.py
@@ -25,7 +25,6 @@ from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 import yaml
 
 
-
 @dataclasses.dataclass(frozen=True)
 class MockOptions(core.BenchmarkOptions):
   param1: int = 1
@@ -378,6 +377,51 @@ benchmarks:
         test_suite._benchmarks_generators[0]._checkpoint_configs,
         [config_lib.CheckpointConfig()],
     )
+
+  @mock.patch.object(config_parsing, '_load_yaml_config', autospec=True)
+  @mock.patch.object(config_parsing, '_import_class', autospec=True)
+  def test_baseline_flags_set_on_suite(self, mock_import, mock_load):
+    mock_load.return_value = yaml.safe_load(self._get_valid_yaml_content())
+    mock_import.return_value = MockGenerator
+
+    test_suite = config_parsing.create_test_suite_from_config(
+        'fake.yaml',
+        baseline_capture_path='/tmp/caps',
+        baseline_path='/tmp/base.json',
+    )
+
+    self.assertEqual(test_suite._baseline_capture_path, '/tmp/caps')
+    self.assertEqual(test_suite._baseline_path, '/tmp/base.json')
+
+  @mock.patch.object(config_parsing, '_load_yaml_config', autospec=True)
+  @mock.patch.object(config_parsing, '_import_class', autospec=True)
+  def test_baseline_absent_is_none_on_suite(self, mock_import, mock_load):
+    mock_load.return_value = yaml.safe_load(self._get_valid_yaml_content())
+    mock_import.return_value = MockGenerator
+
+    test_suite = config_parsing.create_test_suite_from_config('fake.yaml')
+
+    self.assertIsNone(test_suite._baseline_capture_path)
+    self.assertIsNone(test_suite._baseline_path)
+
+  @mock.patch.object(config_parsing, '_load_yaml_config', autospec=True)
+  @mock.patch.object(config_parsing, '_import_class', autospec=True)
+  def test_baseline_from_yaml_with_flag_override(self, mock_import, mock_load):
+    config = yaml.safe_load(self._get_valid_yaml_content())
+    config['baseline_capture_path'] = '/yaml/caps'
+    config['baseline_path'] = '/yaml/base.json'
+    mock_load.return_value = config
+    mock_import.return_value = MockGenerator
+
+    suite = config_parsing.create_test_suite_from_config('fake.yaml')
+    self.assertEqual(suite._baseline_capture_path, '/yaml/caps')
+    self.assertEqual(suite._baseline_path, '/yaml/base.json')
+
+    suite = config_parsing.create_test_suite_from_config(
+        'fake.yaml', baseline_capture_path='/flag/caps'
+    )
+    self.assertEqual(suite._baseline_capture_path, '/flag/caps')
+    self.assertEqual(suite._baseline_path, '/yaml/base.json')
 
   @mock.patch.object(config_parsing, '_load_yaml_config', autospec=True)
   @mock.patch.object(config_parsing, '_import_class', autospec=True)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/core.py
@@ -40,25 +40,16 @@ from orbax.checkpoint._src.testing.benchmarks.core import multihost
 class BenchmarkOptions:
   """Base class for benchmark generator options.
 
-  The baseline_* fields are orchestration switches configured once per run
-  (not swept); subclasses inherit them automatically.
-
   Attributes:
     enable_trace: Whether to capture a per-operation `jax.profiler` trace for
       each measured save/load. Off by default.
     trace_every_repeat: Whether to capture traces on every repeat, or only the
       first repeat (the default); traces on every repeat overflow the Trace
       Viewer.
-    baseline_path: Path to a stored baseline to compare this run against, or
-      None to skip comparison.
-    baseline_capture_path: Path to write this run's baseline to, or None to
-      skip capture.
   """
 
   enable_trace: bool = False
   trace_every_repeat: bool = False
-  baseline_path: str | None = None
-  baseline_capture_path: str | None = None
 
   @classmethod
   def from_dict(cls, options_dict: dict[str, Any]) -> "BenchmarkOptions":
@@ -485,6 +476,8 @@ class TestSuite:
       num_repeats: int = 1,
       local_directory: str | None = None,
       remove_repeated_dir: bool = False,
+      baseline_path: str | None = None,
+      baseline_capture_path: str | None = None,
   ):
     self._name = name
     self._benchmarks_generators = benchmarks_generators
@@ -493,6 +486,8 @@ class TestSuite:
     self._output_dir = output_dir
     self._local_directory = local_directory
     self._remove_repeated_dir = remove_repeated_dir
+    self._baseline_path = baseline_path
+    self._baseline_capture_path = baseline_capture_path
     tensorboard_dir = None
     if output_dir:
       tensorboard_dir = epath.Path(output_dir) / "tensorboard"
@@ -584,14 +579,15 @@ class TestSuite:
     suite gather produced. Only the primary host writes/reads.
 
     Args:
-      benchmark: The benchmark whose options select the capture/compare paths
-        and whose name keys the baseline + its aggregated metrics.
+      benchmark: The benchmark whose name keys the baseline + its aggregated
+        metrics, and whose options snapshot is recorded in a captured baseline.
+        The capture/compare paths themselves are suite-level.
     """
     if multihost.get_process_index() != 0:
       return
     options = benchmark.options
-    capture = options.baseline_capture_path
-    compare = options.baseline_path
+    capture = self._baseline_capture_path
+    compare = self._baseline_path
     if not capture and not compare:
       return
     metrics = self._baseline_metrics(benchmark.name)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/run_benchmarks.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/run_benchmarks.py
@@ -17,12 +17,11 @@ r"""Main script to run Orbax checkpoint benchmarks based on YAML configurations.
 
 When running in an open-source environment (e.g., on a cluster with mpirun),
 jax.distributed.initialize() will be called to set up the distributed system
-using standard environment variables like JAX_COORDINATOR_ADDRESS, JAX_PROCESS_ID,
-and JAX_NUM_PROCESSES.
+using standard environment variables like JAX_COORDINATOR_ADDRESS,
+JAX_PROCESS_ID and JAX_NUM_PROCESSES.
 """
 
 import os
-from typing import List
 
 from absl import app
 from absl import flags
@@ -30,6 +29,7 @@ from absl import logging
 from etils import epath
 import jax
 from orbax.checkpoint._src.testing.benchmarks.core import config_parsing
+
 try:
   import pathwaysutils  # pylint: disable=g-import-not-at-top
 
@@ -64,6 +64,18 @@ _REMOVE_REPEATED_DIR = flags.DEFINE_bool(
     'remove_repeated_dir',
     False,
     'Remove the generated repeat_* directories after execution.',
+)
+_BASELINE_CAPTURE_PATH = flags.DEFINE_string(
+    'baseline_capture_path',
+    None,
+    'If set, directory to write each benchmark baseline JSON to after the '
+    'run. Records the cross-host aggregated metrics as the baseline.',
+)
+_BASELINE_PATH = flags.DEFINE_string(
+    'baseline_path',
+    None,
+    'If set, a stored baseline JSON to compare this run against; the '
+    'per-metric delta is logged at the end of the run.',
 )
 
 
@@ -144,6 +156,8 @@ def _run_benchmarks(
     output_directory: str,
     local_directory: str | None = None,
     remove_repeated_dir: bool = False,
+    baseline_capture_path: str | None = None,
+    baseline_path: str | None = None,
 ) -> None:
   """Runs Orbax checkpoint benchmarks based on a generator class and a config file.
 
@@ -154,6 +168,9 @@ def _run_benchmarks(
       benchmarks.
     remove_repeated_dir: Whether to remove the generated repeat_* directories
       after execution.
+    baseline_capture_path: If set, directory each benchmark's captured baseline
+      JSON is written to after the run.
+    baseline_path: If set, a stored baseline the run is compared against.
 
   Raises:
     RuntimeError: If any benchmark test fails.
@@ -175,6 +192,8 @@ def _run_benchmarks(
         output_dir=output_directory,
         local_directory=local_directory,
         remove_repeated_dir=remove_repeated_dir,
+        baseline_capture_path=baseline_capture_path,
+        baseline_path=baseline_path,
     )
   except Exception as e:
     logging.error('Failed to create test suite from config: %s', e)
@@ -198,7 +217,7 @@ def _run_benchmarks(
     raise RuntimeError(exception_message)
 
 
-def main(argv: List[str]) -> None:
+def main(argv: list[str]) -> None:
   if len(argv) > 1:
     raise app.UsageError(f'Too many command-line arguments: {argv[1:]}')
 
@@ -225,6 +244,8 @@ def main(argv: List[str]) -> None:
       _OUTPUT_DIRECTORY.value,
       _LOCAL_DIRECTORY.value,
       remove_repeated_dir=_REMOVE_REPEATED_DIR.value,
+      baseline_capture_path=_BASELINE_CAPTURE_PATH.value,
+      baseline_path=_BASELINE_PATH.value,
   )
 
   logging.info('run_benchmarks.py finished.')


### PR DESCRIPTION
## Description

Baseline capture/compare is configured once per run, not per benchmark
variant — so this makes it a suite-level concern instead of a
`BenchmarkOptions` field.

- `baseline_path` / `baseline_capture_path` move off `BenchmarkOptions` (the
  swept per-variant options dataclass) onto `TestSuite`, where the existing
  post-aggregation handler captures/compares the cross-host **perf metrics**.
- `run_benchmarks` gains `--baseline_capture_path` / `--baseline_path`.
  `create_test_suite_from_config` resolves them — a flag overrides a top-level
  `baseline_*` key in the YAML — and passes them to the suite.

So one config can capture a baseline on one revision and compare against it on
another by toggling a flag, without editing the YAML or carrying the path
through every benchmark variant. (`create_test_suite_from_config`'s inline
config parsing was extracted into small helpers to keep it under the McCabe
limit once the new param was added.)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or a public API)
- [x] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover this change and pass locally. (`config_parsing_test` covers
  flag/YAML resolution onto the suite; the full `benchmarks/` suite passes.)
- [x] Public APIs and non-trivial functions are documented.
- [ ] **If this change is user-facing, I have updated [`CHANGELOG.md`](CHANGELOG.md)** — N/A: internal benchmark tooling, no user-facing behavior change.
