### PR TITLE
Add native-Orbax checkpoint load benchmark

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/GUIDE.md
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/GUIDE.md
@@ -285,8 +285,8 @@ The canonical generator: saves the pytree then restores it, measuring
 | `checkpoint_config` / `checkpoint_configs` | no | one empty config | Checkpoint(s) to save/load. Plural ⇒ swept. |
 | `mesh_config` / `mesh_configs` | no | none | Device mesh(es). Plural ⇒ swept. Omitted ⇒ `context.mesh` is `None`. |
 | `benchmarks` | yes | — | List of `{generator, options}` entries. |
-| `baseline_capture_path` | no | none | Write captured baseline JSON here (overridden by `--baseline_capture_path`). |
-| `baseline_path` | no | none | Compare against this stored baseline (overridden by `--baseline_path`). |
+| `baseline_capture_path` | no | none | Write captured baseline JSON here. |
+| `baseline_path` | no | none | Compare against this stored baseline. |
 
 ### `benchmarks`
 
@@ -345,8 +345,6 @@ python checkpoint/orbax/checkpoint/_src/testing/benchmarks/run_benchmarks.py \
 | `--local_directory` | no | Local scratch directory (some checkpoint-manager benchmarks). |
 | `--enable_hlo_dump` | no | Dump XLA HLO protos to `<output_directory>/hlo_dump/`. |
 | `--remove_repeated_dir` | no | Delete the generated `repeat_*` directories after the run. |
-| `--baseline_capture_path` | no | Write each benchmark's baseline JSON (cross-host aggregated) here. |
-| `--baseline_path` | no | Compare against the stored baseline and log the per-metric delta. |
 
 The runner enables `jax_enable_x64`. On a single process it runs locally; on
 CPU, simulate devices with
@@ -486,11 +484,13 @@ checkpoint directories.
 
 ### 🆚 Baselines (capture / compare)
 
-```bash
+Set these in the config (suite level), not via flags:
+
+```yaml
 # Capture on the baseline revision (writes cross-host aggregates as <git_sha>.json):
-... --baseline_capture_path=gs://bucket/baselines/my_suite/
-# Compare a later revision (logs a per-metric delta):
-... --baseline_path=gs://bucket/baselines/my_suite/<git_sha>.json
+baseline_capture_path: gs://bucket/baselines/my_suite/
+# Compare a later revision (logs a per-metric delta) — set this instead:
+baseline_path: gs://bucket/baselines/my_suite/<git_sha>.json
 ```
 
 If no git sha resolves, the baseline is written as `unknown.json`.
@@ -552,14 +552,15 @@ benchmarks:
 
 ### D — Capture a baseline, then compare
 
+Set the baseline path in the config (`baseline_capture_path` to capture,
+`baseline_path` to compare), then run the same command on each revision:
+
 ```bash
 RB=checkpoint/orbax/checkpoint/_src/testing/benchmarks/run_benchmarks.py
-# baseline revision:
-python $RB --config_file=sweep.yaml --output_directory=/tmp/baseline/ \
-    --baseline_capture_path=gs://my-bucket/baselines/sweep/
-# candidate revision:
-python $RB --config_file=sweep.yaml --output_directory=/tmp/candidate/ \
-    --baseline_path=gs://my-bucket/baselines/sweep/<git_sha>.json
+# baseline revision (sweep.yaml has `baseline_capture_path: gs://my-bucket/baselines/sweep/`):
+python $RB --config_file=sweep.yaml --output_directory=/tmp/baseline/
+# candidate revision (sweep.yaml has `baseline_path: gs://my-bucket/baselines/sweep/<git_sha>.json`):
+python $RB --config_file=sweep.yaml --output_directory=/tmp/candidate/
 ```
 
 ---
@@ -575,7 +576,7 @@ python $RB --config_file=sweep.yaml --output_directory=/tmp/candidate/ \
 ```
 
 Metrics are also printed to the logs as a per-process report after each
-benchmark, and (with `--baseline_path`) as a per-metric delta table.
+benchmark, and (when `baseline_path` is set) as a per-metric delta table.
 
 ---
 
@@ -583,7 +584,7 @@ benchmark, and (with `--baseline_path`) as a per-metric delta table.
 
 ```none
 RUN          python checkpoint/orbax/checkpoint/_src/testing/benchmarks/run_benchmarks.py \
-               --config_file=cfg.yaml --output_directory=/tmp/out/ [--baseline_capture_path=… | --baseline_path=…]
+               --config_file=cfg.yaml --output_directory=/tmp/out/
 
 MEASURE      with metrics.measure("op"):  <code>        # captures the whole suite; blocks nest
              return TestResult(metrics=metrics)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/checkpoint_generation.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/checkpoint_generation.py
@@ -24,6 +24,7 @@ import jax.numpy as jnp
 import numpy as np
 from orbax.checkpoint import checkpoint_utils
 from orbax.checkpoint import pathways
+from orbax.checkpoint import v1 as ocp
 from orbax.checkpoint._src.arrays import abstract_arrays
 from orbax.checkpoint._src.arrays import sharding as sharding_utils
 from orbax.checkpoint._src.checkpointers import checkpointer
@@ -32,7 +33,6 @@ from orbax.checkpoint._src.multihost import multihost
 from orbax.checkpoint._src.serialization import type_handlers
 from orbax.checkpoint._src.testing.benchmarks.core import configs
 from orbax.checkpoint._src.tree import utils as tree_utils
-
 
 
 def _create_array(
@@ -187,6 +187,33 @@ def _get_abstract_state(
   return get_abstract_state_from_sharding_config(
       epath.Path(config.sharding_config_path), metadata, devices=devices
   )
+
+
+def generate_and_save_checkpoint(
+    config: configs.CheckpointConfig,
+    output_dir: epath.PathLike,
+    mesh: jax.sharding.Mesh | None = None,
+) -> None:
+  """Generates a synthetic checkpoint from a spec and writes it with `ocp.save`.
+
+  Materialises a synthetic Orbax checkpoint on disk so a load benchmark has
+  something to read without depending on a real model download. The fixture is
+  deterministic for a fixed `config.random_seed`, which the digest-mode
+  correctness check relies on.
+
+  Args:
+    config: The checkpoint config; must carry a `spec`.
+    output_dir: Directory to write the Orbax checkpoint to.
+    mesh: Mesh used to shard the generated data. If None, the data is not
+      sharded.
+  """
+  out = epath.Path(output_dir)
+  if out.exists() and any(out.iterdir()):
+    logging.warning(
+        'A fixture is already present at %s; overwriting it.', out
+    )
+  pytree = generate_checkpoint(config, mesh=mesh)
+  ocp.save(out, pytree, overwrite=True)
 
 
 def load_checkpoint(config: configs.CheckpointConfig) -> Any:

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/config_parsing.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/config_parsing.py
@@ -52,7 +52,6 @@ from orbax.checkpoint._src.testing.benchmarks.core import core
 import yaml
 
 
-
 def _import_class(class_path: str) -> type[Any]:
   """Dynamically imports a class from a string path."""
   try:
@@ -101,6 +100,15 @@ def _validate_config(config: dict[str, Any]) -> None:
       raise ValueError(
           f"'options' must be a dict in benchmarks entry at index {i}"
       )
+    options = benchmark_group['options']
+    if options.get('capture_digests_path') and options.get(
+        'reference_digests_path'
+    ):
+      raise ValueError(
+          'capture_digests_path and reference_digests_path are mutually'
+          f' exclusive in benchmarks entry at index {i}: a run either captures'
+          ' digests or compares against them.'
+      )
 
 
 def _parse_checkpoint_configs(
@@ -127,15 +135,53 @@ def _parse_mesh_configs(
   return None
 
 
+def parse_config(
+    config_path: str,
+) -> tuple[
+    list[config_lib.CheckpointConfig], list[config_lib.MeshConfig] | None
+]:
+  """Parses the checkpoint + mesh configs from a benchmark YAML.
+
+  Pure parsing — no mesh construction or checkpoint generation. Callers that
+  need to materialise a fixture (e.g. the `--generate_fixture` entrypoint) use
+  the returned configs to drive `device_mesh` + `checkpoint_generation`.
+
+  Args:
+    config_path: Path to the YAML configuration file.
+
+  Returns:
+    A tuple of (checkpoint configs, mesh configs or None).
+  """
+  config = _load_yaml_config(config_path)
+  return _parse_checkpoint_configs(config), _parse_mesh_configs(config)
+
+
+def load_config(config_path: str) -> dict[str, Any]:
+  """Loads and validates a benchmark YAML config into a raw dict.
+
+  Args:
+    config_path: Path to the YAML configuration file.
+
+  Returns:
+    The parsed, validated config dict.
+  """
+  config = _load_yaml_config(config_path)
+  _validate_config(config)
+  return config
+
+
 def create_test_suite_from_config(
     config_path: str,
     output_dir: str | None = None,
     local_directory: str | None = None,
     remove_repeated_dir: bool = False,
-    baseline_capture_path: str | None = None,
-    baseline_path: str | None = None,
 ) -> core.TestSuite:
-  """Creates a single TestSuite object from the benchmark configuration.
+  """Loads a benchmark YAML config and builds its TestSuite.
+
+  Perf baseline capture/compare paths (`baseline_capture_path` /
+  `baseline_path`) and each load benchmark's correctness-digest paths
+  (`capture_digests_path` / `reference_digests_path`, under a benchmark's
+  `options`) are read from the config itself — there is no run-flag override.
 
   Args:
     config_path: Path to the YAML configuration file.
@@ -145,25 +191,17 @@ def create_test_suite_from_config(
       used for ECM benchmarks.
     remove_repeated_dir: Whether to remove the generated repeat_* directories
       after execution.
-    baseline_capture_path: If set, the run captures a baseline into this
-      directory; overrides a `baseline_capture_path` key in the YAML.
-    baseline_path: If set, the run is compared against this stored baseline;
-      overrides a `baseline_path` key in the YAML.
 
   Returns:
     A TestSuite object containing all benchmarks generated from the config.
   """
-  config = _load_yaml_config(config_path)
-  _validate_config(config)
-
+  config = load_config(config_path)
   suite_name = config['suite_name']
   num_repeats = config.get('num_repeats', 1)
   checkpoint_configs = _parse_checkpoint_configs(config)
   mesh_configs = _parse_mesh_configs(config)
-  baseline_capture_path = baseline_capture_path or config.get(
-      'baseline_capture_path'
-  )
-  baseline_path = baseline_path or config.get('baseline_path')
+  baseline_capture_path = config.get('baseline_capture_path')
+  baseline_path = config.get('baseline_path')
 
   generators: list[core.BenchmarksGenerator] = []
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/config_parsing_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/config_parsing_test.py
@@ -25,7 +25,6 @@ from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 import yaml
 
 
-
 @dataclasses.dataclass(frozen=True)
 class MockOptions(core.BenchmarkOptions):
   param1: int = 1
@@ -377,15 +376,16 @@ benchmarks:
 
   @mock.patch.object(config_parsing, '_load_yaml_config', autospec=True)
   @mock.patch.object(config_parsing, '_import_class', autospec=True)
-  def test_baseline_flags_set_on_suite(self, mock_import, mock_load):
-    mock_load.return_value = yaml.safe_load(self._get_valid_yaml_content())
+  def test_baseline_paths_from_config_set_on_suite(
+      self, mock_import, mock_load
+  ):
+    config = yaml.safe_load(self._get_valid_yaml_content())
+    config['baseline_capture_path'] = '/tmp/caps'
+    config['baseline_path'] = '/tmp/base.json'
+    mock_load.return_value = config
     mock_import.return_value = MockGenerator
 
-    test_suite = config_parsing.create_test_suite_from_config(
-        'fake.yaml',
-        baseline_capture_path='/tmp/caps',
-        baseline_path='/tmp/base.json',
-    )
+    test_suite = config_parsing.create_test_suite_from_config('fake.yaml')
 
     self.assertEqual(test_suite._baseline_capture_path, '/tmp/caps')
     self.assertEqual(test_suite._baseline_path, '/tmp/base.json')
@@ -402,23 +402,15 @@ benchmarks:
     self.assertIsNone(test_suite._baseline_path)
 
   @mock.patch.object(config_parsing, '_load_yaml_config', autospec=True)
-  @mock.patch.object(config_parsing, '_import_class', autospec=True)
-  def test_baseline_from_yaml_with_flag_override(self, mock_import, mock_load):
+  def test_mutually_exclusive_digest_paths_raises(self, mock_load):
     config = yaml.safe_load(self._get_valid_yaml_content())
-    config['baseline_capture_path'] = '/yaml/caps'
-    config['baseline_path'] = '/yaml/base.json'
+    config['benchmarks'][0]['options'] = {
+        'capture_digests_path': '/d',
+        'reference_digests_path': '/d',
+    }
     mock_load.return_value = config
-    mock_import.return_value = MockGenerator
-
-    suite = config_parsing.create_test_suite_from_config('fake.yaml')
-    self.assertEqual(suite._baseline_capture_path, '/yaml/caps')
-    self.assertEqual(suite._baseline_path, '/yaml/base.json')
-
-    suite = config_parsing.create_test_suite_from_config(
-        'fake.yaml', baseline_capture_path='/flag/caps'
-    )
-    self.assertEqual(suite._baseline_capture_path, '/flag/caps')
-    self.assertEqual(suite._baseline_path, '/yaml/base.json')
+    with self.assertRaisesRegex(ValueError, 'mutually exclusive'):
+      config_parsing.load_config('fake.yaml')
 
   @mock.patch.object(config_parsing, '_load_yaml_config', autospec=True)
   @mock.patch.object(config_parsing, '_import_class', autospec=True)

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/markdown_cards.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/markdown_cards.py
@@ -16,8 +16,9 @@
 
 Three cards, all rendered as markdown that TB's Text dashboard displays:
 
-  - scorecard: headline numbers + inventory + run manifest. The
-    screenshot-able card.
+  - at_a_glance: the screenshot-able card — load/save total time + per-stage
+    breakdown, per-host byte counts (the sharding check), inventory detail,
+    and the run manifest.
   - configuration: options + checkpoint config tables, plus pretty-printed
     JSON for nested fields like `spec`.
   - aggregated_metrics: every metric's mean / std / min / max / n / unit,
@@ -32,99 +33,8 @@ from __future__ import annotations
 import collections
 import dataclasses
 import json
+import math
 from typing import Any
-
-_SCORECARD_HEADLINE_KEYS: tuple[tuple[str, str, str], ...] = (
-    # (aggregate key, label, headline stat). Keys carry the measure() operation
-    # prefix (save_blocking_/save_background_/load_) spliced by _add_results.
-    (
-        "save_blocking_4_throughput/save_blocking_gbps",
-        "Save blocking throughput (max GiB/s)",
-        "max",
-    ),
-    (
-        "save_background_4_throughput/save_total_gbps",
-        "Save total throughput (max GiB/s)",
-        "max",
-    ),
-    ("load_4_throughput/load_total_gbps", "Load throughput (max GiB/s)", "max"),
-    (
-        "load_4_throughput/load_per_host_gbps",
-        "Load per-host throughput (max GiB/s)",
-        "max",
-    ),
-    (
-        "save_background_5_inventory/save_total_gb",
-        "Save total per host (GiB)",
-        "max",
-    ),
-    ("load_5_inventory/load_total_gb", "Load total per host (GiB)", "max"),
-    (
-        "save_blocking_2_save_breakdown/blocking_async_s",
-        "Save blocking (slowest host, s)",
-        "max",
-    ),
-    (
-        "load_3_load_breakdown/blocking_s",
-        "Load blocking (slowest host, s)",
-        "max",
-    ),
-    (
-        "save_blocking_7_overhead/sync_global_devices_s",
-        "Sync-barrier overhead (slowest host, s)",
-        "max",
-    ),
-)
-
-
-def render_scorecard(
-    benchmark_name: str,
-    aggregates: dict[str, dict[str, float]],
-    inventory: Any | None,
-    manifest: Any | None,
-) -> str:
-  """Headline numbers + inventory + run manifest as one markdown blob."""
-  lines = [f"## {benchmark_name} — scorecard", ""]
-
-  headline_rows = []
-  for agg_key, label, stat in _SCORECARD_HEADLINE_KEYS:
-    if agg_key in aggregates and stat in aggregates[agg_key]:
-      headline_rows.append((label, aggregates[agg_key][stat]))
-
-  if headline_rows:
-    lines.extend(["### Headline numbers", ""])
-    lines.append("| metric | value |")
-    lines.append("|---|---:|")
-    for label, value in headline_rows:
-      lines.append(f"| {label} | {value:.4f} |")
-    lines.append("")
-
-  if inventory is not None:
-    lines.extend(["### Inventory", ""])
-    lines.append("| field | value |")
-    lines.append("|---|---:|")
-    total_gb = inventory.total_bytes / (1024**3)
-    lines.append(f"| total bytes | {total_gb:.2f} GiB |")
-    lines.append(f"| file count | {inventory.file_count:,} |")
-    small_pct = inventory.small_file_pct * 100
-    canary = "✓" if small_pct < 10 else "⚠ chunk_byte_size too small?"
-    lines.append(f"| small files <1 MiB | {small_pct:.1f}% {canary} |")
-    if inventory.largest_file_bytes > 0:
-      lines.append(
-          f"| largest file | {inventory.largest_file_bytes / (1024**2):.2f}"
-          " MiB |"
-      )
-    if inventory.format:
-      fmt_str = ", ".join(
-          f"{k}={v}" for k, v in sorted(inventory.format.items())
-      )
-      lines.append(f"| format breakdown | {fmt_str} |")
-    lines.append("")
-
-  if manifest is not None:
-    lines.append(manifest.as_markdown())
-
-  return "\n".join(lines)
 
 
 def render_configuration(
@@ -230,6 +140,410 @@ def render_aggregated_metrics(
       )
     lines.append("")
   return "\n".join(lines)
+
+
+def _glance_num(value: float | None, fmt: str = "{:.2f}") -> str:
+  """Formats a value for a glance card, or an em-dash when missing."""
+  return fmt.format(value) if value is not None else "—"
+
+
+def _humanize_bytes(num_bytes: float | None) -> str:
+  """Formats a byte count with the largest fitting binary unit, or em-dash."""
+  if num_bytes is None:
+    return "—"
+  value = float(num_bytes)
+  for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+    if abs(value) < 1024:
+      return f"{value:.0f} {unit}" if unit == "B" else f"{value:.2f} {unit}"
+    value /= 1024
+  return f"{value:.2f} PiB"
+
+
+def _humanize_gib(value_gib: float | None) -> str:
+  """Humanizes a value expressed in GiB into the most readable binary unit."""
+  return _humanize_bytes(None if value_gib is None else value_gib * 1024**3)
+
+
+def _glance_agg(
+    aggregates: dict[str, dict[str, float]],
+    keys: list[str],
+    stat: str = "mean",
+) -> float | None:
+  """Returns the first non-NaN `stat` across candidate keys, or None."""
+  for key in keys:
+    stats = aggregates.get(key)
+    if stats is not None:
+      value = stats.get(stat)
+      if value is not None and not math.isnan(value):
+        return value
+  return None
+
+
+def _glance_host(
+    host_values: dict[str, float], keys: list[str] | None
+) -> float | None:
+  """Returns the first non-NaN value across candidate keys for one host."""
+  for key in keys or []:
+    if key in host_values and not math.isnan(host_values[key]):
+      return host_values[key]
+  return None
+
+
+def _per_host_table(
+    per_host_values: list[tuple[int, dict[str, float]]],
+    columns: list[tuple[str, list[str], str]],
+    pct_keys: list[str] | None = None,
+    pct_of: float | None = None,
+) -> list[str]:
+  """Renders one row per host for the columns at least one host reported.
+
+  Args:
+    per_host_values: (host_index, metric->mean) per host, sorted by index.
+    columns: (column label, candidate metric keys, kind) tuples; kind is
+      "bytes" (GiB value, humanized), "count" (integer), or "num" (decimal).
+    pct_keys: Candidate keys whose value is shown as a percentage of `pct_of`.
+    pct_of: Denominator for the percentage column; omitted when falsy.
+
+  Returns:
+    Markdown lines for the table, or empty if there is nothing to show.
+  """
+  present = [
+      (label, keys, kind)
+      for label, keys, kind in columns
+      if any(_glance_host(v, keys) is not None for _, v in per_host_values)
+  ]
+  if not per_host_values or not present:
+    return []
+  show_pct = False
+  if pct_keys is not None and pct_of:
+    show_pct = any(
+        _glance_host(v, pct_keys) is not None for _, v in per_host_values
+    )
+  header = "| host |" + "".join(f" {label} |" for label, _, _ in present)
+  separator = "|---|" + "---:|" * len(present)
+  if show_pct:
+    header += " % of total |"
+    separator += "---:|"
+  lines = ["#### Per-host", "", header, separator]
+  for idx, values in per_host_values:
+    row = f"| {idx} |"
+    for _, keys, kind in present:
+      value = _glance_host(values, keys)
+      if kind == "bytes":
+        cell = _humanize_gib(value)
+      elif kind == "count":
+        cell = _glance_num(value, "{:.0f}")
+      else:
+        cell = _glance_num(value)
+      row += f" {cell} |"
+    if show_pct and pct_keys is not None and pct_of:
+      part = _glance_host(values, pct_keys)
+      row += f" {part / pct_of * 100:.1f}% |" if part is not None else " — |"
+    lines.append(row)
+  lines.append("")
+  return lines
+
+
+def render_glance_card(
+    benchmark_name: str,
+    aggregates: dict[str, dict[str, float]],
+    per_host_values: list[tuple[int, dict[str, float]]],
+    inventory: Any | None,
+    manifest: Any | None,
+) -> str:
+  """Quick-glance load/save card: headline + per-stage + per-host breakdown.
+
+  Surfaces the jax.monitoring load/save breakdown, throughput, and per-host
+  byte counts already captured by the default metrics in one screenshot-able
+  card. The per-host byte rows (and their share of the total) are the sharding
+  check: each host should read/write only its slice. The checkpoint inventory
+  and run manifest are appended for provenance.
+
+  Args:
+    benchmark_name: Title rendered as the top-level heading.
+    aggregates: Cross-host aggregate stats per metric key.
+    per_host_values: (host_index, metric->mean) per host, sorted by index.
+    inventory: Optional directory inventory; supplies on-disk total bytes, file
+      count, small-file canary, and format breakdown.
+    manifest: Optional suite run manifest; appended via `as_markdown()`.
+
+  Returns:
+    The card rendered as a markdown string.
+  """
+  on_disk_gb = None
+  if inventory is not None and getattr(inventory, "total_bytes", 0):
+    on_disk_gb = inventory.total_bytes / (1024**3)
+  lines = [f"## {benchmark_name} — at a glance", ""]
+  lines += _glance_section(_LOAD_SPEC, aggregates, per_host_values, on_disk_gb)
+  lines += _glance_section(_SAVE_SPEC, aggregates, per_host_values, on_disk_gb)
+  lines += _glance_inventory(inventory)
+  if manifest is not None:
+    lines.append(manifest.as_markdown())
+  return "\n".join(lines).rstrip() + "\n"
+
+
+def _glance_inventory(inventory: Any | None) -> list[str]:
+  """Renders the checkpoint inventory block (folded in from the scorecard)."""
+  if inventory is None:
+    return []
+  out = ["### Inventory", "", "| field | value |", "|---|---:|"]
+  out.append(f"| total bytes | {_humanize_bytes(inventory.total_bytes)} |")
+  out.append(f"| file count | {inventory.file_count:,} |")
+  small_pct = inventory.small_file_pct * 100
+  canary = "✓" if small_pct < 10 else "⚠ chunk_byte_size too small?"
+  out.append(f"| small files <1 MiB | {small_pct:.1f}% {canary} |")
+  if inventory.largest_file_bytes > 0:
+    out.append(
+        f"| largest file | {_humanize_bytes(inventory.largest_file_bytes)} |"
+    )
+  if inventory.format:
+    fmt_str = ", ".join(f"{k}={v}" for k, v in sorted(inventory.format.items()))
+    out.append(f"| format breakdown | {fmt_str} |")
+  out.append("")
+  return out
+
+
+@dataclasses.dataclass(frozen=True)
+class _OpSpec:
+  """Declarative spec for one operation (load/save) section of the card."""
+
+  title: str
+  bytes_verb: str  # "read" / "written"
+  blocking_keys: list[str]
+  total_time_keys: list[str]
+  bytes_keys: list[str]  # per-host byte counter(s)
+  op_count_keys: list[str]  # per-host physical read/write op count
+  tput_label: str
+  tput_keys: list[list[str]]  # [left candidates, right candidates]
+  hbm_keys: list[str]
+  breakdown: list[tuple[str, list[str]]]
+  per_host_cols: list[tuple[str, list[str], str]]  # (label, keys, kind)
+
+
+_LOAD_SPEC = _OpSpec(
+    title="Load",
+    bytes_verb="read",
+    blocking_keys=["load_3_load_breakdown/blocking_s"],
+    total_time_keys=["load_3_load_breakdown/total_s"],
+    bytes_keys=["load_5_inventory/load_requested_gb"],
+    op_count_keys=[
+        "load_6_tensorstore/tensorstore_kvstore_file_read_value_diff",
+        "load_6_tensorstore/tensorstore_kvstore_gcs_read_value_diff",
+    ],
+    tput_label="Throughput (host / total)",
+    tput_keys=[
+        ["load_4_throughput/load_per_host_gbps"],
+        ["load_4_throughput/load_total_gbps"],
+    ],
+    hbm_keys=["load_7_memory/device_hbm_peak_diff_gb"],
+    breakdown=[
+        ("worker I/O (storage read)", ["load_3_load_breakdown/worker_io_s"]),
+        (
+            "primary deserialize",
+            ["load_3_load_breakdown/primary_deserialization_s"],
+        ),
+        ("broadcast", ["load_3_load_breakdown/broadcast_s"]),
+        ("blocking", ["load_3_load_breakdown/blocking_s"]),
+        ("total", ["load_3_load_breakdown/total_s"]),
+    ],
+    per_host_cols=[
+        ("bytes read", ["load_5_inventory/load_requested_gb"], "bytes"),
+        (
+            "reads",
+            [
+                "load_6_tensorstore/tensorstore_kvstore_file_read_value_diff",
+                "load_6_tensorstore/tensorstore_kvstore_gcs_read_value_diff",
+            ],
+            "count",
+        ),
+        ("blocking s", ["load_3_load_breakdown/blocking_s"], "num"),
+        ("total s", ["load_3_load_breakdown/total_s"], "num"),
+        ("worker I/O s", ["load_3_load_breakdown/worker_io_s"], "num"),
+    ],
+)
+
+
+_SAVE_SPEC = _OpSpec(
+    title="Save",
+    bytes_verb="written",
+    blocking_keys=["save_blocking_2_save_breakdown/blocking_s"],
+    total_time_keys=[
+        "save_background_2_save_breakdown/total_async_s",
+        "save_background_2_save_breakdown/total_s",
+        "save_blocking_2_save_breakdown/total_s",
+    ],
+    bytes_keys=[
+        "save_background_5_inventory/save_total_gb",
+        "save_blocking_5_inventory/save_total_gb",
+    ],
+    op_count_keys=[
+        "save_background_6_tensorstore/tensorstore_kvstore_file_write_value_diff",
+        "save_blocking_6_tensorstore/tensorstore_kvstore_file_write_value_diff",
+        "save_background_6_tensorstore/tensorstore_kvstore_gcs_write_value_diff",
+        "save_blocking_6_tensorstore/tensorstore_kvstore_gcs_write_value_diff",
+    ],
+    tput_label="Throughput (blocking / total)",
+    tput_keys=[
+        ["save_blocking_4_throughput/save_blocking_gbps"],
+        ["save_background_4_throughput/save_total_gbps"],
+    ],
+    hbm_keys=[
+        "save_background_7_memory/device_hbm_peak_diff_gb",
+        "save_blocking_7_memory/device_hbm_peak_diff_gb",
+    ],
+    breakdown=[
+        (
+            "directory creation",
+            [
+                "save_blocking_2_save_breakdown/directory_creation_s",
+                "save_background_2_save_breakdown/async_directory_creation_s",
+            ],
+        ),
+        (
+            "metadata write",
+            [
+                "save_background_2_save_breakdown/metadata_write_s",
+                "save_blocking_2_save_breakdown/metadata_write_s",
+            ],
+        ),
+        (
+            "commit",
+            [
+                "save_background_2_save_breakdown/commit_s",
+                "save_blocking_2_save_breakdown/commit_s",
+            ],
+        ),
+        (
+            "ocdbt merge",
+            [
+                "save_background_2_save_breakdown/ocdbt_merge_s",
+                "save_blocking_2_save_breakdown/ocdbt_merge_s",
+            ],
+        ),
+        ("blocking", ["save_blocking_2_save_breakdown/blocking_s"]),
+        (
+            "total",
+            [
+                "save_background_2_save_breakdown/total_async_s",
+                "save_background_2_save_breakdown/total_s",
+            ],
+        ),
+    ],
+    per_host_cols=[
+        (
+            "bytes written",
+            [
+                "save_background_5_inventory/save_total_gb",
+                "save_blocking_5_inventory/save_total_gb",
+            ],
+            "bytes",
+        ),
+        (
+            "writes",
+            [
+                "save_background_6_tensorstore/tensorstore_kvstore_file_write_value_diff",
+                "save_blocking_6_tensorstore/tensorstore_kvstore_file_write_value_diff",
+                "save_background_6_tensorstore/tensorstore_kvstore_gcs_write_value_diff",
+                "save_blocking_6_tensorstore/tensorstore_kvstore_gcs_write_value_diff",
+            ],
+            "count",
+        ),
+        ("blocking s", ["save_blocking_2_save_breakdown/blocking_s"], "num"),
+    ],
+)
+
+
+def _glance_section(
+    spec: _OpSpec,
+    aggregates: dict[str, dict[str, float]],
+    per_host_values: list[tuple[int, dict[str, float]]],
+    on_disk_gb: float | None,
+) -> list[str]:
+  """Renders one operation (load/save) section from its `_OpSpec`."""
+  blocking = _glance_agg(aggregates, spec.blocking_keys, "max")
+  total_time = _glance_agg(aggregates, spec.total_time_keys, "max")
+  per_host_mean = _glance_agg(aggregates, spec.bytes_keys, "mean")
+  per_host_min = _glance_agg(aggregates, spec.bytes_keys, "min")
+  per_host_max = _glance_agg(aggregates, spec.bytes_keys, "max")
+  if not any(v is not None for v in (blocking, total_time, per_host_mean)):
+    return [
+        f"### {spec.title}",
+        "",
+        f"_(no {spec.title.lower()} in this run)_",
+        "",
+    ]
+
+  reads_mean = _glance_agg(aggregates, spec.op_count_keys, "mean")
+  reads_min = _glance_agg(aggregates, spec.op_count_keys, "min")
+  reads_max = _glance_agg(aggregates, spec.op_count_keys, "max")
+  tput_left = _glance_agg(aggregates, spec.tput_keys[0], "max")
+  tput_right = _glance_agg(aggregates, spec.tput_keys[1], "max")
+  hbm = _glance_agg(aggregates, spec.hbm_keys, "max")
+
+  out = [f"### {spec.title}", "", "| metric | value |", "|---|---:|"]
+  out.append(
+      f"| Total time (blocking / total) | {_glance_num(blocking)} /"
+      f" {_glance_num(total_time)} s |"
+  )
+  if per_host_mean is not None:
+    out.append(
+        f"| Bytes {spec.bytes_verb} / host (mean · min · max) |"
+        f" {_humanize_gib(per_host_mean)} · {_humanize_gib(per_host_min)} ·"
+        f" {_humanize_gib(per_host_max)} |"
+    )
+  if reads_mean is not None:
+    verb = "Reads" if spec.bytes_verb == "read" else "Writes"
+    rmean = _glance_num(reads_mean, "{:.0f}")
+    rmin = _glance_num(reads_min, "{:.0f}")
+    rmax = _glance_num(reads_max, "{:.0f}")
+    out.append(
+        f"| {verb} / host (mean · min · max) | {rmean} · {rmin} · {rmax} |"
+    )
+  if on_disk_gb is not None:
+    out.append(f"| Checkpoint size (on-disk) | {_humanize_gib(on_disk_gb)} |")
+  # Sharding check: per-host bytes vs the on-disk checkpoint size. ~1 means
+  # every host moved ~the whole checkpoint (replicated); ~1/N means each host
+  # handled only its shard. (Dividing by the per-device-inflated logical-read
+  # counter would be wrong — it tracks local-device copies, not sharding.)
+  if per_host_mean is not None and on_disk_gb:
+    ratio = per_host_mean / on_disk_gb
+    flag = (
+        "✓ sharded"
+        if ratio <= 0.9
+        else "⚠ each host handles ~the whole checkpoint"
+    )
+    out.append(f"| Per-host ÷ checkpoint | {ratio:.3f}  {flag} |")
+  if tput_left is not None or tput_right is not None:
+    out.append(
+        f"| {spec.tput_label} | {_glance_num(tput_left)} /"
+        f" {_glance_num(tput_right)} GiB/s |"
+    )
+  if hbm is not None:
+    out.append(f"| HBM peak / host (max) | {_humanize_gib(hbm)} |")
+  out.append("")
+
+  rows = [
+      (label, _glance_agg(aggregates, keys, "mean"))
+      for label, keys in spec.breakdown
+  ]
+  rows = [(label, v) for label, v in rows if v is not None]
+  if rows:
+    out += [
+        f"#### {spec.title} time breakdown (mean s)",
+        "",
+        "| stage | s |",
+        "|---|---:|",
+    ]
+    out += [f"| {label} | {_glance_num(v)} |" for label, v in rows]
+    out.append("")
+
+  out += _per_host_table(
+      per_host_values,
+      spec.per_host_cols,
+      pct_keys=spec.bytes_keys,
+      pct_of=on_disk_gb,
+  )
+  return out
 
 
 def options_to_hparams(options: Any) -> dict[str, bool | int | float | str]:

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/markdown_cards_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/markdown_cards_test.py
@@ -22,45 +22,106 @@ from orbax.checkpoint._src.testing.benchmarks.core import inventory as inv_lib
 from orbax.checkpoint._src.testing.benchmarks.core import markdown_cards
 from orbax.checkpoint._src.testing.benchmarks.core import run_manifest as rm_lib
 
-_AGGS = {
-    'save_background_4_throughput/save_total_gbps': {
-        'max': 22.4,
-        'min': 18.0,
-        'mean': 20.1,
-        'p50': 20.2,
-        'p99': 22.3,
+_LOAD_AGGS = {
+    'load_3_load_breakdown/blocking_s': {'mean': 12.0, 'min': 11.5, 'max': 12.5},
+    'load_3_load_breakdown/total_s': {'mean': 13.0, 'min': 13.0, 'max': 13.0},
+    'load_3_load_breakdown/worker_io_s': {'mean': 9.8, 'min': 9.7, 'max': 9.9},
+    'load_5_inventory/load_requested_gb': {'mean': 8.75, 'min': 8.7, 'max': 8.8},
+    'load_5_inventory/load_total_gb': {'mean': 140.0, 'min': 140.0, 'max': 140.0},
+    'load_6_tensorstore/tensorstore_kvstore_file_read_value_diff': {
+        'mean': 6.0,
+        'min': 5.0,
+        'max': 7.0,
     },
-    'load_4_throughput/load_total_gbps': {
-        'max': 18.9,
-        'min': 17.0,
-        'mean': 18.0,
-        'p50': 18.1,
-        'p99': 18.8,
-    },
-    'save_background_5_inventory/save_total_gb': {
-        'max': 140.2,
-        'min': 140.2,
-        'mean': 140.2,
-    },
-    'save_blocking_2_save_breakdown/blocking_async_s': {
-        'max': 4.21,
-        'min': 4.0,
-        'mean': 4.1,
-    },
+    'load_4_throughput/load_per_host_gbps': {'mean': 0.7, 'min': 0.6, 'max': 0.8},
+    'load_4_throughput/load_total_gbps': {'mean': 11.0, 'min': 10.0, 'max': 11.3},
 }
 
+_LOAD_PER_HOST = [
+    (
+        0,
+        {
+            'load_5_inventory/load_requested_gb': 8.7,
+            'load_6_tensorstore/tensorstore_kvstore_file_read_value_diff': 6,
+            'load_3_load_breakdown/blocking_s': 11.9,
+            'load_3_load_breakdown/total_s': 12.9,
+            'load_3_load_breakdown/worker_io_s': 9.7,
+        },
+    ),
+    (
+        1,
+        {
+            'load_5_inventory/load_requested_gb': 8.8,
+            'load_6_tensorstore/tensorstore_kvstore_file_read_value_diff': 7,
+            'load_3_load_breakdown/blocking_s': 12.1,
+            'load_3_load_breakdown/total_s': 13.1,
+            'load_3_load_breakdown/worker_io_s': 9.9,
+        },
+    ),
+]
 
-class ScorecardTest(parameterized.TestCase):
+# 140 GiB on-disk checkpoint — the canary divides per-host read by this.
+_INV = inv_lib.CheckpointInventory(
+    total_bytes=140 * 1024**3,
+    file_count=4096,
+    small_file_count=128,
+    small_file_pct=0.031,
+    largest_file_bytes=64 * 1024**2,
+    smallest_file_bytes=32,
+    format={'ocdbt': 4090, 'metadata': 6},
+)
 
-  def test_headline_save_load_throughput_in_output(self):
-    out = markdown_cards.render_scorecard('llama70b', _AGGS, None, None)
-    self.assertIn('llama70b', out)
-    self.assertIn('Save total throughput', out)
-    self.assertIn('Load throughput', out)
-    self.assertIn('22.4', out)
-    self.assertIn('18.9', out)
 
-  def test_inventory_section_appears_when_provided(self):
+class GlanceCardTest(parameterized.TestCase):
+
+  def test_load_headline_and_breakdown_render(self):
+    out = markdown_cards.render_glance_card(
+        'llama70b', _LOAD_AGGS, _LOAD_PER_HOST, _INV, None
+    )
+    self.assertIn('## llama70b — at a glance', out)
+    self.assertIn('### Load', out)
+    self.assertIn('Bytes read / host', out)
+    self.assertIn('Reads / host', out)
+    self.assertIn('Checkpoint size (on-disk)', out)
+    self.assertIn('#### Load time breakdown', out)
+    self.assertIn('worker I/O', out)
+
+  def test_per_host_table_with_pct_of_checkpoint(self):
+    out = markdown_cards.render_glance_card(
+        'b', _LOAD_AGGS, _LOAD_PER_HOST, _INV, None
+    )
+    self.assertIn('#### Per-host', out)
+    self.assertIn('| 0 |', out)
+    self.assertIn('| 1 |', out)
+    self.assertRegex(out, r'\|\s*reads\s*\|')  # per-host reads column (integer)
+    self.assertIn('% of total', out)
+    self.assertIn('6.2%', out)  # 8.7 / 140 ≈ 6.2%
+
+  def test_sharding_flag_marks_a_slice(self):
+    out = markdown_cards.render_glance_card(
+        'b', _LOAD_AGGS, _LOAD_PER_HOST, _INV, None
+    )
+    self.assertIn('✓ sharded', out)  # 8.75 / 140 = 0.06 <= 0.9
+
+  def test_sharding_flag_warns_on_whole_checkpoint(self):
+    aggs = dict(_LOAD_AGGS)
+    aggs['load_5_inventory/load_requested_gb'] = {
+        'mean': 140.0,
+        'min': 140.0,
+        'max': 140.0,
+    }
+    out = markdown_cards.render_glance_card(
+        'b', aggs, _LOAD_PER_HOST, _INV, None
+    )
+    self.assertIn('the whole checkpoint', out)
+
+  def test_save_section_absent_for_load_only(self):
+    out = markdown_cards.render_glance_card(
+        'b', _LOAD_AGGS, _LOAD_PER_HOST, None, None
+    )
+    self.assertIn('_(no save in this run)_', out)
+
+  def test_inventory_and_manifest_folded_in(self):
     inv = inv_lib.CheckpointInventory(
         total_bytes=140 * 1024**3,
         file_count=4096,
@@ -70,17 +131,6 @@ class ScorecardTest(parameterized.TestCase):
         smallest_file_bytes=32,
         format={'ocdbt': 4090, 'metadata': 6},
     )
-    out = markdown_cards.render_scorecard('llama70b', _AGGS, inv, None)
-    self.assertIn('### Inventory', out)
-    self.assertIn('4,096', out)
-    self.assertIn('3.1%', out)
-    self.assertIn('ocdbt', out)
-
-  def test_inventory_section_omitted_when_none(self):
-    out = markdown_cards.render_scorecard('llama70b', _AGGS, None, None)
-    self.assertNotIn('### Inventory', out)
-
-  def test_manifest_section_appears_when_provided(self):
     m = rm_lib.RunManifest(
         captured_at='2026-05-25T20:00:00+00:00',
         hostname='h',
@@ -96,15 +146,75 @@ class ScorecardTest(parameterized.TestCase):
         xla_flags='',
         libtpu_init_args='',
     )
-    out = markdown_cards.render_scorecard('llama70b', _AGGS, None, m)
+    out = markdown_cards.render_glance_card(
+        'b', _LOAD_AGGS, _LOAD_PER_HOST, inv, m
+    )
+    self.assertIn('### Inventory', out)
+    self.assertIn('4,096', out)
     self.assertIn('## Run manifest', out)
     self.assertIn('abc123', out)
-    self.assertIn('0.10.1', out)
 
-  def test_no_aggregates_renders_skeleton(self):
-    out = markdown_cards.render_scorecard('llama70b', {}, None, None)
-    self.assertIn('llama70b', out)
-    self.assertNotIn('Save throughput', out)
+  def test_save_section_renders_written_bytes(self):
+    save_aggs = {
+        'save_blocking_2_save_breakdown/blocking_s': {
+            'mean': 30.0,
+            'min': 29.0,
+            'max': 31.0,
+        },
+        'save_background_2_save_breakdown/total_async_s': {
+            'mean': 31.0,
+            'min': 31.0,
+            'max': 31.0,
+        },
+        'save_background_5_inventory/save_total_gb': {
+            'mean': 8.75,
+            'min': 8.7,
+            'max': 8.8,
+        },
+        'save_blocking_4_throughput/save_blocking_gbps': {
+            'mean': 4.0,
+            'min': 3.5,
+            'max': 4.6,
+        },
+    }
+    per_host = [
+        (
+            0,
+            {
+                'save_background_5_inventory/save_total_gb': 8.7,
+                'save_blocking_2_save_breakdown/blocking_s': 29.5,
+            },
+        ),
+        (
+            1,
+            {
+                'save_background_5_inventory/save_total_gb': 8.8,
+                'save_blocking_2_save_breakdown/blocking_s': 30.5,
+            },
+        ),
+    ]
+    out = markdown_cards.render_glance_card(
+        'b', save_aggs, per_host, None, None
+    )
+    self.assertIn('### Save', out)
+    self.assertIn('Bytes written / host', out)
+    self.assertIn('_(no load in this run)_', out)
+
+  def test_sub_gib_bytes_are_humanized(self):
+    aggs = {
+        'load_3_load_breakdown/blocking_s': {'mean': 1.0, 'min': 1.0, 'max': 1.0},
+        # 0.5 GiB per host -> should render as MiB, not "0.00 GiB".
+        'load_5_inventory/load_requested_gb': {
+            'mean': 0.5,
+            'min': 0.5,
+            'max': 0.5,
+        },
+        'load_5_inventory/load_total_gb': {'mean': 1.0, 'min': 1.0, 'max': 1.0},
+    }
+    per_host = [(0, {'load_5_inventory/load_requested_gb': 0.5})]
+    out = markdown_cards.render_glance_card('b', aggs, per_host, None, None)
+    self.assertIn('512.00 MiB', out)
+    self.assertNotIn('0.00 GiB', out)
 
 
 class ConfigurationTest(parameterized.TestCase):

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metrics_manager.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metrics_manager.py
@@ -425,7 +425,10 @@ class MetricsManager:
       aggregates = self._gather_cross_host_aggregates(benchmark_name)
       if aggregates:
         self._cross_host_aggregates[benchmark_name] = aggregates
-        self._write_summary_cards(benchmark_name, results, aggregates)
+        per_host_values = self._gather_per_host_values(benchmark_name)
+        self._write_summary_cards(
+            benchmark_name, results, aggregates, per_host_values
+        )
     # Final barrier so non-primaries don't exit while the primary writes —
     # otherwise the coordinator marks them gone and the shutdown barrier fails.
     multihost.sync_global_processes(f"metrics:summary-done:{benchmark_name}")
@@ -509,6 +512,34 @@ class MetricsManager:
           matrix[i, j] = d[key]
     return _summary_aggregates(matrix, union_keys)
 
+  def _gather_per_host_values(
+      self, benchmark_name: str
+  ) -> list[tuple[int, dict[str, float]]]:
+    """Reads each host's means sidecar as (host_index, metric->mean) pairs.
+
+    Mirrors `_gather_cross_host_aggregates`' read but keeps the per-host values
+    for the at-a-glance card instead of collapsing them across hosts.
+
+    Args:
+      benchmark_name: The benchmark whose sidecars are read.
+
+    Returns:
+      (host_index, metric->mean) per host, sorted by host index.
+    """
+    out: list[tuple[int, dict[str, float]]] = []
+    for host_dir in sorted(self._sidecar_gather_root(benchmark_name).iterdir()):
+      sidecar = host_dir / "_per_host_means.json"
+      if not (host_dir.name.startswith("host_") and sidecar.exists()):
+        continue
+      try:
+        idx = int(host_dir.name.split("_", 1)[1])
+      except ValueError:
+        continue
+      data = json.loads(sidecar.read_text())
+      out.append((idx, dict(zip(data["keys"], data["means"]))))
+    out.sort(key=lambda item: item[0])
+    return out
+
   def _write_config_and_hparams(self, writer: Any, benchmark_name: str) -> None:
     """Writes the configuration text card and HParams for a benchmark.
 
@@ -540,6 +571,7 @@ class MetricsManager:
       benchmark_name: str,
       results: list[tuple[metric_lib.Metrics, Exception | None]],
       aggregates: BenchmarkSummary,
+      per_host_values: list[tuple[int, dict[str, float]]],
   ) -> None:
     """Writes the __summary__ run: aggregate scalars, text cards, and HParams.
 
@@ -550,6 +582,7 @@ class MetricsManager:
       benchmark_name: The benchmark being summarized.
       results: The (Metrics, error) tuples for that benchmark.
       aggregates: Cross-host aggregate stats per metric key.
+      per_host_values: (host_index, metric->mean) per host for the glance card.
     """
     assert self._tensorboard_dir is not None
     if self._enable_per_host_metrics:
@@ -571,9 +604,10 @@ class MetricsManager:
       writer.write_texts(
           step=0,
           texts={
-              "scorecard": markdown_cards.render_scorecard(
+              "at_a_glance": markdown_cards.render_glance_card(
                   benchmark_name,
                   aggregates,
+                  per_host_values,
                   self._inventories.get(benchmark_name),
                   self._suite_run_manifest,
               )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/configs/llama3-405b.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/configs/llama3-405b.yaml
@@ -1,0 +1,22 @@
+# Native-Orbax load benchmark — Llama 3.1 405B (tier 3: ~810 GB bf16, fsdp=64,
+# v5p-128; stress tier — run after smaller tiers pass). Reads the published GCS
+# checkpoint + sharding config; no fixture.
+#
+# Run: python -m orbax.checkpoint._src.testing.benchmarks.run_benchmarks \
+#        --config_file=<this file> --output_directory=<out>   # TB: <out>/tensorboard
+# A/B: add baseline_capture_path + options.capture_digests_path (capture), or
+#      baseline_path + options.reference_digests_path (compare).
+
+suite_name: "orbax_load_llama3-405b"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["data", "fsdp", "tensor"]
+  ici_parallelism: {"data": 1, "fsdp": 64, "tensor": 1}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.orbax_load.load_benchmark.OrbaxLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/checkpoints/llama-3.1-405B-checkpoints/0/items"
+      sharding_config_path: "gs://orbax-benchmarks/sharding-configs/llama3.1-405b-v5p-128-data-1-fsdp-64-tensor-1/abstract_state.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/configs/llama3-70b.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/configs/llama3-70b.yaml
@@ -1,0 +1,21 @@
+# Native-Orbax load benchmark — Llama 3.1 70B (tier 2: ~140 GB bf16, fsdp=16,
+# v5p-32). Reads the published GCS checkpoint + sharding config; no fixture.
+#
+# Run: python -m orbax.checkpoint._src.testing.benchmarks.run_benchmarks \
+#        --config_file=<this file> --output_directory=<out>   # TB: <out>/tensorboard
+# A/B: add baseline_capture_path + options.capture_digests_path (capture), or
+#      baseline_path + options.reference_digests_path (compare).
+
+suite_name: "orbax_load_llama3-70b"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["data", "fsdp", "tensor"]
+  ici_parallelism: {"data": 1, "fsdp": 16, "tensor": 1}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.orbax_load.load_benchmark.OrbaxLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/checkpoints/llama-3.1-70B-checkpoints/0/items"
+      sharding_config_path: "gs://orbax-benchmarks/sharding-configs/llama3.1-70b-v5p-32-data-1-fsdp-16-tensor-1/abstract_state.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/configs/llama3-8b.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/configs/llama3-8b.yaml
@@ -1,0 +1,22 @@
+# Native-Orbax load benchmark — Llama 3.1 8B (tier 1: ~16 GB bf16, fsdp=4,
+# v5p-8). Reads the published GCS checkpoint + sharding config; no fixture.
+#
+# Run: python -m orbax.checkpoint._src.testing.benchmarks.run_benchmarks \
+#        --config_file=<this file> --output_directory=<out>   # TB: <out>/tensorboard
+# A/B: add baseline_capture_path + options.capture_digests_path (capture), or
+#      baseline_path + options.reference_digests_path (compare).
+
+suite_name: "orbax_load_llama3-8b"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["data", "fsdp", "tensor"]
+  # Must match the topology encoded in sharding_config_path.
+  ici_parallelism: {"data": 1, "fsdp": 4, "tensor": 1}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.orbax_load.load_benchmark.OrbaxLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/checkpoints/llama-3.1-8B-checkpoints/0/items"
+      sharding_config_path: "gs://orbax-benchmarks/sharding-configs/llama3.1-8b-v5p-8-data-1-fsdp-4-tensor-1/abstract_state.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/configs/synthetic.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/configs/synthetic.yaml
@@ -1,0 +1,53 @@
+# Synthetic native-Orbax load benchmark — ~512 MiB fp32, three read modes
+# (replicated / load-and-broadcast / custom-sharded) -> 3 at-a-glance cards.
+#
+# NOTE: load-and-broadcast needs a >=2-D mesh (a replica axis + a shard axis):
+# orbax's primary-replica lookup does np.take(mesh.devices, ...).flatten(), which
+# AttributeErrors on the 1-D fully-replicated mesh this synthetic load builds.
+# It is not TPU-specific (runs on CPU with the right mesh), but this fixture
+# can't supply that mesh. Sharded reads also only shrink per-host bytes when the
+# fixture is saved with a small chunk_byte_size (else one big blob is re-read).
+# `use_colocated_python` is Pathways-only.
+#
+# Run (RB=orbax.checkpoint._src.testing.benchmarks.run_benchmarks,
+#      GM=orbax/checkpoint/_src/testing/benchmarks/orbax_load/sharding/generate_from_metadata.py):
+#   python -m $RB --config_file=<this> --output_directory=/tmp/orbax_load_synthetic --generate_fixture
+#   python $GM --checkpoint /tmp/orbax_load_synthetic --axis-size <num_devices> \
+#     --strategy fsdp --output /tmp/orbax_load_sharding_fsdp.json
+#   python -m $RB --config_file=<this> --output_directory=/tmp/run   # TB: /tmp/run/tensorboard
+# Multi-host: launch the last step once per process via run_multihost.py;
+# --axis-size must equal the total device count, and step 1's --output_directory
+# must equal checkpoint_path below.
+#
+# A/B (optional): add baseline_capture_path + options.capture_digests_path
+# (capture) or baseline_path + options.reference_digests_path (compare).
+
+suite_name: "orbax_load_synthetic"
+num_repeats: 2
+
+checkpoint_config:
+  random_seed: 0
+  spec:
+    embedding: {dtype: float32, shape: [16384, 4096]}
+    layer_0_mlp: {dtype: float32, shape: [4096, 4096]}
+    layer_1_mlp: {dtype: float32, shape: [4096, 4096]}
+    layer_attn_qkv: {dtype: float32, shape: [4096, 4096]}
+
+benchmarks:
+  # 1) Replicated — every host reads the whole checkpoint.
+  - generator: "orbax.checkpoint._src.testing.benchmarks.orbax_load.load_benchmark.OrbaxLoadBenchmark"
+    options:
+      checkpoint_path: "/tmp/orbax_load_synthetic"
+      enable_trace: true
+  # 2) Load-and-broadcast — one replica reads, broadcasts (multi-slice/TPU only).
+  - generator: "orbax.checkpoint._src.testing.benchmarks.orbax_load.load_benchmark.OrbaxLoadBenchmark"
+    options:
+      checkpoint_path: "/tmp/orbax_load_synthetic"
+      use_load_and_broadcast: true
+      enable_trace: true
+  # 3) Custom-sharded — each host reads only its shard (fsdp across devices).
+  - generator: "orbax.checkpoint._src.testing.benchmarks.orbax_load.load_benchmark.OrbaxLoadBenchmark"
+    options:
+      checkpoint_path: "/tmp/orbax_load_synthetic"
+      sharding_config_path: "/tmp/orbax_load_sharding_fsdp.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/load_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/load_benchmark.py
@@ -1,0 +1,255 @@
+# Copyright 2026 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Load-only benchmark for native Orbax checkpoints.
+
+Purpose-built A/B comparison target: run against `main` to capture a
+baseline, then run against a branch that changes the load path to see the
+per-stage / per-host / throughput diff, and verify the loaded tree is still
+bit-exact. Points at a real Orbax checkpoint (e.g. a published GCS model) or
+a synthetic checkpoint produced by `run_benchmarks --generate_fixture`.
+
+Correctness is independent of the perf baseline: a load-only benchmark has no
+in-memory reference, so it hashes the loaded tree per host.
+`capture_digests_path` records the digests; `reference_digests_path` verifies
+the loaded tree against a previously-captured set and raises on a mismatch. Both
+are driven by `run_benchmarks` flags (the config stays mode-agnostic).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import dataclasses
+import json
+import pprint
+from typing import Any
+
+from absl import logging
+from etils import epath
+import jax
+from orbax.checkpoint import pathways
+from orbax.checkpoint import v1 as ocp
+from orbax.checkpoint._src.multihost import multihost
+from orbax.checkpoint._src.testing.benchmarks.core import checkpoint_generation
+from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
+from orbax.checkpoint._src.testing.benchmarks.core import inventory as inventory_lib
+from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
+from orbax.checkpoint._src.testing.benchmarks.core import pytree_utils
+
+
+@dataclasses.dataclass(frozen=True)
+class OrbaxLoadBenchmarkOptions(benchmarks_core.BenchmarkOptions):
+  """Configuration for loading a native Orbax checkpoint.
+
+  Self-contained: builds its own `ocp.Context()` (the default ORBAX layout)
+  from the load-side tuning knobs, so a single run can sweep e.g.
+  `use_load_and_broadcast` or `restore_concurrent_gb` for A/B comparison. Each
+  knob may be a single value or a list to expand into a parameter sweep.
+
+  Attributes:
+    checkpoint_path: Path (local or `gs://`) to an Orbax checkpoint directory
+      (the `items` dir saved by `ocp.save`).
+    sharding_config_path: Optional JSON file describing the target sharding per
+      tensor. If absent, every loaded tensor is fully replicated across local
+      devices (useful for inner-loop smoke).
+    capture_digests_path: Directory to write per-host SHA-256 digests of the
+      loaded tree to (one `host_<idx>.json` per process). Set in this
+      benchmark's `options`; mutually exclusive with `reference_digests_path`.
+    reference_digests_path: Directory of previously-captured per-host digests to
+      verify the loaded tree against; each host checks its own `host_<idx>.json`
+      and a mismatch raises with per-tensor detail. Set in this benchmark's
+      `options`; mutually exclusive with `capture_digests_path`.
+    use_load_and_broadcast: Whether to load on one replica and broadcast to the
+      others instead of every replica reading from storage.
+    use_colocated_python: On the Pathways backend, dispatch the load via the
+      colocated-Python handler. No-op on other backends.
+    restore_concurrent_gb: Cap on concurrent read bytes (in GiB); `None` leaves
+      the Orbax default.
+    metric_tracemalloc_enabled: Whether to capture the tracemalloc metric
+      (opt-in because its per-allocation snapshots are expensive).
+  """
+
+  checkpoint_path: str | None = None
+  sharding_config_path: str | None = None
+  capture_digests_path: str | None = None
+  reference_digests_path: str | None = None
+  use_load_and_broadcast: bool | Sequence[bool] = False
+  use_colocated_python: bool | Sequence[bool] = False
+  restore_concurrent_gb: int | None | Sequence[int | None] = None
+  metric_tracemalloc_enabled: bool = False
+
+  def is_valid(self) -> bool:
+    if self.checkpoint_path is None:
+      return False
+    return super().is_valid()
+
+  @property
+  def context(self) -> ocp.Context:
+    ctx = ocp.Context()
+    ctx.array.loading.use_load_and_broadcast = self.use_load_and_broadcast
+    ctx.memory.read_concurrent_bytes = (
+        self.restore_concurrent_gb * 1024**3
+        if self.restore_concurrent_gb is not None
+        else None
+    )
+    return ctx
+
+
+def _replicated_abstract_state(metadata: Any) -> Any:
+  """Builds an abstract state with every leaf replicated across local devices.
+
+  Used when no `sharding_config_path` is supplied — convenient for inner-loop
+  smoke against tiny fixtures where no real sharding decision needs to be made.
+  Leaf shapes and dtypes come from the checkpoint metadata.
+
+  Args:
+    metadata: The checkpoint metadata pytree (shapes + dtypes per leaf).
+
+  Returns:
+    An abstract state pytree with every leaf replicated across local devices.
+  """
+  mesh = jax.sharding.Mesh(jax.devices(), ("data",))
+  replicated = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+  return jax.tree.map(
+      lambda x: jax.ShapeDtypeStruct(
+          shape=x.shape, dtype=x.dtype, sharding=replicated
+      ),
+      metadata,
+  )
+
+
+def _load_digests(path: epath.PathLike) -> dict[str, str] | None:
+  """Loads a per-host digests JSON file, or None if absent/unreadable."""
+  try:
+    p = epath.Path(path)
+    if not p.exists():
+      return None
+    return json.loads(p.read_text()) or None
+  except (OSError, ValueError) as e:
+    logging.warning("Could not load digests from %s: %s", path, e)
+    return None
+
+
+def _write_digests(path: epath.PathLike, digests: dict[str, str]) -> None:
+  """Writes per-host digests to a JSON file, creating parent dirs."""
+  p = epath.Path(path)
+  p.parent.mkdir(parents=True, exist_ok=True)
+  p.write_text(json.dumps(digests, indent=2))
+
+
+def _clear_pytree(pytree: Any) -> None:
+  """Frees the device arrays held by a pytree."""
+  jax.tree.map(
+      lambda x: x.delete() if isinstance(x, jax.Array) else None, pytree
+  )
+
+
+def _metrics_to_measure(options: OrbaxLoadBenchmarkOptions) -> list[str]:
+  """Returns the metrics to capture, adding tracemalloc when opted in."""
+  metrics = metric_lib.default_metrics()
+  if options.metric_tracemalloc_enabled:
+    metrics.append("tracemalloc")
+  return metrics
+
+
+@benchmarks_core.benchmark_options(OrbaxLoadBenchmarkOptions)
+class OrbaxLoadBenchmark(benchmarks_core.BenchmarksGenerator):
+  """Loads a native Orbax checkpoint from disk under the default ORBAX layout.
+
+  Built for A/B comparison: capture a baseline against one build of orbax,
+  re-run against another, compare. Optional per-host digests carry correctness
+  so verification works without a reference copy in memory.
+  """
+
+  def test_fn(
+      self, context: benchmarks_core.TestContext
+  ) -> benchmarks_core.TestResult:
+    metrics = metric_lib.Metrics()
+    options = context.options
+    assert isinstance(options, OrbaxLoadBenchmarkOptions)
+    logging.info("Benchmark options: %s", pprint.pformat(options))
+
+    # This benchmark loads from `options.checkpoint_path`. A synthetic config
+    # carries a `checkpoint_config` spec only so `--generate_fixture` can
+    # materialise the fixture; the framework also generates that tree in memory
+    # before `test_fn`, so free it here — it is not what we measure.
+    if context.pytree is not None:
+      _clear_pytree(context.pytree)
+
+    metrics_to_measure = _metrics_to_measure(options)
+    assert options.checkpoint_path is not None
+    checkpoint_path = epath.Path(options.checkpoint_path)
+    load_trace = context.trace_path("load")
+
+    # Pathways-only: route the load through the colocated-Python handler. A
+    # no-op elsewhere, so it is safe to leave in the single-backend path.
+    if options.use_colocated_python and multihost.is_pathways_backend():
+      pathways.register_type_handlers(
+          checkpointing_impl=pathways.CheckpointingImpl.from_options(
+              use_colocated_python=True
+          ),
+          use_replica_parallel=False,
+          enable_replica_parallel_separate_folder=False,
+      )
+
+    with ocp.Context(context=options.context):
+      metadata = ocp.metadata(checkpoint_path)
+      if options.sharding_config_path:
+        abstract_pytree = (
+            checkpoint_generation.get_abstract_state_from_sharding_config(
+                epath.Path(options.sharding_config_path),
+                metadata.metadata,
+                devices=jax.devices(),
+            )
+        )
+      else:
+        abstract_pytree = _replicated_abstract_state(metadata.metadata)
+
+      if load_trace is not None:
+        jax.profiler.start_trace(str(load_trace))
+      with metrics.measure("load", metrics_to_measure):
+        restored_pytree = ocp.load(
+            checkpoint_path, abstract_state=abstract_pytree
+        )
+      if load_trace is not None:
+        jax.profiler.stop_trace()
+
+    # Correctness digests are per-host: `digest_pytree` hashes the shards this
+    # process owns, so capture and compare are per-host files in a directory.
+    # Under a fixed sharding, host i owns the same shards on both runs, so each
+    # host verifies its own slice — correct for sharded multi-host loads, not
+    # just single-host / replicated ones. A run either captures or compares.
+    host_file = f"host_{jax.process_index():05d}.json"
+    if options.capture_digests_path:
+      _write_digests(
+          epath.Path(options.capture_digests_path) / host_file,
+          pytree_utils.digest_pytree(restored_pytree),
+      )
+    elif options.reference_digests_path:
+      reference_digests = _load_digests(
+          epath.Path(options.reference_digests_path) / host_file
+      )
+      if reference_digests:
+        pytree_utils.assert_digests_match(reference_digests, restored_pytree)
+    _clear_pytree(restored_pytree)
+    # Inventory the checkpoint we loaded (not the empty per-run dir the
+    # framework would otherwise scan) so the card's on-disk size — and the
+    # per-host bytes-read sharding check against it — are real. Primary only:
+    # the result is suite-level and a parallel walk would race.
+    checkpoint_inventory = None
+    if jax.process_index() == 0:
+      checkpoint_inventory = inventory_lib.scan_checkpoint(checkpoint_path)
+    return benchmarks_core.TestResult(
+        metrics=metrics, inventory=checkpoint_inventory
+    )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/load_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/load_benchmark_test.py
@@ -1,0 +1,125 @@
+# Copyright 2026 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the OrbaxLoadBenchmark generator class."""
+
+import os
+import tempfile
+
+from absl.testing import absltest
+from orbax.checkpoint import v1 as ocp
+from orbax.checkpoint._src.testing.benchmarks.core import checkpoint_generation
+from orbax.checkpoint._src.testing.benchmarks.core import configs as benchmark_configs
+from orbax.checkpoint._src.testing.benchmarks.orbax_load import load_benchmark as olb
+
+
+def _small_fixture(d: str) -> str:
+  """Writes a tiny synthetic Orbax checkpoint and returns its path."""
+  ckpt = os.path.join(d, "ckpt")
+  config = benchmark_configs.CheckpointConfig(
+      random_seed=0,
+      spec={
+          "w": {"dtype": "float32", "shape": [32, 32]},
+          "b": {"dtype": "float32", "shape": [32]},
+      },
+  )
+  checkpoint_generation.generate_and_save_checkpoint(config, ckpt, mesh=None)
+  return ckpt
+
+
+class OptionsTest(absltest.TestCase):
+
+  def test_requires_checkpoint_path(self):
+    self.assertFalse(olb.OrbaxLoadBenchmarkOptions().is_valid())
+
+  def test_with_path_is_valid(self):
+    opts = olb.OrbaxLoadBenchmarkOptions(checkpoint_path="/tmp/x")
+    self.assertTrue(opts.is_valid())
+
+  def test_context_inherits_orbax_default(self):
+    opts = olb.OrbaxLoadBenchmarkOptions(checkpoint_path="/tmp/x")
+    self.assertIsInstance(opts.context, ocp.Context)
+
+
+class GenerationTest(absltest.TestCase):
+
+  def test_generator_emits_one_benchmark_per_option_combo(self):
+    opts = olb.OrbaxLoadBenchmarkOptions(checkpoint_path="/tmp/x")
+    gen = olb.OrbaxLoadBenchmark(
+        checkpoint_configs=[benchmark_configs.CheckpointConfig()],
+        options=opts,
+    )
+    benchmarks = gen.generate(skip_incompatible_mesh_configs=False)
+    self.assertGreaterEqual(len(benchmarks), 1)
+
+
+class FixtureTest(absltest.TestCase):
+  """The synthetic fixture (generated via checkpoint_generation) round-trips."""
+
+  def test_generate_and_save_round_trips(self):
+    with tempfile.TemporaryDirectory() as d:
+      ckpt = _small_fixture(d)
+      restored = ocp.load(ckpt)
+      self.assertEqual(set(restored), {"w", "b"})
+      self.assertEqual(restored["w"].shape, (32, 32))
+
+
+class LoadFlowTest(absltest.TestCase):
+  """Smoke test that the test_fn actually loads an Orbax checkpoint.
+
+  Runs against a small synthetic fixture on a single process. Multi-host
+  behaviour is covered by the docker smoke harness, not by a unit test.
+  """
+
+  def test_loads_synthetic_fixture(self):
+    with tempfile.TemporaryDirectory() as d:
+      ckpt = _small_fixture(d)
+      opts = olb.OrbaxLoadBenchmarkOptions(checkpoint_path=ckpt)
+      gen = olb.OrbaxLoadBenchmark(
+          checkpoint_configs=[benchmark_configs.CheckpointConfig()],
+          options=opts,
+      )
+      bench = gen.generate(skip_incompatible_mesh_configs=False)[0]
+      result = bench.run(repeat_index=0)
+      self.assertTrue(result.is_successful(), msg=str(result.error))
+      # Time scalar surfaces under the standard 0_basics/ namespace.
+      time_keys = [
+          k
+          for k in result.metrics.results
+          if k.startswith("load_0_basics/time_s")
+      ]
+      self.assertNotEmpty(time_keys)
+
+  def test_digests_captured_to_path(self):
+    with tempfile.TemporaryDirectory() as d:
+      ckpt = _small_fixture(d)
+      digests_dir = os.path.join(d, "digests")
+      opts = olb.OrbaxLoadBenchmarkOptions(
+          checkpoint_path=ckpt,
+          capture_digests_path=digests_dir,
+      )
+      gen = olb.OrbaxLoadBenchmark(
+          checkpoint_configs=[benchmark_configs.CheckpointConfig()],
+          options=opts,
+      )
+      bench = gen.generate(skip_incompatible_mesh_configs=False)[0]
+      result = bench.run(repeat_index=0)
+      self.assertTrue(result.is_successful(), msg=str(result.error))
+      # This host's per-leaf digests were written to host_<idx>.json.
+      host_file = os.path.join(digests_dir, "host_00000.json")
+      self.assertTrue(os.path.exists(host_file))
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/sharding/generate_from_metadata.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/sharding/generate_from_metadata.py
@@ -1,0 +1,168 @@
+"""Sharding-config generator for native Orbax checkpoints.
+
+Reads leaf names, shapes, and dtypes from an Orbax checkpoint's metadata
+(via `ocp.metadata`) and applies a leading-dim FSDP rule (or an inner-dim
+TP rule) to each, emitting the per-tensor sharding JSON that
+`get_abstract_state_from_sharding_config` consumes. Use it to produce a
+sharding config for a custom Orbax checkpoint, or for a topology the
+published configs don't cover.
+
+The published Llama 3.1 sharding configs already live under
+`gs://orbax-benchmarks/sharding-configs/...` (and the `llama3-*` YAMLs in
+`../configs/` point straight at them); this script is for everything else.
+
+The output JSON shape matches what `get_abstract_state_from_sharding_config`
+consumes: per-leaf `{shape, dtype, sharding: {mesh: {shape, axes}, spec}}`.
+The mesh it emits is single-axis, so the consuming YAML's
+`mesh_config.mesh_axes` must be the matching single axis
+(`["fsdp"]` / `["tp"]`) of the same size.
+
+Usage:
+
+  # Against a published or custom Orbax checkpoint, fsdp=16:
+  python generate_from_metadata.py \\
+      --checkpoint gs://my-bucket/my-ckpt/items \\
+      --axis-size 16 --strategy fsdp \\
+      --output my_model_fsdp16.json
+
+  # Inner-dim TP variant:
+  python generate_from_metadata.py \\
+      --checkpoint /local/path/to/items \\
+      --axis-size 8 --strategy tp_inner \\
+      --output my_model_tp8.json
+"""
+
+import argparse
+import json
+import pathlib
+
+from etils import epath
+import numpy as np
+from orbax.checkpoint import v1 as ocp
+from orbax.checkpoint._src.tree import utils as tree_utils
+
+
+def _fsdp_spec(
+    shape: list[int], axis_name: str, axis_size: int
+) -> list[str | None]:
+  """Leading-dim FSDP partition spec; falls back to fully replicated.
+
+  Args:
+    shape: The leaf shape.
+    axis_name: Mesh axis to shard the leading dim along.
+    axis_size: Size of that mesh axis.
+
+  Returns:
+    A PartitionSpec-style list (axis name or None per dim).
+  """
+  if len(shape) < 2:
+    return [None] * len(shape)
+  if shape[0] % axis_size == 0:
+    return [axis_name] + [None] * (len(shape) - 1)
+  return [None] * len(shape)
+
+
+def _tp_inner_spec(
+    shape: list[int], axis_name: str, axis_size: int
+) -> list[str | None]:
+  """Inner-dim (last-axis) partition spec; falls back to fully replicated.
+
+  Args:
+    shape: The leaf shape.
+    axis_name: Mesh axis to shard the last dim along.
+    axis_size: Size of that mesh axis.
+
+  Returns:
+    A PartitionSpec-style list (axis name or None per dim).
+  """
+  if len(shape) < 2:
+    return [None] * len(shape)
+  if shape[-1] % axis_size == 0:
+    return [None] * (len(shape) - 1) + [axis_name]
+  return [None] * len(shape)
+
+
+_STRATEGIES = {
+    "fsdp": ("fsdp", _fsdp_spec),
+    "tp_inner": ("tp", _tp_inner_spec),
+}
+
+
+def build_config(
+    checkpoint_path: str, axis_size: int, strategy: str = "fsdp"
+) -> dict:
+  """Builds the per-leaf sharding map for every leaf in the checkpoint.
+
+  Args:
+    checkpoint_path: Path (local or `gs://`) to an Orbax checkpoint dir.
+    axis_size: Size of the single mesh axis to shard along.
+    strategy: Sharding strategy, "fsdp" or "tp_inner".
+
+  Returns:
+    A `{leaf_name: entry}` sharding-config map.
+
+  Raises:
+    ValueError: If `strategy` is unknown.
+  """
+  try:
+    axis_name, spec_fn = _STRATEGIES[strategy]
+  except KeyError as e:
+    raise ValueError(
+        f"Unknown strategy {strategy!r}; supported: "
+        + ", ".join(sorted(_STRATEGIES))
+    ) from e
+  metadata = ocp.metadata(epath.Path(checkpoint_path))
+  flat = tree_utils.to_flat_dict(metadata.metadata, sep=".")
+  mesh = {"shape": [axis_size], "axes": [axis_name]}
+  out: dict[str, dict] = {}
+  for name, leaf in flat.items():
+    shape = list(leaf.shape)
+    out[name] = {
+        "shape": shape,
+        "dtype": np.dtype(leaf.dtype).name,
+        "sharding": {
+            "mesh": mesh,
+            "spec": spec_fn(shape, axis_name, axis_size),
+        },
+    }
+  return out
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument(
+      "--checkpoint",
+      required=True,
+      help="Path (local or gs://) to the Orbax checkpoint directory.",
+  )
+  parser.add_argument(
+      "--axis-size",
+      type=int,
+      required=True,
+      help="Size of the single mesh axis (= number of devices participating).",
+  )
+  parser.add_argument(
+      "--strategy",
+      default="fsdp",
+      choices=sorted(_STRATEGIES),
+      help=(
+          "Sharding strategy. `fsdp` splits dim 0 (contiguous shards);"
+          " `tp_inner` splits the last dim (strided shards)."
+      ),
+  )
+  parser.add_argument(
+      "--output",
+      type=pathlib.Path,
+      required=True,
+      help="Destination JSON path; parent dir is created if missing.",
+  )
+  args = parser.parse_args()
+
+  cfg = build_config(args.checkpoint, args.axis_size, strategy=args.strategy)
+  args.output.parent.mkdir(parents=True, exist_ok=True)
+  args.output.write_text(json.dumps(cfg, indent=2))
+  print(f"Wrote {len(cfg)} leaf entries to {args.output}")
+
+
+if __name__ == "__main__":
+  main()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/run_benchmarks.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/run_benchmarks.py
@@ -28,7 +28,9 @@ from absl import flags
 from absl import logging
 from etils import epath
 import jax
+from orbax.checkpoint._src.testing.benchmarks.core import checkpoint_generation
 from orbax.checkpoint._src.testing.benchmarks.core import config_parsing
+from orbax.checkpoint._src.testing.benchmarks.core import device_mesh
 
 try:
   import pathwaysutils  # pylint: disable=g-import-not-at-top
@@ -65,17 +67,12 @@ _REMOVE_REPEATED_DIR = flags.DEFINE_bool(
     False,
     'Remove the generated repeat_* directories after execution.',
 )
-_BASELINE_CAPTURE_PATH = flags.DEFINE_string(
-    'baseline_capture_path',
-    None,
-    'If set, directory to write each benchmark baseline JSON to after the '
-    'run. Records the cross-host aggregated metrics as the baseline.',
-)
-_BASELINE_PATH = flags.DEFINE_string(
-    'baseline_path',
-    None,
-    'If set, a stored baseline JSON to compare this run against; the '
-    'per-metric delta is logged at the end of the run.',
+_GENERATE_FIXTURE = flags.DEFINE_bool(
+    'generate_fixture',
+    False,
+    "If set, generate the synthetic checkpoint described by the config's "
+    'checkpoint_config spec into --output_directory and exit, instead of '
+    'running benchmarks.',
 )
 
 
@@ -151,13 +148,30 @@ def _configure_hlo_dump(output_directory: str):
   logging.info('Set XLA_FLAGS for HLO dump: %s', new_xla_flags)
 
 
+def _generate_fixture(config_file: str, output_directory: str) -> None:
+  """Generates the synthetic checkpoint described by a config, then returns.
+
+  Builds the data from the config's `checkpoint_config` spec on the config's
+  mesh and writes it with `ocp.save`. The plumbing stops at this entrypoint:
+  the benchmark classes are never involved in fixture generation.
+
+  Args:
+    config_file: Path to the YAML config whose `checkpoint_config` supplies the
+      spec and whose `mesh_config` supplies the mesh.
+    output_directory: Directory to write the generated Orbax checkpoint to.
+  """
+  checkpoint_configs, mesh_configs = config_parsing.parse_config(config_file)
+  mesh = device_mesh.create_mesh(mesh_configs[0]) if mesh_configs else None
+  checkpoint_generation.generate_and_save_checkpoint(
+      checkpoint_configs[0], output_directory, mesh=mesh
+  )
+
+
 def _run_benchmarks(
     config_file: str,
     output_directory: str,
     local_directory: str | None = None,
     remove_repeated_dir: bool = False,
-    baseline_capture_path: str | None = None,
-    baseline_path: str | None = None,
 ) -> None:
   """Runs Orbax checkpoint benchmarks based on a generator class and a config file.
 
@@ -168,9 +182,6 @@ def _run_benchmarks(
       benchmarks.
     remove_repeated_dir: Whether to remove the generated repeat_* directories
       after execution.
-    baseline_capture_path: If set, directory each benchmark's captured baseline
-      JSON is written to after the run.
-    baseline_path: If set, a stored baseline the run is compared against.
 
   Raises:
     RuntimeError: If any benchmark test fails.
@@ -192,8 +203,6 @@ def _run_benchmarks(
         output_dir=output_directory,
         local_directory=local_directory,
         remove_repeated_dir=remove_repeated_dir,
-        baseline_capture_path=baseline_capture_path,
-        baseline_path=baseline_path,
     )
   except Exception as e:
     logging.error('Failed to create test suite from config: %s', e)
@@ -239,13 +248,21 @@ def main(argv: list[str]) -> None:
   jax.config.update('jax_enable_x64', True)
   logging.info('Set jax_enable_x64=True')
 
+  if _GENERATE_FIXTURE.value:
+    logging.info(
+        'Generating fixture from %s into %s',
+        _CONFIG_FILE.value,
+        _OUTPUT_DIRECTORY.value,
+    )
+    _generate_fixture(_CONFIG_FILE.value, _OUTPUT_DIRECTORY.value)
+    logging.info('Fixture generation complete.')
+    return
+
   _run_benchmarks(
       _CONFIG_FILE.value,
       _OUTPUT_DIRECTORY.value,
       _LOCAL_DIRECTORY.value,
       remove_repeated_dir=_REMOVE_REPEATED_DIR.value,
-      baseline_capture_path=_BASELINE_CAPTURE_PATH.value,
-      baseline_path=_BASELINE_PATH.value,
   )
 
   logging.info('run_benchmarks.py finished.')


### PR DESCRIPTION
## Description

Adds a native-Orbax checkpoint **load** benchmark, mirroring the existing
safetensors load benchmark, under
`checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/`:

- `load_benchmark.py` (+ test) — loads an Orbax checkpoint, optionally driven by
  a target sharding; reports load timing / throughput / per-host bytes-read and
  optional per-host SHA-256 correctness digests.
- `configs/` — one mode-agnostic config per tier: `synthetic` (a local fixture
  produced via `--generate_fixture`) plus `llama3-{8b,70b,405b}` real tiers that
  read published checkpoints.
- `run_suite.sh` + `AB_README.md` — an A/B harness that runs the tiers and
  writes the capture/compare paths into a per-run config.
- `sharding/generate_from_metadata.py` — derives a target sharding spec from a
  checkpoint's metadata.
- `core/checkpoint_generation.py` — `generate_and_save_checkpoint` helper for the
  `--generate_fixture` path.

It also makes the benchmark runner's baseline and correctness-digest paths
**config-driven instead of run flags**. `run_benchmarks` no longer defines
`--baseline_capture_path` / `--baseline_path` / `--capture_digests_path` /
`--reference_digests_path`; these are read from the config instead
(`baseline_capture_path` / `baseline_path` at the suite level, and per-benchmark
`options.capture_digests_path` / `reference_digests_path`, validated mutually
exclusive). `config_parsing.create_test_suite_from_config` reads them directly,
the suite-runners materialise the per-mode values into a temporary run-config,
and `GUIDE.md` is updated to match.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or a public API)
- [x] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover this change and pass locally.
- [x] Public APIs and non-trivial functions are documented.
- [x] **If this change is user-facing, I have updated [`CHANGELOG.md`](CHANGELOG.md)** — n/a; this change is confined to the `_src/testing/benchmarks` tooling and does not alter a public API.
