### PR TITLE
Per-name benchmark cards driven by jax.monitoring metrics

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/array_handler_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/array_handler_benchmark_test.py
@@ -137,10 +137,12 @@ class ArrayHandlerBenchmarkTest(parameterized.TestCase):
     result = self._run_benchmark_workflow_test(options)
 
     self.assertIsInstance(result, benchmarks_core.TestResult)
-    self.assertIn('serialize_0_basics/time_s', result.metrics.results)
-    self.assertIn('metadata_validation_0_basics/time_s', result.metrics.results)
-    self.assertIn('deserialize_0_basics/time_s', result.metrics.results)
-    self.assertIn('correctness_check_0_basics/time_s', result.metrics.results)
+    self.assertIn('serialize::0_basics/time_s', result.metrics.results)
+    self.assertIn(
+        'metadata_validation::0_basics/time_s', result.metrics.results
+    )
+    self.assertIn('deserialize::0_basics/time_s', result.metrics.results)
+    self.assertIn('correctness_check::0_basics/time_s', result.metrics.results)
 
   @parameterized.named_parameters(
       dict(
@@ -155,14 +157,14 @@ class ArrayHandlerBenchmarkTest(parameterized.TestCase):
   def test_benchmark_ocdbt_enabled_calls_merge(self, options):
     result = self._run_benchmark_workflow_test(options)
 
-    self.assertIn('merge_ocdbt_0_basics/time_s', result.metrics.results)
+    self.assertIn('merge_ocdbt::0_basics/time_s', result.metrics.results)
     self.mock_merge_ocdbt.assert_called_once()
 
   def test_benchmark_ocdbt_disabled_does_not_merge(self):
     options = ArrayHandlerBenchmarkOptions(use_ocdbt=False, use_zarr3=True)
     result = self._run_benchmark_workflow_test(options)
 
-    self.assertNotIn('merge_ocdbt_0_basics/time_s', result.metrics.results)
+    self.assertNotIn('merge_ocdbt::0_basics/time_s', result.metrics.results)
     self.mock_merge_ocdbt.assert_not_called()
 
   @parameterized.named_parameters(

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/checkpoint_manager_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/checkpoint_manager_benchmark_test.py
@@ -109,10 +109,10 @@ class CheckpointManagerBenchmarkTest(parameterized.TestCase):
     self.assertIsInstance(result, benchmarks_core.TestResult)
     self.assertContainsSubset(
         {
-            'save_0_0_basics/time_s',
-            'wait_until_finished_0_0_basics/time_s',
-            'restore_0_0_basics/time_s',
-            'correctness_check_0_basics/time_s',
+            'save_0::0_basics/time_s',
+            'wait_until_finished_0::0_basics/time_s',
+            'restore_0::0_basics/time_s',
+            'correctness_check::0_basics/time_s',
         },
         result.metrics.results.keys(),
     )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/jax_monitoring_tags.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/jax_monitoring_tags.py
@@ -149,12 +149,20 @@ TAG_MAP: dict[str, tuple[str, str]] = {
     # ─── 6_io — safetensors per-host storage reads ────────────────────────
     # The safetensors loader has no TensorStore kvstore; it self-reports its
     # per-host read accounting here (raw bytes; the card converts to GiB).
+    # Two read counts: `file_reads` is coalesced ranged-read requests (~1 per
+    # file when fully coalesced), `storage_reads` is the actual GETs issued,
+    # which is >= file_reads because a block larger than the in-flight budget
+    # is fetched in several chunks.
     "/jax/orbax/read/safetensors/bytes_read": (
         "6_io/file_bytes_read_per_host",
         "bytes",
     ),
     "/jax/orbax/read/safetensors/num_reads": (
         "6_io/file_reads_per_host_count",
+        "count",
+    ),
+    "/jax/orbax/read/safetensors/storage_reads": (
+        "6_io/storage_reads_per_host_count",
         "count",
     ),
     # ─── 8_jax — compile-cache durations ──────────────────────────────────

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/jax_monitoring_tags.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/jax_monitoring_tags.py
@@ -146,6 +146,17 @@ TAG_MAP: dict[str, tuple[str, str]] = {
         "5_inventory/load_total_gb",
         "GiB",
     ),
+    # ─── 6_io — safetensors per-host storage reads ────────────────────────
+    # The safetensors loader has no TensorStore kvstore; it self-reports its
+    # per-host read accounting here (raw bytes; the card converts to GiB).
+    "/jax/orbax/read/safetensors/bytes_read": (
+        "6_io/file_bytes_read_per_host",
+        "bytes",
+    ),
+    "/jax/orbax/read/safetensors/num_reads": (
+        "6_io/file_reads_per_host_count",
+        "count",
+    ),
     # ─── 8_jax — compile-cache durations ──────────────────────────────────
     "/jax/compilation_cache/cache_retrieval_time_sec": (
         "8_jax/cache_retrieval_s",

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/jax_monitoring_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/jax_monitoring_test.py
@@ -33,8 +33,8 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
       jax.monitoring.record_event_duration_secs(
           '/jax/orbax/write/blocking_duration_secs', 1.5
       )
-    self.assertIn('op_2_save_breakdown/blocking_s', metrics.results)
-    value, unit = metrics.results['op_2_save_breakdown/blocking_s']
+    self.assertIn('op::2_save_breakdown/blocking_s', metrics.results)
+    value, unit = metrics.results['op::2_save_breakdown/blocking_s']
     self.assertEqual(value, 1.5)
     self.assertEqual(unit, 's')
 
@@ -44,8 +44,8 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
       jax.monitoring.record_scalar(
           '/jax/orbax/write/blocking_gbytes_per_sec', 12.5
       )
-    self.assertIn('op_4_throughput/save_blocking_gbps', metrics.results)
-    value, unit = metrics.results['op_4_throughput/save_blocking_gbps']
+    self.assertIn('op::4_throughput/save_blocking_gbps', metrics.results)
+    value, unit = metrics.results['op::4_throughput/save_blocking_gbps']
     self.assertEqual(value, 12.5)
     self.assertEqual(unit, 'GiB/s')
 
@@ -63,7 +63,7 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
           '/jax/orbax/write/some_unknown_event_secs', 0.3
       )
     self.assertIn(
-        'op_9_other/orbax_write_some_unknown_event_secs',
+        'op::9_other/orbax_write_some_unknown_event_secs',
         metrics.results,
     )
 
@@ -73,8 +73,8 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
       jax.monitoring.record_event_duration_secs(
           '/jax/orbax/write/blocking_duration_secs', 2.0, storage_type='gs'
       )
-    self.assertIn('op_2_save_breakdown/blocking_s', metrics.results)
-    value, _ = metrics.results['op_2_save_breakdown/blocking_s']
+    self.assertIn('op::2_save_breakdown/blocking_s', metrics.results)
+    value, _ = metrics.results['op::2_save_breakdown/blocking_s']
     self.assertEqual(value, 2.0)
 
   def test_does_not_capture_after_block_exits(self):
@@ -102,10 +102,53 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
       jax.monitoring.record_event_duration_secs(
           '/jax/orbax/read/blocking_duration_secs', 2.0
       )
-    self.assertEqual(m_a.results['op_a_2_save_breakdown/blocking_s'][0], 1.0)
-    self.assertEqual(m_b.results['op_b_3_load_breakdown/blocking_s'][0], 2.0)
-    self.assertNotIn('op_b_2_save_breakdown/blocking_s', m_b.results)
-    self.assertNotIn('op_a_3_load_breakdown/blocking_s', m_a.results)
+    self.assertEqual(m_a.results['op_a::2_save_breakdown/blocking_s'][0], 1.0)
+    self.assertEqual(m_b.results['op_b::3_load_breakdown/blocking_s'][0], 2.0)
+    self.assertNotIn('op_b::2_save_breakdown/blocking_s', m_b.results)
+    self.assertNotIn('op_a::3_load_breakdown/blocking_s', m_a.results)
+
+  def test_opt_out_when_not_in_metric_keys(self):
+    metrics = metric_lib.Metrics()
+    with metrics.measure('op', ['time']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/orbax/write/blocking_duration_secs', 1.5
+      )
+    self.assertFalse(any('save_breakdown' in k for k in metrics.results))
+
+  def test_nested_blocks_each_capture(self):
+    # jax.monitoring fans out to every registered listener, so an event inside
+    # the inner block is recorded by the inner AND the enclosing outer block.
+    metrics = metric_lib.Metrics()
+    with metrics.measure('outer', ['jax_monitoring']):
+      with metrics.measure('inner', ['jax_monitoring']):
+        jax.monitoring.record_event_duration_secs(
+            '/jax/orbax/read/blocking_duration_secs', 1.5
+        )
+    self.assertEqual(
+        metrics.results['inner::3_load_breakdown/blocking_s'][0], 1.5
+    )
+    self.assertEqual(
+        metrics.results['outer::3_load_breakdown/blocking_s'][0], 1.5
+    )
+
+  def test_async_completion_pools_into_same_name(self):
+    # Background save: bracket the deferred completion in a second same-named
+    # block; the distinct breakdown tags pool into the one "save" card.
+    metrics = metric_lib.Metrics()
+    with metrics.measure('save', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/orbax/write/blocking_duration_secs', 2.0
+      )
+    with metrics.measure('save', ['jax_monitoring']):
+      jax.monitoring.record_event_duration_secs(
+          '/jax/checkpoint/write/async/total_duration_secs', 9.0
+      )
+    self.assertEqual(
+        metrics.results['save::2_save_breakdown/blocking_s'][0], 2.0
+    )
+    self.assertEqual(
+        metrics.results['save::2_save_breakdown/total_async_s'][0], 9.0
+    )
 
   def test_ocdbt_merge_tagged_under_save_breakdown(self):
     metrics = metric_lib.Metrics()
@@ -113,7 +156,7 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
       jax.monitoring.record_event_duration_secs(
           '/jax/checkpoint/write/async/ocdbt_merge_duration_secs', 0.7
       )
-    self.assertIn('op_2_save_breakdown/ocdbt_merge_s', metrics.results)
+    self.assertIn('op::2_save_breakdown/ocdbt_merge_s', metrics.results)
 
   def test_sync_global_devices_tagged_under_overhead(self):
     metrics = metric_lib.Metrics()
@@ -122,7 +165,7 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
           '/jax/checkpoint/sync_global_devices_duration_sec', 0.05
       )
     self.assertIn(
-        'op_7_overhead/sync_global_devices_s',
+        'op::7_overhead/sync_global_devices_s',
         metrics.results,
     )
 
@@ -133,19 +176,19 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
           '/jax/orbax/checkpoint_manager/threaded_checkpoint_deleter/duration',
           0.12,
       )
-    self.assertIn('op_7_overhead/delete_threaded_s', metrics.results)
+    self.assertIn('op::7_overhead/delete_threaded_s', metrics.results)
 
   def test_checkpoint_read_gbytes_per_sec_tagged_under_throughput(self):
     metrics = metric_lib.Metrics()
     with metrics.measure('op', ['jax_monitoring']):
       jax.monitoring.record_scalar('/jax/checkpoint/read/gbytes_per_sec', 18.9)
-    self.assertIn('op_4_throughput/load_total_gbps', metrics.results)
+    self.assertIn('op::4_throughput/load_total_gbps', metrics.results)
 
   def test_checkpoint_read_gbytes_tagged_under_inventory(self):
     metrics = metric_lib.Metrics()
     with metrics.measure('op', ['jax_monitoring']):
       jax.monitoring.record_scalar('/jax/checkpoint/read/gbytes', 140.2)
-    self.assertIn('op_5_inventory/load_total_gb', metrics.results)
+    self.assertIn('op::5_inventory/load_total_gb', metrics.results)
 
   def test_standard_delete_tagged_under_overhead(self):
     metrics = metric_lib.Metrics()
@@ -154,22 +197,22 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
           '/jax/orbax/checkpoint_manager/standard_checkpoint_deleter/duration',
           0.08,
       )
-    self.assertIn('op_7_overhead/delete_standard_s', metrics.results)
+    self.assertIn('op::7_overhead/delete_standard_s', metrics.results)
 
   def test_compile_cache_hits_counted(self):
     metrics = metric_lib.Metrics()
     with metrics.measure('op', ['jax_monitoring']):
       for _ in range(3):
         jax.monitoring.record_event('/jax/compilation_cache/cache_hits')
-    self.assertIn('op_8_jax/cache_hits_count', metrics.results)
-    self.assertEqual(metrics.results['op_8_jax/cache_hits_count'][0], 3)
+    self.assertIn('op::8_jax/cache_hits_count', metrics.results)
+    self.assertEqual(metrics.results['op::8_jax/cache_hits_count'][0], 3)
 
   def test_compile_cache_misses_counted(self):
     metrics = metric_lib.Metrics()
     with metrics.measure('op', ['jax_monitoring']):
       jax.monitoring.record_event('/jax/compilation_cache/cache_misses')
       jax.monitoring.record_event('/jax/compilation_cache/cache_misses')
-    self.assertEqual(metrics.results['op_8_jax/cache_misses_count'][0], 2)
+    self.assertEqual(metrics.results['op::8_jax/cache_misses_count'][0], 2)
 
   def test_compile_cache_hit_rate_derived(self):
     metrics = metric_lib.Metrics()
@@ -177,8 +220,8 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
       for _ in range(3):
         jax.monitoring.record_event('/jax/compilation_cache/cache_hits')
       jax.monitoring.record_event('/jax/compilation_cache/cache_misses')
-    self.assertIn('op_8_jax/cache_hit_rate', metrics.results)
-    rate, _ = metrics.results['op_8_jax/cache_hit_rate']
+    self.assertIn('op::8_jax/cache_hit_rate', metrics.results)
+    rate, _ = metrics.results['op::8_jax/cache_hit_rate']
     self.assertAlmostEqual(rate, 0.75)
 
   def test_compile_cache_durations_mapped(self):
@@ -190,9 +233,11 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
       jax.monitoring.record_event_duration_secs(
           '/jax/compilation_cache/compile_time_saved_sec', 1.7
       )
-    self.assertEqual(metrics.results['op_8_jax/cache_retrieval_s'], (0.42, 's'))
     self.assertEqual(
-        metrics.results['op_8_jax/compile_time_saved_s'], (1.7, 's')
+        metrics.results['op::8_jax/cache_retrieval_s'], (0.42, 's')
+    )
+    self.assertEqual(
+        metrics.results['op::8_jax/compile_time_saved_s'], (1.7, 's')
     )
 
   def test_unmapped_discrete_events_are_dropped(self):
@@ -221,9 +266,9 @@ class JaxMonitoringMetricTest(parameterized.TestCase):
           '/jax/checkpoint/read/broadcast_duration_secs', 0.5
       )
       jax.monitoring.record_scalar('/jax/orbax/write/gbytes', 100.0)
-    self.assertIn('op_2_save_breakdown/blocking_s', metrics.results)
-    self.assertIn('op_3_load_breakdown/broadcast_s', metrics.results)
-    self.assertIn('op_5_inventory/save_total_gb', metrics.results)
+    self.assertIn('op::2_save_breakdown/blocking_s', metrics.results)
+    self.assertIn('op::3_load_breakdown/broadcast_s', metrics.results)
+    self.assertIn('op::5_inventory/save_total_gb', metrics.results)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/markdown_cards.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/markdown_cards.py
@@ -16,13 +16,16 @@
 
 Three cards, all rendered as markdown that TB's Text dashboard displays:
 
-  - at_a_glance: the screenshot-able card — load/save total time + per-stage
-    breakdown, per-host byte counts (the sharding check), inventory detail,
-    and the run manifest.
+  - at_a_glance: the screenshot-able headline — total time, throughput,
+    per-host bytes (with each host's share of the on-disk size), inventory,
+    and the run manifest. Headline rows are generic candidate-key lookups, so
+    the same renderer serves a load card and a save card: whichever of the
+    candidate keys the card's metrics populate is the one shown.
   - configuration: options + checkpoint config tables, plus pretty-printed
     JSON for nested fields like `spec`.
   - aggregated_metrics: every metric's mean / std / min / max / n / unit,
-    grouped by the numeric section prefix (`2_save_breakdown/` etc.).
+    grouped by the numeric section prefix (`2_save_breakdown/` etc.). This is
+    the per-stage breakdown — it is built straight from the jax-exported tags.
 
 Everything in this module is a pure function — no I/O, no MetricsManager
 state. Tests are correspondingly cheap.
@@ -255,17 +258,20 @@ def render_glance_card(
     inventory: Any | None,
     manifest: Any | None,
 ) -> str:
-  """Quick-glance load/save card: headline + per-stage + per-host breakdown.
+  """Quick-glance headline card: a few generic rows + per-host + inventory.
 
-  Surfaces the jax.monitoring load/save breakdown, throughput, and per-host
-  byte counts already captured by the default metrics in one screenshot-able
-  card. The per-host byte rows (and their share of the total) are the sharding
-  check: each host should read/write only its slice. The checkpoint inventory
-  and run manifest are appended for provenance.
+  The headline rows are candidate-key lookups whose lists cover both load and
+  save tags, so the renderer needs no per-kind template: a load card's metrics
+  populate the load candidates, a save card's the save candidates, and only the
+  resolved ones render. The per-host byte rows (and each host's share of the
+  on-disk size) are the sharding check: each host should move only its slice.
+  The full per-stage breakdown lives in the `aggregated_metrics` card; the
+  inventory and run manifest are appended here for provenance.
 
   Args:
     benchmark_name: Title rendered as the top-level heading.
-    aggregates: Cross-host aggregate stats per metric key.
+    aggregates: Cross-host aggregate stats per metric key (already sliced to one
+      operation name, so keys are bare tags).
     per_host_values: (host_index, metric->mean) per host, sorted by index.
     inventory: Optional directory inventory; supplies on-disk total bytes, file
       count, small-file canary, and format breakdown.
@@ -277,9 +283,29 @@ def render_glance_card(
   on_disk_gb = None
   if inventory is not None and getattr(inventory, "total_bytes", 0):
     on_disk_gb = inventory.total_bytes / (1024**3)
-  lines = [f"## {benchmark_name} — at a glance", ""]
-  lines += _glance_section(_LOAD_SPEC, aggregates, per_host_values, on_disk_gb)
-  lines += _glance_section(_SAVE_SPEC, aggregates, per_host_values, on_disk_gb)
+  lines = [
+      f"## {benchmark_name} — at a glance",
+      "",
+      "| metric | value |",
+      "|---|---:|",
+  ]
+  total = _glance_agg(aggregates, _TOTAL_TIME_KEYS, "max")
+  lines.append(f"| Total time | {_glance_num(total)} s |")
+  throughput = _glance_agg(aggregates, _THROUGHPUT_KEYS, "max")
+  if throughput is not None:
+    lines.append(f"| Throughput | {_glance_num(throughput)} GiB/s |")
+  bytes_per_host = _glance_agg(aggregates, _BYTES_KEYS, "mean")
+  if bytes_per_host is not None:
+    lines.append(f"| Bytes / host (mean) | {_humanize_gib(bytes_per_host)} |")
+  if on_disk_gb is not None:
+    lines.append(f"| Checkpoint size (on-disk) | {_humanize_gib(on_disk_gb)} |")
+  hbm = _glance_agg(aggregates, ["7_memory/device_hbm_peak_diff_gb"], "max")
+  if hbm is not None:
+    lines.append(f"| HBM peak / host (max) | {_humanize_gib(hbm)} |")
+  lines.append("")
+  lines += _per_host_table(
+      per_host_values, _PER_HOST_COLS, pct_keys=_BYTES_KEYS, pct_of=on_disk_gb
+  )
   lines += _glance_inventory(inventory)
   if manifest is not None:
     lines.append(manifest.as_markdown())
@@ -307,261 +333,44 @@ def _glance_inventory(inventory: Any | None) -> list[str]:
   return out
 
 
-@dataclasses.dataclass(frozen=True)
-class _OpSpec:
-  """Declarative spec for one operation (load/save) section of the card."""
-
-  title: str
-  bytes_verb: str  # "read" / "written"
-  blocking_keys: list[str]
-  total_time_keys: list[str]
-  bytes_keys: list[str]  # per-host byte counter(s)
-  op_count_keys: list[str]  # per-host physical read/write op count
-  tput_label: str
-  tput_keys: list[list[str]]  # [left candidates, right candidates]
-  hbm_keys: list[str]
-  breakdown: list[tuple[str, list[str]]]
-  per_host_cols: list[tuple[str, list[str], str]]  # (label, keys, kind)
-
-
-_LOAD_SPEC = _OpSpec(
-    title="Load",
-    bytes_verb="read",
-    blocking_keys=["load_3_load_breakdown/blocking_s"],
-    total_time_keys=["load_3_load_breakdown/total_s"],
-    bytes_keys=[
-        "load_6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff",
-        "load_6_tensorstore/tensorstore_kvstore_gcs_bytes_read_value_diff",
-    ],
-    op_count_keys=[
-        "load_6_tensorstore/tensorstore_kvstore_file_read_value_diff",
-        "load_6_tensorstore/tensorstore_kvstore_gcs_read_value_diff",
-    ],
-    tput_label="Throughput (host / total)",
-    tput_keys=[
-        ["load_4_throughput/load_per_host_gbps"],
-        ["load_4_throughput/load_total_gbps"],
-    ],
-    hbm_keys=["load_7_memory/device_hbm_peak_diff_gb"],
-    breakdown=[
-        ("worker I/O (storage read)", ["load_3_load_breakdown/worker_io_s"]),
-        (
-            "primary deserialize",
-            ["load_3_load_breakdown/primary_deserialization_s"],
-        ),
-        ("broadcast", ["load_3_load_breakdown/broadcast_s"]),
-        ("blocking", ["load_3_load_breakdown/blocking_s"]),
-        ("total", ["load_3_load_breakdown/total_s"]),
-    ],
-    per_host_cols=[
-        (
-            "bytes read",
-            [
-                "load_6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff",
-                "load_6_tensorstore/tensorstore_kvstore_gcs_bytes_read_value_diff",
-            ],
-            "bytes",
-        ),
-        (
-            "reads",
-            [
-                "load_6_tensorstore/tensorstore_kvstore_file_read_value_diff",
-                "load_6_tensorstore/tensorstore_kvstore_gcs_read_value_diff",
-            ],
-            "count",
-        ),
-        ("blocking s", ["load_3_load_breakdown/blocking_s"], "num"),
-        ("total s", ["load_3_load_breakdown/total_s"], "num"),
-        ("worker I/O s", ["load_3_load_breakdown/worker_io_s"], "num"),
-    ],
-)
-
-
-_SAVE_SPEC = _OpSpec(
-    title="Save",
-    bytes_verb="written",
-    blocking_keys=["save_blocking_2_save_breakdown/blocking_s"],
-    total_time_keys=[
-        "save_background_2_save_breakdown/total_async_s",
-        "save_background_2_save_breakdown/total_s",
-        "save_blocking_2_save_breakdown/total_s",
-    ],
-    bytes_keys=[
-        "save_background_6_tensorstore/tensorstore_kvstore_file_bytes_written_value_diff",
-        "save_blocking_6_tensorstore/tensorstore_kvstore_file_bytes_written_value_diff",
-        "save_background_6_tensorstore/tensorstore_kvstore_gcs_bytes_written_value_diff",
-        "save_blocking_6_tensorstore/tensorstore_kvstore_gcs_bytes_written_value_diff",
-    ],
-    op_count_keys=[
-        "save_background_6_tensorstore/tensorstore_kvstore_file_write_value_diff",
-        "save_blocking_6_tensorstore/tensorstore_kvstore_file_write_value_diff",
-        "save_background_6_tensorstore/tensorstore_kvstore_gcs_write_value_diff",
-        "save_blocking_6_tensorstore/tensorstore_kvstore_gcs_write_value_diff",
-    ],
-    tput_label="Throughput (blocking / total)",
-    tput_keys=[
-        ["save_blocking_4_throughput/save_blocking_gbps"],
-        ["save_background_4_throughput/save_total_gbps"],
-    ],
-    hbm_keys=[
-        "save_background_7_memory/device_hbm_peak_diff_gb",
-        "save_blocking_7_memory/device_hbm_peak_diff_gb",
-    ],
-    breakdown=[
-        (
-            "directory creation",
-            [
-                "save_blocking_2_save_breakdown/directory_creation_s",
-                "save_background_2_save_breakdown/async_directory_creation_s",
-            ],
-        ),
-        (
-            "metadata write",
-            [
-                "save_background_2_save_breakdown/metadata_write_s",
-                "save_blocking_2_save_breakdown/metadata_write_s",
-            ],
-        ),
-        (
-            "commit",
-            [
-                "save_background_2_save_breakdown/commit_s",
-                "save_blocking_2_save_breakdown/commit_s",
-            ],
-        ),
-        (
-            "ocdbt merge",
-            [
-                "save_background_2_save_breakdown/ocdbt_merge_s",
-                "save_blocking_2_save_breakdown/ocdbt_merge_s",
-            ],
-        ),
-        ("blocking", ["save_blocking_2_save_breakdown/blocking_s"]),
-        (
-            "total",
-            [
-                "save_background_2_save_breakdown/total_async_s",
-                "save_background_2_save_breakdown/total_s",
-            ],
-        ),
-    ],
-    per_host_cols=[
-        (
-            "bytes written",
-            [
-                "save_background_6_tensorstore/tensorstore_kvstore_file_bytes_written_value_diff",
-                "save_blocking_6_tensorstore/tensorstore_kvstore_file_bytes_written_value_diff",
-                "save_background_6_tensorstore/tensorstore_kvstore_gcs_bytes_written_value_diff",
-                "save_blocking_6_tensorstore/tensorstore_kvstore_gcs_bytes_written_value_diff",
-            ],
-            "bytes",
-        ),
-        (
-            "writes",
-            [
-                "save_background_6_tensorstore/tensorstore_kvstore_file_write_value_diff",
-                "save_blocking_6_tensorstore/tensorstore_kvstore_file_write_value_diff",
-                "save_background_6_tensorstore/tensorstore_kvstore_gcs_write_value_diff",
-                "save_blocking_6_tensorstore/tensorstore_kvstore_gcs_write_value_diff",
-            ],
-            "count",
-        ),
-        ("blocking s", ["save_blocking_2_save_breakdown/blocking_s"], "num"),
-    ],
-)
-
-
-def _glance_section(
-    spec: _OpSpec,
-    aggregates: dict[str, dict[str, float]],
-    per_host_values: list[tuple[int, dict[str, float]]],
-    on_disk_gb: float | None,
-) -> list[str]:
-  """Renders one operation (load/save) section from its `_OpSpec`."""
-  blocking = _glance_agg(aggregates, spec.blocking_keys, "max")
-  total_time = _glance_agg(aggregates, spec.total_time_keys, "max")
-  per_host_mean = _glance_agg(aggregates, spec.bytes_keys, "mean")
-  per_host_min = _glance_agg(aggregates, spec.bytes_keys, "min")
-  per_host_max = _glance_agg(aggregates, spec.bytes_keys, "max")
-  if not any(v is not None for v in (blocking, total_time, per_host_mean)):
-    return [
-        f"### {spec.title}",
-        "",
-        f"_(no {spec.title.lower()} in this run)_",
-        "",
-    ]
-
-  reads_mean = _glance_agg(aggregates, spec.op_count_keys, "mean")
-  reads_min = _glance_agg(aggregates, spec.op_count_keys, "min")
-  reads_max = _glance_agg(aggregates, spec.op_count_keys, "max")
-  tput_left = _glance_agg(aggregates, spec.tput_keys[0], "max")
-  tput_right = _glance_agg(aggregates, spec.tput_keys[1], "max")
-  hbm = _glance_agg(aggregates, spec.hbm_keys, "max")
-
-  out = [f"### {spec.title}", "", "| metric | value |", "|---|---:|"]
-  out.append(
-      f"| Total time (blocking / total) | {_glance_num(blocking)} /"
-      f" {_glance_num(total_time)} s |"
-  )
-  if per_host_mean is not None:
-    out.append(
-        f"| Bytes {spec.bytes_verb} / host (mean · min · max) |"
-        f" {_humanize_gib(per_host_mean)} · {_humanize_gib(per_host_min)} ·"
-        f" {_humanize_gib(per_host_max)} |"
-    )
-  if reads_mean is not None:
-    verb = "Reads" if spec.bytes_verb == "read" else "Writes"
-    rmean = _glance_num(reads_mean, "{:.0f}")
-    rmin = _glance_num(reads_min, "{:.0f}")
-    rmax = _glance_num(reads_max, "{:.0f}")
-    out.append(
-        f"| {verb} / host (mean · min · max) | {rmean} · {rmin} · {rmax} |"
-    )
-  if on_disk_gb is not None:
-    out.append(f"| Checkpoint size (on-disk) | {_humanize_gib(on_disk_gb)} |")
-  # Sharding check: per-host bytes vs the on-disk checkpoint size. ~1 means
-  # every host moved ~the whole checkpoint (replicated); ~1/N means each host
-  # handled only its shard. (Dividing by the per-device-inflated logical-read
-  # counter would be wrong — it tracks local-device copies, not sharding.)
-  if per_host_mean is not None and on_disk_gb:
-    ratio = per_host_mean / on_disk_gb
-    flag = (
-        "✓ sharded"
-        if ratio <= 0.9
-        else "⚠ each host handles ~the whole checkpoint"
-    )
-    out.append(f"| Per-host ÷ checkpoint | {ratio:.3f}  {flag} |")
-  if tput_left is not None or tput_right is not None:
-    out.append(
-        f"| {spec.tput_label} | {_glance_num(tput_left)} /"
-        f" {_glance_num(tput_right)} GiB/s |"
-    )
-  if hbm is not None:
-    out.append(f"| HBM peak / host (max) | {_humanize_gib(hbm)} |")
-  out.append("")
-
-  rows = [
-      (label, _glance_agg(aggregates, keys, "mean"))
-      for label, keys in spec.breakdown
-  ]
-  rows = [(label, v) for label, v in rows if v is not None]
-  if rows:
-    out += [
-        f"#### {spec.title} time breakdown (mean s)",
-        "",
-        "| stage | s |",
-        "|---|---:|",
-    ]
-    out += [f"| {label} | {_glance_num(v)} |" for label, v in rows]
-    out.append("")
-
-  out += _per_host_table(
-      per_host_values,
-      spec.per_host_cols,
-      pct_keys=spec.bytes_keys,
-      pct_of=on_disk_gb,
-  )
-  return out
+_TOTAL_TIME_KEYS = [
+    "3_load_breakdown/total_s",
+    "2_save_breakdown/total_async_s",
+    "2_save_breakdown/total_s",
+    "0_basics/time_s",
+]
+_THROUGHPUT_KEYS = [
+    "4_throughput/load_total_gbps",
+    "4_throughput/save_total_gbps",
+    "4_throughput/load_per_host_gbps",
+    "4_throughput/save_blocking_gbps",
+]
+_BYTES_KEYS = [
+    "6_io/file_bytes_read_per_host",
+    "6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff",
+    "6_tensorstore/tensorstore_kvstore_gcs_bytes_read_value_diff",
+    "6_tensorstore/tensorstore_kvstore_file_bytes_written_value_diff",
+    "6_tensorstore/tensorstore_kvstore_gcs_bytes_written_value_diff",
+]
+_READ_WRITE_COUNT_KEYS = [
+    "6_io/file_reads_per_host_count",
+    "6_tensorstore/tensorstore_kvstore_file_read_value_diff",
+    "6_tensorstore/tensorstore_kvstore_gcs_read_value_diff",
+    "6_tensorstore/tensorstore_kvstore_file_write_value_diff",
+    "6_tensorstore/tensorstore_kvstore_gcs_write_value_diff",
+]
+_BLOCKING_TIME_KEYS = [
+    "3_load_breakdown/blocking_s",
+    "2_save_breakdown/blocking_s",
+]
+# Per-host columns for the at-a-glance card. Candidate-key lists cover load and
+# save flavours; `_BYTES_KEYS` also feeds the "% of on-disk" sharding column.
+_PER_HOST_COLS = [
+    ("bytes", _BYTES_KEYS, "bytes"),
+    ("reads/writes", _READ_WRITE_COUNT_KEYS, "count"),
+    ("blocking s", _BLOCKING_TIME_KEYS, "num"),
+    ("total s", _TOTAL_TIME_KEYS, "num"),
+]
 
 
 def options_to_hparams(options: Any) -> dict[str, bool | int | float | str]:

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/markdown_cards_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/markdown_cards_test.py
@@ -22,69 +22,53 @@ from orbax.checkpoint._src.testing.benchmarks.core import inventory as inv_lib
 from orbax.checkpoint._src.testing.benchmarks.core import markdown_cards
 from orbax.checkpoint._src.testing.benchmarks.core import run_manifest as rm_lib
 
+# Aggregates reach the renderer already sliced to one operation name, so keys
+# are bare tags (no `load::` / `save::` prefix).
 _LOAD_AGGS = {
-    'load_3_load_breakdown/blocking_s': {
-        'mean': 12.0,
-        'min': 11.5,
-        'max': 12.5,
-    },
-    'load_3_load_breakdown/total_s': {'mean': 13.0, 'min': 13.0, 'max': 13.0},
-    'load_3_load_breakdown/worker_io_s': {'mean': 9.8, 'min': 9.7, 'max': 9.9},
-    'load_6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff': {
+    '3_load_breakdown/blocking_s': {'mean': 12.0, 'min': 11.5, 'max': 12.5},
+    '3_load_breakdown/total_s': {'mean': 13.0, 'min': 13.0, 'max': 13.0},
+    '3_load_breakdown/worker_io_s': {'mean': 9.8, 'min': 9.7, 'max': 9.9},
+    '6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff': {
         'mean': 8.75 * 1024**3,
         'min': 8.7 * 1024**3,
         'max': 8.8 * 1024**3,
     },
-    'load_5_inventory/load_total_gb': {
-        'mean': 140.0,
-        'min': 140.0,
-        'max': 140.0,
-    },
-    'load_6_tensorstore/tensorstore_kvstore_file_read_value_diff': {
+    '5_inventory/load_total_gb': {'mean': 140.0, 'min': 140.0, 'max': 140.0},
+    '6_tensorstore/tensorstore_kvstore_file_read_value_diff': {
         'mean': 6.0,
         'min': 5.0,
         'max': 7.0,
     },
-    'load_4_throughput/load_per_host_gbps': {
-        'mean': 0.7,
-        'min': 0.6,
-        'max': 0.8,
-    },
-    'load_4_throughput/load_total_gbps': {
-        'mean': 11.0,
-        'min': 10.0,
-        'max': 11.3,
-    },
+    '4_throughput/load_per_host_gbps': {'mean': 0.7, 'min': 0.6, 'max': 0.8},
+    '4_throughput/load_total_gbps': {'mean': 11.0, 'min': 10.0, 'max': 11.3},
 }
 
 _LOAD_PER_HOST = [
     (
         0,
         {
-            'load_6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff': (
+            '6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff': (
                 8.7 * 1024**3
             ),
-            'load_6_tensorstore/tensorstore_kvstore_file_read_value_diff': 6,
-            'load_3_load_breakdown/blocking_s': 11.9,
-            'load_3_load_breakdown/total_s': 12.9,
-            'load_3_load_breakdown/worker_io_s': 9.7,
+            '6_tensorstore/tensorstore_kvstore_file_read_value_diff': 6,
+            '3_load_breakdown/blocking_s': 11.9,
+            '3_load_breakdown/total_s': 12.9,
         },
     ),
     (
         1,
         {
-            'load_6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff': (
+            '6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff': (
                 8.8 * 1024**3
             ),
-            'load_6_tensorstore/tensorstore_kvstore_file_read_value_diff': 7,
-            'load_3_load_breakdown/blocking_s': 12.1,
-            'load_3_load_breakdown/total_s': 13.1,
-            'load_3_load_breakdown/worker_io_s': 9.9,
+            '6_tensorstore/tensorstore_kvstore_file_read_value_diff': 7,
+            '3_load_breakdown/blocking_s': 12.1,
+            '3_load_breakdown/total_s': 13.1,
         },
     ),
 ]
 
-# 140 GiB on-disk checkpoint — the canary divides per-host read by this.
+# 140 GiB on-disk checkpoint — the per-host % column divides by this.
 _INV = inv_lib.CheckpointInventory(
     total_bytes=140 * 1024**3,
     file_count=4096,
@@ -98,17 +82,16 @@ _INV = inv_lib.CheckpointInventory(
 
 class GlanceCardTest(parameterized.TestCase):
 
-  def test_load_headline_and_breakdown_render(self):
+  def test_load_headline_renders(self):
     out = markdown_cards.render_glance_card(
         'llama70b', _LOAD_AGGS, _LOAD_PER_HOST, _INV, None
     )
     self.assertIn('## llama70b — at a glance', out)
-    self.assertIn('### Load', out)
-    self.assertIn('Bytes read / host', out)
-    self.assertIn('Reads / host', out)
+    self.assertIn('| Total time | 13.00 s |', out)
+    self.assertIn('| Throughput | 11.30 GiB/s |', out)
+    self.assertIn('Bytes / host (mean)', out)
+    self.assertIn('8.75 GiB', out)
     self.assertIn('Checkpoint size (on-disk)', out)
-    self.assertIn('#### Load time breakdown', out)
-    self.assertIn('worker I/O', out)
 
   def test_per_host_table_with_pct_of_checkpoint(self):
     out = markdown_cards.render_glance_card(
@@ -117,46 +100,11 @@ class GlanceCardTest(parameterized.TestCase):
     self.assertIn('#### Per-host', out)
     self.assertIn('| 0 |', out)
     self.assertIn('| 1 |', out)
-    self.assertRegex(out, r'\|\s*reads\s*\|')  # per-host reads column (integer)
+    self.assertRegex(out, r'\|\s*reads/writes\s*\|')
     self.assertIn('% of total', out)
     self.assertIn('6.2%', out)  # 8.7 / 140 ≈ 6.2%
 
-  def test_sharding_flag_marks_a_slice(self):
-    out = markdown_cards.render_glance_card(
-        'b', _LOAD_AGGS, _LOAD_PER_HOST, _INV, None
-    )
-    self.assertIn('✓ sharded', out)  # 8.75 / 140 = 0.06 <= 0.9
-
-  def test_sharding_flag_warns_on_whole_checkpoint(self):
-    aggs = dict(_LOAD_AGGS)
-    aggs[
-        'load_6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff'
-    ] = {
-        'mean': 140.0 * 1024**3,
-        'min': 140.0 * 1024**3,
-        'max': 140.0 * 1024**3,
-    }
-    out = markdown_cards.render_glance_card(
-        'b', aggs, _LOAD_PER_HOST, _INV, None
-    )
-    self.assertIn('the whole checkpoint', out)
-
-  def test_save_section_absent_for_load_only(self):
-    out = markdown_cards.render_glance_card(
-        'b', _LOAD_AGGS, _LOAD_PER_HOST, None, None
-    )
-    self.assertIn('_(no save in this run)_', out)
-
   def test_inventory_and_manifest_folded_in(self):
-    inv = inv_lib.CheckpointInventory(
-        total_bytes=140 * 1024**3,
-        file_count=4096,
-        small_file_count=128,
-        small_file_pct=0.031,
-        largest_file_bytes=64 * 1024**2,
-        smallest_file_bytes=32,
-        format={'ocdbt': 4090, 'metadata': 6},
-    )
     m = rm_lib.RunManifest(
         captured_at='2026-05-25T20:00:00+00:00',
         hostname='h',
@@ -173,82 +121,66 @@ class GlanceCardTest(parameterized.TestCase):
         libtpu_init_args='',
     )
     out = markdown_cards.render_glance_card(
-        'b', _LOAD_AGGS, _LOAD_PER_HOST, inv, m
+        'b', _LOAD_AGGS, _LOAD_PER_HOST, _INV, m
     )
     self.assertIn('### Inventory', out)
     self.assertIn('4,096', out)
     self.assertIn('## Run manifest', out)
     self.assertIn('abc123', out)
 
-  def test_save_section_renders_written_bytes(self):
+  def test_save_metrics_render(self):
     save_aggs = {
-        'save_blocking_2_save_breakdown/blocking_s': {
-            'mean': 30.0,
-            'min': 29.0,
-            'max': 31.0,
-        },
-        'save_background_2_save_breakdown/total_async_s': {
-            'mean': 31.0,
-            'min': 31.0,
-            'max': 31.0,
-        },
-        'save_background_6_tensorstore/tensorstore_kvstore_file_bytes_written_value_diff': {
+        '2_save_breakdown/blocking_s': {'mean': 30.0, 'min': 29.0, 'max': 31.0},
+        '2_save_breakdown/total_s': {'mean': 31.0, 'min': 31.0, 'max': 31.0},
+        '6_tensorstore/tensorstore_kvstore_file_bytes_written_value_diff': {
             'mean': 8.75 * 1024**3,
             'min': 8.7 * 1024**3,
             'max': 8.8 * 1024**3,
         },
-        'save_blocking_4_throughput/save_blocking_gbps': {
-            'mean': 4.0,
-            'min': 3.5,
-            'max': 4.6,
-        },
+        '4_throughput/save_total_gbps': {'mean': 4.0, 'min': 3.5, 'max': 4.6},
     }
     per_host = [
         (
             0,
             {
-                'save_background_6_tensorstore/tensorstore_kvstore_file_bytes_written_value_diff': (
+                '6_tensorstore/tensorstore_kvstore_file_bytes_written_value_diff': (
                     8.7 * 1024**3
                 ),
-                'save_blocking_2_save_breakdown/blocking_s': 29.5,
+                '2_save_breakdown/blocking_s': 29.5,
             },
         ),
         (
             1,
             {
-                'save_background_6_tensorstore/tensorstore_kvstore_file_bytes_written_value_diff': (
+                '6_tensorstore/tensorstore_kvstore_file_bytes_written_value_diff': (
                     8.8 * 1024**3
                 ),
-                'save_blocking_2_save_breakdown/blocking_s': 30.5,
+                '2_save_breakdown/blocking_s': 30.5,
             },
         ),
     ]
     out = markdown_cards.render_glance_card(
         'b', save_aggs, per_host, None, None
     )
-    self.assertIn('### Save', out)
-    self.assertIn('Bytes written / host', out)
-    self.assertIn('_(no load in this run)_', out)
+    self.assertIn('| Total time | 31.00 s |', out)
+    self.assertIn('| Throughput | 4.60 GiB/s |', out)
+    self.assertIn('Bytes / host (mean)', out)
+    self.assertIn('8.75 GiB', out)
 
   def test_sub_gib_bytes_are_humanized(self):
     aggs = {
-        'load_3_load_breakdown/blocking_s': {
-            'mean': 1.0,
-            'min': 1.0,
-            'max': 1.0,
-        },
+        '3_load_breakdown/blocking_s': {'mean': 1.0, 'min': 1.0, 'max': 1.0},
         # 0.5 GiB per host -> should render as MiB, not "0.00 GiB".
-        'load_6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff': {
+        '6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff': {
             'mean': 0.5 * 1024**3,
             'min': 0.5 * 1024**3,
             'max': 0.5 * 1024**3,
         },
-        'load_5_inventory/load_total_gb': {'mean': 1.0, 'min': 1.0, 'max': 1.0},
     }
     per_host = [(
         0,
         {
-            'load_6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff': (
+            '6_tensorstore/tensorstore_kvstore_file_bytes_read_value_diff': (
                 0.5 * 1024**3
             )
         },
@@ -256,6 +188,39 @@ class GlanceCardTest(parameterized.TestCase):
     out = markdown_cards.render_glance_card('b', aggs, per_host, None, None)
     self.assertIn('512.00 MiB', out)
     self.assertNotIn('0.00 GiB', out)
+
+  def test_safetensors_io_bytes_drive_load_card(self):
+    # Safetensors has no kvstore counters: per-host bytes + reads arrive via
+    # jax.monitoring under 6_io/, and must still populate the bytes row.
+    aggs = {
+        '3_load_breakdown/blocking_s': {'mean': 2.0, 'min': 2.0, 'max': 2.0},
+        '6_io/file_bytes_read_per_host': {
+            'mean': 8.75 * 1024**3,
+            'min': 8.7 * 1024**3,
+            'max': 8.8 * 1024**3,
+        },
+        '6_io/file_reads_per_host_count': {'mean': 3.0, 'min': 3.0, 'max': 3.0},
+    }
+    per_host = [
+        (
+            0,
+            {
+                '6_io/file_bytes_read_per_host': 8.7 * 1024**3,
+                '6_io/file_reads_per_host_count': 3,
+            },
+        ),
+        (
+            1,
+            {
+                '6_io/file_bytes_read_per_host': 8.8 * 1024**3,
+                '6_io/file_reads_per_host_count': 3,
+            },
+        ),
+    ]
+    out = markdown_cards.render_glance_card('st', aggs, per_host, _INV, None)
+    self.assertIn('Bytes / host (mean)', out)
+    self.assertIn('8.75 GiB', out)
+    self.assertIn('% of total', out)
 
 
 class ConfigurationTest(parameterized.TestCase):

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric.py
@@ -539,11 +539,16 @@ class Metrics:
       metric_key: str,
       metric_results: dict[str, tuple[Any, str]],
   ):
+    """Stores results keyed `{metric_name}::{tag}`.
+
+    The `name::` namespace lets the summary group results into one card per
+    operation name; `::` (not `_`) so names containing `_` split cleanly.
+    """
     for key, (value, unit) in metric_results.items():
       if metric_key:
-        full_key = f"{metric_name}_{metric_key}_{key}"
+        full_key = f"{metric_name}::{metric_key}_{key}"
       else:
-        full_key = f"{metric_name}_{key}"
+        full_key = f"{metric_name}::{key}"
       self.results[full_key] = (value, unit)
 
   @contextlib.contextmanager

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py
@@ -34,7 +34,7 @@ class MetricsTest(parameterized.TestCase):
         pass
 
     self.assertEqual(
-        metrics.results, {'test_metric_0_basics/time_s': (2.0, 's')}
+        metrics.results, {'test_metric::0_basics/time_s': (2.0, 's')}
     )
 
   @mock.patch(
@@ -49,7 +49,7 @@ class MetricsTest(parameterized.TestCase):
     with metrics.measure('test_metric', ['rss']):
       pass
     self.assertEqual(
-        metrics.results, {'test_metric_0_basics/host_rss_diff_mb': (2.0, 'MB')}
+        metrics.results, {'test_metric::0_basics/host_rss_diff_mb': (2.0, 'MB')}
     )
 
   @mock.patch(
@@ -72,7 +72,7 @@ class MetricsTest(parameterized.TestCase):
       self.assertEqual(metric_lib.TracemallocMetric._active_count, 1)
     self.assertEqual(
         metrics.results,
-        {'test_metric_7_memory/tracemalloc_peak_diff_mb': (2.0, 'MB')},
+        {'test_metric::7_memory/tracemalloc_peak_diff_mb': (2.0, 'MB')},
     )
     self.assertEqual(metric_lib.TracemallocMetric._active_count, 0)
     mock_tracemalloc.start.assert_called_once()
@@ -113,7 +113,7 @@ metric2: 4.5600 s
       ts_store.write(np.asarray(range(10)).astype(np.int32)).result()
 
     self.assertIn(
-        'test_metric_6_tensorstore/changed_metric_count', metrics.results
+        'test_metric::6_tensorstore/changed_metric_count', metrics.results
     )
 
   @mock.patch.object(metric_lib.TensorstoreMetric, '_collect_metrics')
@@ -140,12 +140,12 @@ metric2: 4.5600 s
       pass
     self.assertEqual(
         metrics.results[
-            'op_6_tensorstore/tensorstore_kvstore_file_read_count_diff'
+            'op::6_tensorstore/tensorstore_kvstore_file_read_count_diff'
         ][0],
         5,
     )
     self.assertEqual(
-        metrics.results['op_6_tensorstore/tensorstore_cache_bytes_value_diff'][
+        metrics.results['op::6_tensorstore/tensorstore_cache_bytes_value_diff'][
             0
         ],
         100,
@@ -176,13 +176,13 @@ metric2: 4.5600 s
       ).result()
       ts_store.write(np.asarray(range(10)).astype(np.int32)).result()
 
-    self.assertIn('test_metric_0_basics/time_s', metrics.results)
-    self.assertIn('test_metric_0_basics/host_rss_diff_mb', metrics.results)
+    self.assertIn('test_metric::0_basics/time_s', metrics.results)
+    self.assertIn('test_metric::0_basics/host_rss_diff_mb', metrics.results)
     self.assertIn(
-        'test_metric_7_memory/tracemalloc_peak_diff_mb', metrics.results
+        'test_metric::7_memory/tracemalloc_peak_diff_mb', metrics.results
     )
     self.assertIn(
-        'test_metric_6_tensorstore/changed_metric_count', metrics.results
+        'test_metric::6_tensorstore/changed_metric_count', metrics.results
     )
 
   def test_default_metrics_returns_expected_metrics(self):
@@ -223,8 +223,8 @@ class DeviceMemoryMetricTest(parameterized.TestCase):
     metrics = metric_lib.Metrics()
     with metrics.measure('op', ['device_memory']):
       pass
-    self.assertIn('op_7_memory/jax_live_arrays_count_delta', metrics.results)
-    val, _ = metrics.results['op_7_memory/jax_live_arrays_count_delta']
+    self.assertIn('op::7_memory/jax_live_arrays_count_delta', metrics.results)
+    val, _ = metrics.results['op::7_memory/jax_live_arrays_count_delta']
     self.assertEqual(val, 2)
 
   @mock.patch('jax.live_arrays', return_value=[])
@@ -247,8 +247,8 @@ class DeviceMemoryMetricTest(parameterized.TestCase):
     metrics = metric_lib.Metrics()
     with metrics.measure('op', ['device_memory']):
       pass
-    self.assertIn('op_7_memory/device_hbm_peak_diff_gb', metrics.results)
-    val, unit = metrics.results['op_7_memory/device_hbm_peak_diff_gb']
+    self.assertIn('op::7_memory/device_hbm_peak_diff_gb', metrics.results)
+    val, unit = metrics.results['op::7_memory/device_hbm_peak_diff_gb']
     self.assertAlmostEqual(val, 2.0)
     self.assertEqual(unit, 'GiB')
 
@@ -261,8 +261,8 @@ class DeviceMemoryMetricTest(parameterized.TestCase):
     metrics = metric_lib.Metrics()
     with metrics.measure('op', ['device_memory']):
       pass
-    self.assertNotIn('op_7_memory/device_hbm_peak_diff_gb', metrics.results)
-    self.assertIn('op_7_memory/jax_live_arrays_count_delta', metrics.results)
+    self.assertNotIn('op::7_memory/device_hbm_peak_diff_gb', metrics.results)
+    self.assertIn('op::7_memory/jax_live_arrays_count_delta', metrics.results)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metrics_manager.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metrics_manager.py
@@ -98,6 +98,19 @@ class AggregatedStats:
   count: int
 
 
+def _slice_namespace(d: dict[str, Any], name: str) -> dict[str, Any]:
+  """Returns entries of `d` keyed `{name}::{key}`, stripped to `{key}`."""
+  prefix = f"{name}::"
+  return {k[len(prefix):]: v for k, v in d.items() if k.startswith(prefix)}
+
+
+def _slice_per_host(
+    per_host_values: list[tuple[int, dict[str, float]]], name: str
+) -> list[tuple[int, dict[str, float]]]:
+  """Per-host values for one capture name, with the `{name}::` prefix stripped."""
+  return [(idx, _slice_namespace(vals, name)) for idx, vals in per_host_values]
+
+
 class MetricsManager:
   """Manages metrics aggregation and reporting for a test suite.
 
@@ -230,15 +243,10 @@ class MetricsManager:
     """Writes a single result to TensorBoard."""
     writer = self._get_writer(benchmark_name)
     if error is None:
-      for key, (value, unit) in metrics.results.items():
-        # Hierarchical keys (e.g. "2_save_breakdown/blocking_s") already
-        # encode the unit in their suffix; appending "_s" again gives the
-        # ugly "..._blocking_s_s". Skip the suffix for those; flat legacy
-        # keys keep the existing "{key}_{unit}" shape.
-        if "/" in key:
-          tag = key
-        else:
-          tag = f'{key}_{unit.replace("/", "_")}'
+      for key, (value, _) in metrics.results.items():
+        # Keys are "{name}::{section}/{leaf}"; render the name namespace as a TB
+        # group so a benchmark's per-name scalars stay visible per host.
+        tag = key.replace("::", "/")
         if isinstance(value, (int, float)):
           writer.write_scalars(step=step, scalars={tag: value})
         else:
@@ -575,14 +583,17 @@ class MetricsManager:
   ) -> None:
     """Writes the __summary__ run: aggregate scalars, text cards, and HParams.
 
-    Per-host mode opens a sibling __summary__ writer; legacy mode reuses the
-    benchmark's single writer.
+    One at-a-glance + aggregated-metrics card per distinct operation name — a
+    name is a `measure()` block name, and its metrics are keyed `{name}::{tag}`
+    (`at_a_glance/<name>`, `aggregated_metrics/<name>`). Per-host mode opens a
+    sibling __summary__ writer; legacy mode reuses the single writer.
 
     Args:
       benchmark_name: The benchmark being summarized.
       results: The (Metrics, error) tuples for that benchmark.
-      aggregates: Cross-host aggregate stats per metric key.
-      per_host_values: (host_index, metric->mean) per host for the glance card.
+      aggregates: Cross-host aggregate stats per metric key, keyed
+        `{name}::{tag}`.
+      per_host_values: (host_index, metric->mean) per host for the glance cards.
     """
     assert self._tensorboard_dir is not None
     if self._enable_per_host_metrics:
@@ -597,32 +608,37 @@ class MetricsManager:
     try:
       # Aggregate scalars only — TB's Distributions/Histograms views plot over
       # a step axis and collapse to empty at step 0, so histograms are skipped.
+      # Keys carry a `name::` namespace; render it as a `/` group.
       for key, stats in aggregates.items():
+        tag = key.replace("::", "/")
         writer.write_scalars(
-            step=0, scalars={f"{key}_{stat}": v for stat, v in stats.items()}
+            step=0, scalars={f"{tag}_{stat}": v for stat, v in stats.items()}
         )
-      writer.write_texts(
-          step=0,
-          texts={
-              "at_a_glance": markdown_cards.render_glance_card(
-                  benchmark_name,
-                  aggregates,
-                  per_host_values,
-                  self._inventories.get(benchmark_name),
-                  self._suite_run_manifest,
-              )
-          },
-      )
+
       self._write_config_and_hparams(writer, benchmark_name)
       stats_dict, units_dict = self._aggregate_metrics(results)
-      writer.write_texts(
-          step=0,
-          texts={
-              "aggregated_metrics": markdown_cards.render_aggregated_metrics(
-                  benchmark_name, stats_dict, units_dict
-              )
-          },
-      )
+      inventory = self._inventories.get(benchmark_name)
+
+      cards: dict[str, str] = {}
+      names = sorted({k.split("::", 1)[0] for k in aggregates if "::" in k})
+      for name in names:
+        cards[f"at_a_glance/{name}"] = markdown_cards.render_glance_card(
+            f"{benchmark_name} · {name}",
+            _slice_namespace(aggregates, name),
+            _slice_per_host(per_host_values, name),
+            inventory,
+            self._suite_run_manifest,
+        )
+        cards[f"aggregated_metrics/{name}"] = (
+            markdown_cards.render_aggregated_metrics(
+                f"{benchmark_name} · {name}",
+                _slice_namespace(stats_dict, name),
+                _slice_namespace(units_dict, name),
+            )
+        )
+
+      if cards:
+        writer.write_texts(step=0, texts=cards)
       writer.flush()
     finally:
       if owned:

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metrics_manager_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/core/metrics_manager_test.py
@@ -115,8 +115,8 @@ class MetricsManagerTest(parameterized.TestCase):
 
     # Benchmark 'bench1', Rep 1: success
     m1 = metric_lib.Metrics()
-    m1.results['op_time_duration'] = (1.0, 's')
-    m1.results['op_other_metric'] = ('some_string', 'text')
+    m1.results['op::0_basics/time_s'] = (1.0, 's')
+    m1.results['op::9_other/note'] = ('some_string', 'text')
     manager.add_result(
         bench1_name,
         m1,
@@ -135,7 +135,7 @@ class MetricsManagerTest(parameterized.TestCase):
 
     # Add a second benchmark to ensure writers are created per benchmark
     m3 = metric_lib.Metrics()
-    m3.results['loss'] = (0.5, 'none')
+    m3.results['load::0_basics/time_s'] = (0.5, 's')
     manager.add_result(
         bench2_name,
         m3,
@@ -164,19 +164,20 @@ class MetricsManagerTest(parameterized.TestCase):
     )
 
     # Since the mock writer instance is reused, we check all calls on it.
+    # Keys are "{name}::{tag}"; the writer renders the name as a "/" group.
     # Calls for 'bench1'
     mock_writer.write_scalars.assert_any_call(
-        step=0, scalars={'op_time_duration_s': 1.0}
+        step=0, scalars={'op/0_basics/time_s': 1.0}
     )
     mock_writer.write_texts.assert_any_call(
-        step=0, texts={'op_other_metric_text': 'some_string'}
+        step=0, texts={'op/9_other/note': 'some_string'}
     )
     mock_writer.write_texts.assert_any_call(
         step=1, texts={'error': "<pre>ValueError('failure')</pre>"}
     )
     # Calls for 'bench2'
     mock_writer.write_scalars.assert_any_call(
-        step=0, scalars={'loss_none': 0.5}
+        step=0, scalars={'load/0_basics/time_s': 0.5}
     )
 
     # Configuration is now rendered as markdown; verify the benchmark name
@@ -211,6 +212,41 @@ class MetricsManagerTest(parameterized.TestCase):
     self.assertEqual(mock_writer.close.call_count, 2)
     self.assertGreaterEqual(mock_writer.flush.call_count, 2)
 
+  @mock.patch('clu.metric_writers.create_default_writer')
+  def test_each_name_builds_one_card_pair(self, mock_create_writer):
+    mock_writer = mock.Mock()
+    mock_create_writer.return_value = mock_writer
+    temp_dir = epath.Path(self.create_tempdir().full_path)
+    manager = metrics_manager.MetricsManager(
+        name='Suite',
+        num_repeats=1,
+        tensorboard_dir=temp_dir,
+        enable_per_host_metrics=False,
+    )
+    metrics = metric_lib.Metrics()
+    # Two distinct measure() names, keyed `{name}::{tag}`.
+    metrics.results = {
+        'warm::3_load_breakdown/total_s': (12.0, 's'),
+        'ckpt::2_save_breakdown/total_s': (3.0, 's'),
+    }
+    manager.add_result('bench', metrics)
+    manager.generate_report()
+
+    texts = {}
+    for _, kwargs in mock_writer.write_texts.call_args_list:
+      texts.update(kwargs.get('texts', {}))
+    # One glance + one aggregate card per distinct operation name.
+    self.assertIn('at_a_glance/warm', texts)
+    self.assertIn('at_a_glance/ckpt', texts)
+    self.assertIn('aggregated_metrics/warm', texts)
+    self.assertIn('aggregated_metrics/ckpt', texts)
+    self.assertIn('bench · warm', texts['at_a_glance/warm'])
+    self.assertIn('12.00', texts['at_a_glance/warm'])
+    self.assertIn('3.00', texts['at_a_glance/ckpt'])
+    # The breakdown table groups by the jax section prefix.
+    self.assertIn('3_load_breakdown', texts['aggregated_metrics/warm'])
+    self.assertIn('2_save_breakdown', texts['aggregated_metrics/ckpt'])
+
   def test_generate_report_no_successful_runs_for_aggregation(self):
     manager = metrics_manager.MetricsManager(name='Suite', num_repeats=2)
     manager.add_result('bench1', metric_lib.Metrics(), error=ValueError('1'))
@@ -234,7 +270,7 @@ class MetricsManagerTest(parameterized.TestCase):
     )
 
     m1 = metric_lib.Metrics()
-    m1.results['acc'] = (0.9, '')
+    m1.results['load::0_basics/time_s'] = (0.9, 's')
     manager.add_result('bench1', m1)
 
     mock_create_writer.assert_called_once_with(
@@ -243,7 +279,7 @@ class MetricsManagerTest(parameterized.TestCase):
         collection='bench1',
     )
     mock_writer.write_scalars.assert_called_once_with(
-        step=0, scalars={'acc_': 0.9}
+        step=0, scalars={'load/0_basics/time_s': 0.9}
     )
     mock_writer.flush.assert_called_once()
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/emergency_checkpoint_manager_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/emergency_checkpoint_manager_benchmark_test.py
@@ -119,24 +119,24 @@ class EmergencyCheckpointManagerBenchmarkTest(parameterized.TestCase):
       self.assertIsInstance(result, benchmarks_core.TestResult)
     with self.subTest('metrics timings'):
       self.assertIn(
-          'create_directories_0_basics/time_s', result.metrics.results
+          'create_directories::0_basics/time_s', result.metrics.results
       )
       self.assertIn(
-          'create_abstract_pytree_0_basics/time_s', result.metrics.results
+          'create_abstract_pytree::0_basics/time_s', result.metrics.results
       )
       self.assertIn(
-          'create_restore_args_0_basics/time_s', result.metrics.results
+          'create_restore_args::0_basics/time_s', result.metrics.results
       )
       self.assertIn(
-          'create_checkpoint_manager_0_basics/time_s', result.metrics.results
+          'create_checkpoint_manager::0_basics/time_s', result.metrics.results
       )
-      self.assertIn('train_loop_0_basics/time_s', result.metrics.results)
-      self.assertIn('save_0_0_basics/time_s', result.metrics.results)
+      self.assertIn('train_loop::0_basics/time_s', result.metrics.results)
+      self.assertIn('save_0::0_basics/time_s', result.metrics.results)
       self.assertIn(
-          'wait_until_finished_0_0_basics/time_s', result.metrics.results
+          'wait_until_finished_0::0_basics/time_s', result.metrics.results
       )
       self.assertIn(
-          'sync_global_processes_0_0_basics/time_s', result.metrics.results
+          'sync_global_processes_0::0_basics/time_s', result.metrics.results
       )
     with self.subTest('checkpoint manager calls'):
       mock_checkpoint_manager_cls.assert_called_once()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/lustre_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/lustre_benchmark_test.py
@@ -93,10 +93,10 @@ class LustreBenchmarkTest(parameterized.TestCase):
     # Verify result
     self.assertIsInstance(result, benchmarks_core.TestResult)
     expected_metrics = {
-        'resolve_cache_0_basics/time_s',
-        'save_cache_0_basics/time_s',
-        'finalize_cache_0_basics/time_s',
-        'save_0_basics/time_s',
+        'resolve_cache::0_basics/time_s',
+        'save_cache::0_basics/time_s',
+        'finalize_cache::0_basics/time_s',
+        'save::0_basics/time_s',
     }
     self.assertContainsSubset(expected_metrics, result.metrics.results.keys())
 
@@ -171,10 +171,10 @@ class LustreBenchmarkTest(parameterized.TestCase):
     # Verify result
     self.assertIsInstance(result, benchmarks_core.TestResult)
     expected_metrics = {
-        'prefetch_cache_0_basics/time_s',
-        'wait_prefetch_cache_0_basics/time_s',
-        'restore_cache_0_basics/time_s',
-        'restore_0_basics/time_s',
+        'prefetch_cache::0_basics/time_s',
+        'wait_prefetch_cache::0_basics/time_s',
+        'restore_cache::0_basics/time_s',
+        'restore::0_basics/time_s',
     }
     self.assertContainsSubset(expected_metrics, result.metrics.results.keys())
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/multihost_dispatchers_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/multihost_dispatchers_benchmark_test.py
@@ -148,11 +148,11 @@ class MultihostDispatchersBenchmarkTest(parameterized.TestCase):
     self.assertIsInstance(result, core.TestResult)
     self.assertContainsSubset(
         {
-            'dispatch_without_result_specs_0_basics/time_s',
-            'dispatch_without_result_specs_block_until_ready_0_basics/time_s',
-            'dispatch_with_dummy_result_array_0_basics/time_s',
-            'dispatch_with_dummy_result_array_block_until_ready_0_basics/time_s',
-            'dispatch_with_result_specs_0_basics/time_s',
+            'dispatch_without_result_specs::0_basics/time_s',
+            'dispatch_without_result_specs_block_until_ready::0_basics/time_s',
+            'dispatch_with_dummy_result_array::0_basics/time_s',
+            'dispatch_with_dummy_result_array_block_until_ready::0_basics/time_s',
+            'dispatch_with_result_specs::0_basics/time_s',
         },
         result.metrics.results.keys(),
     )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/load_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/orbax_load/load_benchmark_test.py
@@ -97,7 +97,7 @@ class LoadFlowTest(absltest.TestCase):
       time_keys = [
           k
           for k in result.metrics.results
-          if k.startswith("load_0_basics/time_s")
+          if k.startswith("load::0_basics/time_s")
       ]
       self.assertNotEmpty(time_keys)
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/p2p_checkpoint_manager_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/p2p_checkpoint_manager_benchmark_test.py
@@ -127,39 +127,39 @@ class P2pCheckpointManagerBenchmarkTest(parameterized.TestCase):
       self.assertIsInstance(result, benchmarks_core.TestResult)
     with self.subTest('metrics timings'):
       self.assertIn(
-          'create_abstract_pytree_0_basics/time_s', result.metrics.results
+          'create_abstract_pytree::0_basics/time_s', result.metrics.results
       )
       self.assertIn(
-          'create_restore_args_0_basics/time_s', result.metrics.results
+          'create_restore_args::0_basics/time_s', result.metrics.results
       )
       self.assertIn(
-          'test_local_restore_create_directories_0_basics/time_s',
+          'test_local_restore_create_directories::0_basics/time_s',
           result.metrics.results,
       )
       self.assertIn(
-          'test_local_restore_create_checkpoint_manager_0_basics/time_s',
+          'test_local_restore_create_checkpoint_manager::0_basics/time_s',
           result.metrics.results,
       )
       self.assertIn(
-          'test_local_restore_train_loop_0_basics/time_s',
+          'test_local_restore_train_loop::0_basics/time_s',
           result.metrics.results,
       )
       self.assertIn(
-          'test_local_restore_save_0_0_basics/time_s', result.metrics.results
+          'test_local_restore_save_0::0_basics/time_s', result.metrics.results
       )
       self.assertIn(
-          'test_local_restore_wait_until_finished_0_0_basics/time_s',
+          'test_local_restore_wait_until_finished_0::0_basics/time_s',
           result.metrics.results,
       )
       self.assertIn(
-          'test_local_restore_save_1_0_basics/time_s', result.metrics.results
+          'test_local_restore_save_1::0_basics/time_s', result.metrics.results
       )
       self.assertIn(
-          'test_local_restore_wait_until_finished_1_0_basics/time_s',
+          'test_local_restore_wait_until_finished_1::0_basics/time_s',
           result.metrics.results,
       )
       self.assertIn(
-          'test_local_restore_restore_and_validate_1_0_basics/time_s',
+          'test_local_restore_restore_and_validate_1::0_basics/time_s',
           result.metrics.results,
       )
     with self.subTest('checkpoint manager calls'):

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytorch_checkpoint_benchmark_test.py
@@ -145,8 +145,8 @@ class PyTorchCheckpointBenchmarkTest(parameterized.TestCase):
     self.assertIsInstance(result, benchmarks_core.TestResult)
     self.assertContainsSubset(
         {
-            'save_0_basics/time_s',
-            'restore_0_basics/time_s',
+            'save::0_basics/time_s',
+            'restore::0_basics/time_s',
         },
         result.metrics.results.keys(),
     )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark.py
@@ -25,6 +25,7 @@ import orbax.checkpoint as ocp
 from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
 from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
 
+
 def _metrics_to_measure(options: "PyTreeCheckpointOptions") -> list[str]:
   """Returns the list of metrics to measure.
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark_test.py
@@ -117,7 +117,7 @@ class PyTreeCheckpointBenchmarkTest(parameterized.TestCase):
         restore_concurrent_gb=restore_concurrent_gb,
         save_device_host_concurrent_gb=save_device_host_concurrent_gb,
         use_replica_parallel=use_replica_parallel,
-        enable_replica_parallel_separate_folder=enable_replica_parallel_separate_folder,
+        enable_replica_parallel_separate_folder=enable_replica_parallel_separate_folder,  # pylint: disable=line-too-long
         use_colocated_python=use_colocated_python,
     )
     context = benchmarks_core.TestContext(
@@ -141,9 +141,9 @@ class PyTreeCheckpointBenchmarkTest(parameterized.TestCase):
     self.assertIsInstance(result, benchmarks_core.TestResult)
     self.assertContainsSubset(
         {
-            'save_0_basics/time_s',
-            'wait_until_finished_0_basics/time_s',
-            'restore_0_basics/time_s',
+            'save::0_basics/time_s',
+            'wait_until_finished::0_basics/time_s',
+            'restore::0_basics/time_s',
         },
         result.metrics.results.keys(),
     )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/single_replica_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/single_replica_benchmark_test.py
@@ -141,11 +141,13 @@ class SingleReplicaBenchmarkTest(parameterized.TestCase):
     mock_is_runtime_to_distributed_ids_initialized.assert_called_once()
     register_pathways_handlers.assert_called_once()
     self.assertIsInstance(result, benchmarks_core.TestResult)
-    self.assertIn('save_0_basics/time_s', result.metrics.results)
-    self.assertIn('wait_until_finished_0_basics/time_s', result.metrics.results)
-    self.assertIn('restore_0_basics/time_s', result.metrics.results)
+    self.assertIn('save::0_basics/time_s', result.metrics.results)
     self.assertIn(
-        'construct_restore_args_0_basics/time_s', result.metrics.results
+        'wait_until_finished::0_basics/time_s', result.metrics.results
+    )
+    self.assertIn('restore::0_basics/time_s', result.metrics.results)
+    self.assertIn(
+        'construct_restore_args::0_basics/time_s', result.metrics.results
     )
     mock_checkpointer.save.assert_called_once()
     mock_checkpointer.wait_until_finished.assert_called_once()
@@ -237,7 +239,7 @@ class SingleReplicaBenchmarkTest(parameterized.TestCase):
     mock_is_runtime_to_distributed_ids_initialized.assert_called_once()
     register_pathways_handlers.assert_called_once_with(
         use_single_replica_array_handler=True,
-        checkpointing_impl=pathways_handler_registry.CheckpointingImpl.from_options(
+        checkpointing_impl=pathways_handler_registry.CheckpointingImpl.from_options(  # pylint: disable=line-too-long
             use_colocated_python=options.use_colocated_python,
         ),
         replica_axis_index=options.replica_axis_index,

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/tpu_vm/setup_tpu.sh
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/tpu_vm/setup_tpu.sh
@@ -129,7 +129,8 @@ pip install .
 
 # Install Benchmark dependencies (from Dockerfile analysis)
 echo "Installing benchmark dependencies..."
-python3 -m pip install gcsfs portpicker clu tensorflow tensorboard google-cloud-logging
+python3 -m pip install gcsfs portpicker clu tensorflow tensorboard google-cloud-logging \
+    safetensors huggingface_hub
 
 if [ -n "$RAMFS_DIR" ]; then
     echo ">>> Setting up high-performance storage..."

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark.py
@@ -168,16 +168,12 @@ class Benchmark(benchmarks_core.BenchmarksGenerator):
     with ocp.Context(context=options.context):
       if save_trace is not None:
         jax.profiler.start_trace(str(save_trace))
-      if options.async_enabled:
-        with metrics.measure("save_blocking", metrics_to_measure):
+      with metrics.measure("save", metrics_to_measure):
+        if options.async_enabled:
           f = ocp.save_async(save_path, pytree)
-        with metrics.measure("save_background", metrics_to_measure):
           f.result()
-      else:
-        with metrics.measure("save_blocking", metrics_to_measure):
+        else:
           ocp.save(save_path, pytree)
-        with metrics.measure("save_background", metrics_to_measure):
-          pass
       context.pytree = clear_pytree(context.pytree)
       if save_trace is not None:
         jax.profiler.stop_trace()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/benchmark_test.py
@@ -98,7 +98,7 @@ class BenchmarkTest(parameterized.TestCase):
         save_concurrent_gb=save_concurrent_gb,
         restore_concurrent_gb=restore_concurrent_gb,
         use_replica_parallel=use_replica_parallel,
-        enable_replica_parallel_separate_folder=enable_replica_parallel_separate_folder,
+        enable_replica_parallel_separate_folder=enable_replica_parallel_separate_folder,  # pylint: disable=line-too-long
     )
 
     # Create unique path for each parameter set
@@ -114,12 +114,9 @@ class BenchmarkTest(parameterized.TestCase):
     result = generator.test_fn(context)
 
     self.assertIsInstance(result, benchmarks_core.TestResult)
-    # The benchmark records "save_blocking", "save_background", "load"
-    # measure() blocks. Each block writes a 0_basics/time_s key.
     metrics = result.metrics.results
-    self.assertIn('save_blocking_0_basics/time_s', metrics)
-    self.assertIn('save_background_0_basics/time_s', metrics)
-    self.assertIn('load_0_basics/time_s', metrics)
+    self.assertIn('save::0_basics/time_s', metrics)
+    self.assertIn('load::0_basics/time_s', metrics)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark.py
@@ -128,20 +128,16 @@ class ReplicaParallelMultislice(benchmarks_core.BenchmarksGenerator):
       with ocp.Context(context=options.context):
         if save_trace is not None:
           jax.profiler.start_trace(str(save_trace))
-        if options.async_enabled:
-          with metrics.measure("save_blocking", metrics_to_measure):
+        with metrics.measure("save", metrics_to_measure):
+          if options.async_enabled:
             logging.info(
                 "ReplicaParallelMultislice: Async Saving pytree to %s.",
                 save_path,
             )
             f = ocp.save_async(save_path, loaded_pytree)
-          with metrics.measure("save_background", metrics_to_measure):
             f.result()
-        else:
-          with metrics.measure("save_blocking", metrics_to_measure):
+          else:
             ocp.save(save_path, loaded_pytree)
-          with metrics.measure("save_background", metrics_to_measure):
-            pass
 
       # Manually trigger a full garbage collection to avoid OOMs.
       collected_objects = gc.collect()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/replica_parallel_multislice_benchmark_test.py
@@ -27,7 +27,7 @@ from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_cor
 from orbax.checkpoint._src.testing.benchmarks.v1 import replica_parallel_multislice_benchmark
 
 ReplicaParallelMultisliceBenchmarkOptions = (
-    replica_parallel_multislice_benchmark.ReplicaParallelMultisliceBenchmarkOptions
+    replica_parallel_multislice_benchmark.ReplicaParallelMultisliceBenchmarkOptions  # pylint: disable=line-too-long
 )
 ReplicaParallelMultislice = (
     replica_parallel_multislice_benchmark.ReplicaParallelMultislice
@@ -130,8 +130,7 @@ class ReplicaParallelMultisliceBenchmarkTest(parameterized.TestCase):
     result = generator.test_fn(context)
     self.assertIsInstance(result, benchmarks_core.TestResult)
     metrics = result.metrics.results
-    self.assertIn('save_blocking_0_basics/time_s', metrics)
-    self.assertIn('save_background_0_basics/time_s', metrics)
+    self.assertIn('save::0_basics/time_s', metrics)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/resharding_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/resharding_benchmark_test.py
@@ -108,7 +108,7 @@ class ReshardingBenchmarkTest(parameterized.TestCase):
 
     self.assertIsInstance(result, benchmarks_core.TestResult)
     metrics = result.metrics.results
-    self.assertIn('load_0_basics/time_s', metrics)
+    self.assertIn('load::0_basics/time_s', metrics)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/restore_and_broadcast_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/v1/restore_and_broadcast_benchmark_test.py
@@ -134,7 +134,7 @@ class RestoreAndBroadcastBenchmarkTest(parameterized.TestCase):
     result = generator.test_fn(context)
     self.assertIsInstance(result, benchmarks_core.TestResult)
     metrics = result.metrics.results
-    self.assertIn('load_0_basics/time_s', metrics)
+    self.assertIn('load::0_basics/time_s', metrics)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/xpk/Dockerfile.orbax_benchmark
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/xpk/Dockerfile.orbax_benchmark
@@ -63,8 +63,8 @@ RUN pip install -U --no-cache-dir \
 ARG JAX_VERSION=newest
 ARG DEVICE=tpu
 
-# Install GCSFS and Portpicker
-RUN pip install --no-cache-dir gcsfs portpicker clu 
+# Install GCSFS, Portpicker, and safetensors-loader dependencies
+RUN pip install --no-cache-dir gcsfs portpicker clu safetensors huggingface_hub
 
 RUN if [ "$DEVICE" = "gpu" ]; then \
     pip install --no-cache-dir tensorflow; \


### PR DESCRIPTION
## Description

Restructures the `_src/testing/benchmarks` metrics/card layer so each
`measure()` block builds its own at-a-glance + aggregated-metrics card, grouped
by operation name (results keyed `{name}::{tag}` — `::` so a name containing `_`
splits cleanly). jax.monitoring is captured per-block via a `JaxMonitoringMetric`
listed in `metric_keys` (part of the default set); its curated tag map drives the
per-stage breakdown, throughput, inventory, and memory rows of the card. Nested
`measure()` blocks that each opt in capture the same emissions independently.

Also adds the safetensors per-host read tags — `6_io/file_bytes_read_per_host`,
`file_reads_per_host_count` (coalesced ranged-read requests), and
`storage_reads_per_host_count` (actual GETs) — so a loader without TensorStore
counters can self-report its read accounting through the same jax.monitoring
channel and land in the card.

The in-tree v1 benchmarks adopt the new shape (one `measure("save")` block, with
the blocking/async breakdown coming from the jax tags) and the existing
benchmark tests are updated to the `{name}::{tag}` keying.

This is the base of a stack; a HuggingFace safetensors load benchmark builds on
top of it.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or a public API)
- [x] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover this change and pass locally.
- [x] Public APIs and non-trivial functions are documented.
- [ ] N/A — internal benchmark tooling, not user-facing, so no `CHANGELOG.md` entry.
