### PR TITLE
HuggingFace safetensors load benchmark

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/deepseek-v3.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/deepseek-v3.yaml
@@ -1,0 +1,30 @@
+# Safetensors load benchmark for DeepSeek V3.
+#
+# Tier 4 alternative -- 671B-param open MoE shipped as ~160 safetensors
+# files totalling ~600 GB in bf16. Uses multi-head latent attention
+# (MLA), shared experts, and a non-Llama tensor naming convention.
+# `prepare.py` reads tensor names + shapes from the actual safetensors
+# headers, so it produces the spec for any model. Stage the model and
+# its FSDP-256 spec to GCS once:
+#
+#   python -m orbax.checkpoint._src.testing.benchmarks.safetensor.prepare \\
+#       --repo deepseek-ai/DeepSeek-V3 \\
+#       --gcs gs://orbax-benchmarks/fixtures/deepseek-v3/ \\
+#       --axis-size 256 --strategy fsdp \\
+#       --sharding-out gs://orbax-benchmarks/sharding/deepseek-v3_fsdp256.json
+#
+# DeepSeek V3 is openly licensed (no gated form); the download is ~600 GB.
+
+suite_name: "safetensor_load_deepseek-v3"
+num_repeats: 2
+
+mesh_config:
+  mesh_axes: ["fsdp"]
+  ici_parallelism: {"fsdp": 256}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/deepseek-v3/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/deepseek-v3_fsdp256.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/deepseek-v3_tp.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/deepseek-v3_tp.yaml
@@ -1,0 +1,29 @@
+# Captures a baseline for DeepSeek-V3 under inner-dim TP-256.
+#
+# Tier-4 open alternative under inner-dim sharding. `prepare.py` reads
+# tensor names + shapes from the actual safetensors headers, so it
+# handles DeepSeek-V3's non-Llama naming. Stage the model and its
+# inner-dim TP-256 spec to GCS once:
+#
+#   python -m orbax.checkpoint._src.testing.benchmarks.safetensor.prepare \\
+#       --repo deepseek-ai/DeepSeek-V3 \\
+#       --gcs gs://orbax-benchmarks/fixtures/deepseek-v3/ \\
+#       --axis-size 256 --strategy tp_inner \\
+#       --sharding-out gs://orbax-benchmarks/sharding/deepseek-v3_tp256.json
+#
+# (Shards any tensor whose last dim is divisible by 256; replicates the
+# rest.) Then this YAML runs as-is.
+
+suite_name: "safetensor_load_deepseek-v3_tp"
+num_repeats: 2
+
+mesh_config:
+  mesh_axes: ["tp"]
+  ici_parallelism: {"tp": 256}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/deepseek-v3/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/deepseek-v3_tp256.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/hf.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/hf.yaml
@@ -1,0 +1,38 @@
+# HuggingFace safetensors load benchmark.
+#
+# Drives the SafetensorLoadBenchmark against a real HuggingFace model
+# (GPT-2), pre-staged to GCS once with `prepare.py`:
+#
+#   python -m orbax.checkpoint._src.testing.benchmarks.safetensor.prepare \
+#     --repo gpt2 --gcs gs://orbax-benchmarks/fixtures/gpt2/
+#
+# Capture phase (baseline revision): add
+# `baseline_capture_path: gs://orbax-benchmarks/baselines/` (top level) to this
+# config, then run it:
+#
+#   python -m orbax.checkpoint._src.testing.benchmarks.run_benchmarks \
+#     --config_file=safetensor/configs/hf.yaml \
+#     --output_directory=gs://orbax-benchmarks/runs/baseline/
+#
+# Compare phase (candidate revision): set
+# `baseline_path: gs://orbax-benchmarks/baselines/<sha>.json` instead, then run
+# again.
+#
+# Defaults to GPT-2 (small, fast download, public) — swap for a larger
+# model when you want a real production-shape A/B.
+
+suite_name: "safetensor_load_hf_gpt2"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["data"]
+  ici_parallelism: {"data": 8}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/gpt2/"
+      # No sharding_config_path — fully replicated across local devices.
+      # For larger models that need real sharding, point this at a JSON
+      # describing the target Mesh + PartitionSpec per tensor.
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-405b.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-405b.yaml
@@ -1,0 +1,30 @@
+# Safetensors load benchmark for Llama 3 405B.
+#
+# Tier 4 -- the stress-test scale. ~810 GB bf16 across ~100 safetensors
+# files, 126 transformer layers. fsdp=256 mesh (v5p-256 / v5e-256+).
+# Exercises the loader's behaviour when:
+#   * file count dominates RPC count even with cross-tensor coalescing
+#     (100 files * 9 weight matrices per layer * 126 layers = a lot
+#     of byte runs to bin-pack);
+#   * per-host shard sizes are tiny relative to file sizes (4 GB
+#     shards out of 100+ GB files);
+#   * concurrent reads cap (`_MAX_CONCURRENT_READS`) is the active
+#     bottleneck, not bandwidth.
+#
+# Llama 3 405B is gated; see safetensor_load_llama3-8b.yaml.
+# GCS pre-staging is *strongly* recommended -- 810 GB download per VM
+# is hours of wall clock per A/B run.
+
+suite_name: "safetensor_load_llama3-405b"
+num_repeats: 2
+
+mesh_config:
+  mesh_axes: ["fsdp"]
+  ici_parallelism: {"fsdp": 256}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/llama3-405b/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/llama3-405b_fsdp256.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-405b_tp.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-405b_tp.yaml
@@ -1,0 +1,21 @@
+# Captures a baseline for Llama-3-405B under inner-dim TP-256.
+#
+# Tier-4 stress case under inner-dim sharding. ~100 files * ~1000
+# tensors-per-file * 256-way TP = the largest cross-tensor coalesce
+# decision space in the suite. See `llama3-8b_tp.yaml` for HF token +
+# gated-access setup; pre-stage the model + TP-256 spec with `prepare.py`
+# (--strategy tp_inner --axis-size 256).
+
+suite_name: "safetensor_load_llama3-405b_tp"
+num_repeats: 2
+
+mesh_config:
+  mesh_axes: ["tp"]
+  ici_parallelism: {"tp": 256}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/llama3-405b/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/llama3-405b_tp256.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-70b.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-70b.yaml
@@ -1,0 +1,33 @@
+# Safetensors load benchmark for Llama 3 70B.
+#
+# Tier 3 alternative -- gated counterpart to safetensor_load_mixtral8x7b.yaml.
+# 140 GB bf16 across ~30 safetensors files, fsdp=128 mesh (v5p-128 / v5e-128).
+# The canonical "production transformer" scale: this is what every team
+# eventually loads, and the closest match to real customer workloads.
+#
+# Llama 3 70B is gated; see safetensor_load_llama3-8b.yaml for
+# the HF_TOKEN setup.
+#
+# Pre-stage this model + its FSDP-128 spec to GCS once with `prepare.py`
+# (downloading 140 GB to every TPU VM on every A/B run wastes hours and
+# burns HF Hub egress quota):
+#
+#   python -m orbax.checkpoint._src.testing.benchmarks.safetensor.prepare \
+#     --repo meta-llama/Llama-3-70B \
+#     --gcs gs://orbax-benchmarks/fixtures/llama3-70b/ \
+#     --axis-size 128 --strategy fsdp \
+#     --sharding-out gs://orbax-benchmarks/sharding/llama3-70b_fsdp128.json
+
+suite_name: "safetensor_load_llama3-70b"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["fsdp"]
+  ici_parallelism: {"fsdp": 128}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/llama3-70b/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/llama3-70b_fsdp128.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-70b_tp.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-70b_tp.yaml
@@ -1,0 +1,21 @@
+# Captures a baseline for Llama-3-70B under inner-dim TP-128 (gated;
+# see `llama3-8b_tp.yaml` for HF token setup).
+#
+# Production-shape tier-3 case: 30 files times the row-parallel TP
+# pattern. The new loader's coalesce policy is most stressed when
+# many thousands of strided byte runs need to be partitioned across
+# all 128 hosts.
+
+suite_name: "safetensor_load_llama3-70b_tp"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["tp"]
+  ici_parallelism: {"tp": 128}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/llama3-70b/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/llama3-70b_tp128.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-8b.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-8b.yaml
@@ -1,0 +1,29 @@
+# Safetensors load benchmark for Llama 3 8B.
+#
+# Tier 2 alternative -- gated counterpart to safetensor_load_mistral7b.yaml.
+# Same shape (16 GB bf16, ~4 safetensors files, fsdp=8 across 8 chips) but
+# the canonical reference model that production teams actually load.
+#
+# Llama 3 8B is gated on HF: the account associated with the HF token
+# must have accepted Meta's terms at
+# https://huggingface.co/meta-llama/Llama-3-8B once. After that:
+#
+#   export HF_TOKEN=hf_...   # before invoking the benchmark
+#
+# The launcher / Dockerfile passes HF_TOKEN through to the worker
+# environment; `huggingface_hub.snapshot_download` picks it up
+# automatically.
+
+suite_name: "safetensor_load_llama3-8b"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["fsdp"]
+  ici_parallelism: {"fsdp": 8}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/llama3-8b/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/llama3-8b_fsdp8.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-8b_tp.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/llama3-8b_tp.yaml
@@ -1,0 +1,19 @@
+# Captures a baseline for Llama-3-8B under inner-dim TP-8 (gated alt
+# to `mistral7b_tp.yaml`).
+#
+# Gated; requires HF_TOKEN with Meta-terms accepted. See
+# `llama3-8b.yaml` for the FSDP variant.
+
+suite_name: "safetensor_load_llama3-8b_tp"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["tp"]
+  ici_parallelism: {"tp": 8}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/llama3-8b/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/llama3-8b_tp8.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/mistral7b.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/mistral7b.yaml
@@ -1,0 +1,27 @@
+# Safetensors load benchmark for Mistral 7B v0.1.
+#
+# Tier 2 of the suite: real ~14 GB safetensors model, naturally sharded
+# into 2 files, leading-dim FSDP across 8 devices. First HF model in the
+# ladder where multi-file load + real per-host shard reads kick in.
+#
+# Mistral 7B v0.1 is openly licensed (no HF token required for read
+# access; no gated access form to accept). Repo URL:
+# https://huggingface.co/mistralai/Mistral-7B-v0.1
+#
+# Hardware: any device topology with 8 chips (v5p-8, v5e-8, v4-8, GPU-8).
+# bf16 weights at fsdp=8 -> ~1.75 GB per chip, comfortable on any v5p/v5e.
+
+suite_name: "safetensor_load_mistral7b"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["fsdp"]
+  ici_parallelism: {"fsdp": 8}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/mistral7b/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/mistral7b_fsdp8.json"
+      enable_trace: true
+      # Capture-only.

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/mistral7b_tp.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/mistral7b_tp.yaml
@@ -1,0 +1,45 @@
+# Safetensors load benchmark for Mistral 7B
+# under inner-dim tensor parallelism (TP-8).
+#
+# Pair to `mistral7b.yaml` (FSDP-8). Same model, same mesh size,
+# but every 2D+ weight is split along its INNER dim instead of the
+# leading dim. In HF safetensors storage (`Linear` weights stored as
+# `(out, in)`), this is the row-parallel-TP equivalent and is the
+# load-bearing case for the new loader's bounded-over-read coalesce
+# policy:
+#
+#   * Each device's shard is NOT contiguous in the file blob -- it is
+#     a set of strided runs (one short run per leading-dim coordinate).
+#   * The new loader's per-file scheduler coalesces those runs up to a
+#     2x over-read ratio (configurable); beyond that, it splits into
+#     many smaller reads.
+#   * The old transient-array loader reads a contiguous 1/N slab per
+#     host and then JIT-reshards to the target inner-dim sharding via
+#     a per-tensor `jnp.sum(axis=0)` collective.
+#
+# So the diff between baseline (old loader) and candidate (new loader)
+# on this YAML answers: which strategy wins on inner-dim TP, and by
+# how much?
+#
+# Watch in the dashboard:
+#   * `6_io/file_reads_per_host_count` -- old: ~1 per file per host
+#     (the bundle read); new: many strided reads after the ratio cap
+#     splits.
+#   * `load_total_gbps` -- the headline; whichever pays less in
+#     overhead wins.
+#   * `load_6_tensorstore/...bytes_read` -- per-host bytes pulled;
+#     new loader's reads should be bounded at 2x ideal, not K x.
+
+suite_name: "safetensor_load_mistral7b_tp"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["tp"]
+  ici_parallelism: {"tp": 8}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/mistral7b/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/mistral7b_tp8.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/mixtral8x7b.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/mixtral8x7b.yaml
@@ -1,0 +1,31 @@
+# Safetensors load benchmark for Mixtral 8x7B v0.1.
+#
+# Tier 3 of the suite: 47B-param MoE shipped as 19 sharded safetensors
+# files totalling ~93 GB in bf16. The smallest fully-real workload in
+# the ladder where the per-file scheduler's cross-tensor coalescing
+# and the bounded-ratio partition policy earn their keep: 19 files
+# times hundreds of expert tensors per layer creates many disjoint
+# byte runs per host, and the partitioner is what keeps the per-host
+# read count from blowing up to thousands of GETs.
+#
+# Mixtral 8x7B v0.1 is openly licensed; no HF token or gated-access
+# form. Repo URL: https://huggingface.co/mistralai/Mixtral-8x7B-v0.1
+#
+# Hardware: requires at least 16 chips (e.g. v5p-16 / v5e-16). bf16 +
+# fsdp=16 -> ~5.8 GB per chip for params; fits comfortably with
+# headroom for activations / buffers.
+
+suite_name: "safetensor_load_mixtral8x7b"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["fsdp"]
+  ici_parallelism: {"fsdp": 16}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/mixtral8x7b/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/mixtral8x7b_fsdp16.json"
+      enable_trace: true
+      # Capture-only.

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/mixtral8x7b_tp.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/configs/mixtral8x7b_tp.yaml
@@ -1,0 +1,24 @@
+# Captures a baseline for Mixtral 8x7B under inner-dim TP-16.
+#
+# Pair to `mixtral8x7b.yaml` (FSDP-16). The MoE shape makes
+# this particularly interesting: 19 files times 8 experts per layer
+# times 3 weight matrices per expert times 32 layers => roughly 15K
+# tensors per file the loader must enumerate, with each shard splitting
+# the inner dim of every weight. The bounded-over-read coalesce policy
+# on the new loader has the most work to do here.
+#
+# See `mistral7b_tp.yaml` for the full rationale.
+
+suite_name: "safetensor_load_mixtral8x7b_tp"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["tp"]
+  ici_parallelism: {"tp": 16}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/mixtral8x7b/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/mixtral8x7b_tp16.json"
+      enable_trace: true

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/load_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/load_benchmark.py
@@ -1,0 +1,253 @@
+# Copyright 2026 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Load-only benchmark for HuggingFace-format safetensors checkpoints.
+
+Purpose-built A/B comparison target: run against `main` to capture a
+baseline, then run against a branch that changes the safetensors load
+path to see the per-stage / per-host / throughput diff. Loads real
+HuggingFace-format checkpoints pre-staged to `gs://` (or local) with
+`safetensor/prepare.py`; it does not download from the Hub at run time.
+
+Correctness is independent of the perf baseline: a load-only benchmark has no
+in-memory reference, so it hashes the loaded tree per host.
+`capture_digests_path` records the digests; `reference_digests_path` verifies
+the loaded tree against a previously-captured set and raises on a mismatch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import dataclasses
+import json
+import pprint
+from typing import Any
+
+from absl import logging
+from etils import epath
+import jax
+from orbax.checkpoint import v1 as ocp
+from orbax.checkpoint._src.testing.benchmarks.core import checkpoint_generation
+from orbax.checkpoint._src.testing.benchmarks.core import core as benchmarks_core
+from orbax.checkpoint._src.testing.benchmarks.core import inventory as inventory_lib
+from orbax.checkpoint._src.testing.benchmarks.core import metric as metric_lib
+from orbax.checkpoint._src.testing.benchmarks.core import pytree_utils
+
+
+@dataclasses.dataclass(frozen=True)
+class SafetensorLoadBenchmarkOptions(benchmarks_core.BenchmarkOptions):
+  """Configuration for loading a HuggingFace-format safetensors checkpoint.
+
+  Self-contained: builds its own `ocp.Context()` with the SAFETENSORS layout
+  pinned from the load-side tuning knobs, so a single run can sweep e.g.
+  `use_load_and_broadcast` or `restore_concurrent_gb` for A/B comparison. Each
+  knob may be a single value or a list to expand into a parameter sweep.
+
+  Attributes:
+    checkpoint_path: Path (local or `gs://`) to a directory containing one or
+      more `*.safetensors` files, pre-staged with `prepare.py` (the benchmark
+      does not download from the Hub at run time). Format matches what
+      HuggingFace ships — single-file (`model.safetensors`) or sharded
+      (`model-NNNNN-of-MMMMM.safetensors`). The optional
+      `model.safetensors.index.json` is allowed but not required.
+    sharding_config_path: Optional JSON file describing the target sharding per
+      tensor. If absent, every loaded tensor is fully replicated across local
+      devices (useful for inner-loop smoke).
+    capture_digests_path: Directory to write per-host SHA-256 digests of the
+      loaded tree to (one `host_<idx>.json` per process); mutually exclusive
+      with `reference_digests_path`.
+    reference_digests_path: Directory of previously-captured per-host digests to
+      verify the loaded tree against; each host checks its own `host_<idx>.json`
+      and a mismatch raises with per-tensor detail; mutually exclusive with
+      `capture_digests_path`.
+    use_load_and_broadcast: Whether to load on one replica and broadcast to the
+      others instead of every replica reading from storage.
+    restore_concurrent_gb: Cap on concurrent read bytes (in GiB); `None` leaves
+      the Orbax default.
+    metric_tracemalloc_enabled: Whether to capture the tracemalloc metric
+      (opt-in because its per-allocation snapshots are expensive).
+  """
+
+  checkpoint_path: str | None = None
+  sharding_config_path: str | None = None
+  capture_digests_path: str | None = None
+  reference_digests_path: str | None = None
+  use_load_and_broadcast: bool | Sequence[bool] = False
+  restore_concurrent_gb: int | None | Sequence[int | None] = None
+  metric_tracemalloc_enabled: bool = False
+
+  def is_valid(self) -> bool:
+    if self.checkpoint_path is None:
+      return False
+    return super().is_valid()
+
+  @property
+  def context(self) -> ocp.Context:
+    ctx = ocp.Context(
+        checkpoint_layout=ocp.options.CheckpointLayout.SAFETENSORS
+    )
+    ctx.array.loading.use_load_and_broadcast = self.use_load_and_broadcast
+    ctx.memory.read_concurrent_bytes = (
+        self.restore_concurrent_gb * 1024**3
+        if self.restore_concurrent_gb is not None
+        else None
+    )
+    return ctx
+
+
+def _replicated_abstract_state(metadata: Any) -> Any:
+  """Builds an abstract state with every leaf replicated across local devices.
+
+  Used when no `sharding_config_path` is supplied — convenient for inner-loop
+  smoke against tiny fixtures where no real sharding decision needs to be made.
+  Leaf shapes and dtypes come from the safetensors header via `ocp.metadata()`.
+
+  Args:
+    metadata: The checkpoint metadata pytree (shapes + dtypes per leaf).
+
+  Returns:
+    An abstract state pytree with every leaf replicated across local devices.
+  """
+  mesh = jax.sharding.Mesh(jax.devices(), ("data",))
+  replicated = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+  return jax.tree.map(
+      lambda x: jax.ShapeDtypeStruct(
+          shape=x.shape, dtype=x.dtype, sharding=replicated
+      ),
+      metadata,
+  )
+
+
+def _load_digests(path: epath.PathLike) -> dict[str, str] | None:
+  """Loads a per-host digests JSON file, or None if absent/unreadable."""
+  try:
+    p = epath.Path(path)
+    if not p.exists():
+      return None
+    return json.loads(p.read_text()) or None
+  except (OSError, ValueError) as e:
+    logging.warning("Could not load digests from %s: %s", path, e)
+    return None
+
+
+def _write_digests(path: epath.PathLike, digests: dict[str, str]) -> None:
+  """Writes per-host digests to a JSON file, creating parent dirs."""
+  p = epath.Path(path)
+  p.parent.mkdir(parents=True, exist_ok=True)
+  p.write_text(json.dumps(digests, indent=2))
+
+
+def _clear_pytree(pytree: Any) -> None:
+  """Frees the device arrays held by a pytree."""
+  jax.tree.map(
+      lambda x: x.delete() if isinstance(x, jax.Array) else None, pytree
+  )
+
+
+def _metrics_to_measure(options: SafetensorLoadBenchmarkOptions) -> list[str]:
+  """Returns the metrics to capture (the defaults plus optional tracemalloc).
+
+  The safetensors loader has no TensorStore counters and self-reports its
+  per-host read accounting via `jax.monitoring`, so its per-host bytes/reads
+  ride in on the default `jax_monitoring` capture. Tracemalloc stays opt-in
+  (per-allocation snapshots are expensive).
+
+  Args:
+    options: Benchmark options; tracemalloc is added when
+      metric_tracemalloc_enabled is set.
+
+  Returns:
+    The metric names to capture for the load.
+  """
+  metrics = metric_lib.default_metrics()
+  if options.metric_tracemalloc_enabled:
+    metrics.append("tracemalloc")
+  return metrics
+
+
+@benchmarks_core.benchmark_options(SafetensorLoadBenchmarkOptions)
+class SafetensorLoadBenchmark(benchmarks_core.BenchmarksGenerator):
+  """Loads a safetensors checkpoint from disk with the sharding-driven path.
+
+  Built for A/B comparison: capture a baseline against one build of orbax,
+  re-run against another, compare. Optional per-host digests carry correctness
+  so verification works without a reference copy in memory.
+  """
+
+  def test_fn(
+      self, context: benchmarks_core.TestContext
+  ) -> benchmarks_core.TestResult:
+    metrics = metric_lib.Metrics()
+    assert (
+        context.pytree is None
+    ), "SafetensorLoadBenchmark does not generate a pytree; it loads one."
+    options = context.options
+    assert isinstance(options, SafetensorLoadBenchmarkOptions)
+    logging.info("Benchmark options: %s", pprint.pformat(options))
+
+    metrics_to_measure = _metrics_to_measure(options)
+    assert options.checkpoint_path is not None
+    checkpoint_path = epath.Path(options.checkpoint_path)
+    load_trace = context.trace_path("load")
+
+    with ocp.Context(context=options.context):
+      metadata = ocp.metadata(checkpoint_path)
+      if options.sharding_config_path:
+        abstract_pytree = (
+            checkpoint_generation.get_abstract_state_from_sharding_config(
+                epath.Path(options.sharding_config_path),
+                metadata.metadata,
+                devices=jax.devices(),
+            )
+        )
+      else:
+        abstract_pytree = _replicated_abstract_state(metadata.metadata)
+
+      if load_trace is not None:
+        jax.profiler.start_trace(str(load_trace))
+      with metrics.measure("load", metrics_to_measure):
+        restored_pytree = ocp.load(
+            checkpoint_path, abstract_state=abstract_pytree
+        )
+      if load_trace is not None:
+        jax.profiler.stop_trace()
+
+    # Correctness digests are per-host: `digest_pytree` hashes the shards this
+    # process owns, so capture and compare are per-host files in a directory.
+    # Under a fixed sharding, host i owns the same shards on both runs, so each
+    # host verifies its own slice — correct for sharded multi-host loads, not
+    # just single-host / replicated ones. A run either captures or compares.
+    host_file = f"host_{jax.process_index():05d}.json"
+    if options.capture_digests_path:
+      _write_digests(
+          epath.Path(options.capture_digests_path) / host_file,
+          pytree_utils.digest_pytree(restored_pytree),
+      )
+    elif options.reference_digests_path:
+      reference_digests = _load_digests(
+          epath.Path(options.reference_digests_path) / host_file
+      )
+      if reference_digests:
+        pytree_utils.assert_digests_match(reference_digests, restored_pytree)
+    _clear_pytree(restored_pytree)
+    # Inventory the checkpoint we loaded (not the empty per-run dir the
+    # framework would otherwise scan) so the card's on-disk size — and the
+    # per-host bytes-read sharding check against it — are real. Primary only:
+    # the result is suite-level and a parallel walk would race.
+    checkpoint_inventory = None
+    if jax.process_index() == 0:
+      checkpoint_inventory = inventory_lib.scan_checkpoint(checkpoint_path)
+    return benchmarks_core.TestResult(
+        metrics=metrics, inventory=checkpoint_inventory
+    )

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/load_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/load_benchmark_test.py
@@ -1,0 +1,120 @@
+# Copyright 2026 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the SafetensorLoadBenchmark generator class."""
+
+import os
+import tempfile
+
+from absl.testing import absltest
+import numpy as np
+from orbax.checkpoint._src.testing.benchmarks.core import configs as benchmark_configs
+from orbax.checkpoint._src.testing.benchmarks.safetensor import load_benchmark as slb
+import safetensors.numpy as st_np
+
+
+def _small_fixture(d: str) -> str:
+  """Writes a tiny 2-tensor `model.safetensors` for the load smoke test."""
+  st_np.save_file(
+      {
+          "w": np.zeros((32, 32), dtype=np.float32),
+          "b": np.zeros((32,), dtype=np.float32),
+      },
+      os.path.join(d, "model.safetensors"),
+  )
+  return d
+
+
+class OptionsTest(absltest.TestCase):
+
+  def test_requires_checkpoint_path(self):
+    opts = slb.SafetensorLoadBenchmarkOptions()
+    self.assertFalse(opts.is_valid())
+
+  def test_with_path_is_valid(self):
+    opts = slb.SafetensorLoadBenchmarkOptions(checkpoint_path="/tmp/x")
+    self.assertTrue(opts.is_valid())
+
+  def test_context_pins_safetensors_layout(self):
+    from orbax.checkpoint import v1 as ocp
+
+    opts = slb.SafetensorLoadBenchmarkOptions(checkpoint_path="/tmp/x")
+    ctx = opts.context
+    self.assertEqual(
+        ctx.checkpoint_layout,
+        ocp.options.CheckpointLayout.SAFETENSORS,
+    )
+
+
+class GenerationTest(absltest.TestCase):
+
+  def test_generator_emits_one_benchmark_per_option_combo(self):
+    opts = slb.SafetensorLoadBenchmarkOptions(checkpoint_path="/tmp/x")
+    gen = slb.SafetensorLoadBenchmark(
+        checkpoint_configs=[benchmark_configs.CheckpointConfig()],
+        options=opts,
+    )
+    benchmarks = gen.generate(skip_incompatible_mesh_configs=False)
+    self.assertGreaterEqual(len(benchmarks), 1)
+
+
+class LoadFlowTest(absltest.TestCase):
+  """Smoke test that the test_fn actually loads through SafetensorsLayout.
+
+  Runs against a tiny local safetensors file on a single process.
+  Multi-host behaviour is covered by the docker smoke harness, not here.
+  """
+
+  def test_loads_local_safetensors(self):
+    with tempfile.TemporaryDirectory() as d:
+      _small_fixture(d)
+      opts = slb.SafetensorLoadBenchmarkOptions(checkpoint_path=d)
+      gen = slb.SafetensorLoadBenchmark(
+          checkpoint_configs=[benchmark_configs.CheckpointConfig()],
+          options=opts,
+      )
+      generated = gen.generate(skip_incompatible_mesh_configs=False)
+      bench = generated[0]
+      result = bench.run(repeat_index=0)
+      self.assertTrue(result.is_successful(), msg=str(result.error))
+      # Time scalar surfaces under the standard 0_basics/ namespace.
+      time_keys = [
+          k
+          for k in result.metrics.results
+          if k.startswith("load::0_basics/time_s")
+      ]
+      self.assertNotEmpty(time_keys)
+
+  def test_digests_captured_to_path(self):
+    with tempfile.TemporaryDirectory() as d:
+      _small_fixture(d)
+      digests_dir = os.path.join(d, "digests")
+      opts = slb.SafetensorLoadBenchmarkOptions(
+          checkpoint_path=d,
+          capture_digests_path=digests_dir,
+      )
+      gen = slb.SafetensorLoadBenchmark(
+          checkpoint_configs=[benchmark_configs.CheckpointConfig()],
+          options=opts,
+      )
+      bench = gen.generate(skip_incompatible_mesh_configs=False)[0]
+      result = bench.run(repeat_index=0)
+      self.assertTrue(result.is_successful(), msg=str(result.error))
+      # This host's per-leaf digests were written to host_<idx>.json.
+      host_file = os.path.join(digests_dir, "host_00000.json")
+      self.assertTrue(os.path.exists(host_file))
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/load_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/load_benchmark_test.py
@@ -95,6 +95,14 @@ class LoadFlowTest(absltest.TestCase):
           if k.startswith("load::0_basics/time_s")
       ]
       self.assertNotEmpty(time_keys)
+      # The loader self-reports per-host reads via jax.monitoring, so the load
+      # card populates even though there are no TensorStore counters.
+      self.assertIn(
+          "load::6_io/file_bytes_read_per_host", result.metrics.results
+      )
+      self.assertIn(
+          "load::6_io/file_reads_per_host_count", result.metrics.results
+      )
 
   def test_digests_captured_to_path(self):
     with tempfile.TemporaryDirectory() as d:

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/prepare.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensor/prepare.py
@@ -1,0 +1,247 @@
+# Copyright 2026 The Orbax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One-shot prep for the safetensors load benchmark: stage a model + spec.
+
+Downloads a model from the HF Hub (`--repo`) or reads an already-staged copy
+(`--local-dir`, may be `gs://`), then optionally mirrors it to GCS (`--gcs`) and
+optionally writes the per-tensor sharding JSON the benchmark consumes
+(`--sharding-out`, one `--strategy` per run). Example:
+
+  python -m orbax.checkpoint._src.testing.benchmarks.safetensor.prepare \\
+      --repo mistralai/Mistral-7B-v0.1 \\
+      --gcs gs://orbax-benchmarks/fixtures/mistral7b/ \\
+      --axis-size 8 --strategy fsdp \\
+      --sharding-out gs://orbax-benchmarks/sharding/mistral7b_fsdp8.json
+
+Needs `huggingface_hub` for `--repo` (plus `HF_TOKEN` for gated models) and an
+authenticated `gsutil` for `--gcs`.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import subprocess
+import tempfile
+
+from absl import app
+from absl import flags
+from etils import epath
+
+# u64 little-endian header length, then that many bytes of JSON.
+_HEADER_LEN_BYTES = 8
+
+# Safetensors dtype string -> the name jnp.dtype() accepts; others are rejected.
+_DTYPE_TO_JNP_NAME = {
+    "BOOL": "bool_",
+    "I8": "int8",
+    "U8": "uint8",
+    "I16": "int16",
+    "U16": "uint16",
+    "I32": "int32",
+    "U32": "uint32",
+    "I64": "int64",
+    "U64": "uint64",
+    "F16": "float16",
+    "F32": "float32",
+    "F64": "float64",
+    "BF16": "bfloat16",
+    "F8_E5M2": "float8_e5m2",
+    "F8_E4M3": "float8_e4m3fn",
+}
+
+
+def _read_safetensors_header(path: epath.Path) -> dict:
+  """Reads the JSON header of one `.safetensors` file (a small ranged read)."""
+  with path.open("rb") as f:
+    (header_len,) = struct.unpack("<Q", f.read(_HEADER_LEN_BYTES))
+    return json.loads(f.read(header_len))
+
+
+def _fsdp_spec(
+    shape: list[int], axis_name: str, axis_size: int
+) -> list[str | None]:
+  """Leading-dim FSDP spec; replicated when dim 0 isn't divisible by axis_size."""
+  if len(shape) >= 2 and shape[0] % axis_size == 0:
+    return [axis_name] + [None] * (len(shape) - 1)
+  return [None] * len(shape)
+
+
+def _tp_inner_spec(
+    shape: list[int], axis_name: str, axis_size: int
+) -> list[str | None]:
+  """Last-axis (inner-dim) TP spec; replicated if the last dim isn't divisible."""
+  if len(shape) >= 2 and shape[-1] % axis_size == 0:
+    return [None] * (len(shape) - 1) + [axis_name]
+  return [None] * len(shape)
+
+
+# strategy -> (mesh axis name, per-tensor spec function)
+_STRATEGIES = {
+    "fsdp": ("fsdp", _fsdp_spec),
+    "tp_inner": ("tp", _tp_inner_spec),
+}
+
+
+def build_config(model_dir: epath.Path, axis_size: int, strategy: str) -> dict:
+  """Builds the `{name: {shape, dtype, sharding}}` map for every tensor.
+
+  Args:
+    model_dir: Directory of `*.safetensors` files (local or `gs://`).
+    axis_size: Size of the single mesh axis to shard along.
+    strategy: One of `_STRATEGIES`.
+
+  Returns:
+    The sharding-config map `get_abstract_state_from_sharding_config` consumes.
+
+  Raises:
+    ValueError: If `strategy` is unknown, no tensors are found, or a dtype is
+      unsupported.
+  """
+  try:
+    axis_name, spec_fn = _STRATEGIES[strategy]
+  except KeyError as e:
+    raise ValueError(
+        f"Unknown strategy {strategy!r}; supported: "
+        + ", ".join(sorted(_STRATEGIES))
+    ) from e
+  mesh = {"shape": [axis_size], "axes": [axis_name]}
+  files = sorted(model_dir.glob("*.safetensors"))
+  if not files:
+    raise ValueError(
+        f"No `.safetensors` files found under {model_dir}. A cached HF model "
+        "lives under $HF_HOME/hub/models--<org>--<repo>/snapshots/<sha>/."
+    )
+  out: dict[str, dict] = {}
+  for f in files:
+    for name, info in _read_safetensors_header(f).items():
+      if name == "__metadata__":
+        continue
+      if name in out:
+        raise ValueError(
+            f"Tensor {name!r} appears in more than one file under {model_dir}; "
+            "check the model's index file."
+        )
+      dtype = info["dtype"]
+      if dtype not in _DTYPE_TO_JNP_NAME:
+        raise ValueError(
+            f"Tensor {name!r} has unsupported dtype {dtype!r}; supported: "
+            + ", ".join(sorted(_DTYPE_TO_JNP_NAME))
+        )
+      shape = list(info["shape"])
+      out[name] = {
+          "shape": shape,
+          "dtype": _DTYPE_TO_JNP_NAME[dtype],
+          "sharding": {"mesh": mesh, "spec": spec_fn(shape, axis_name, axis_size)},
+      }
+  return out
+
+
+def _snapshot_download(repo_id: str, dest: epath.Path) -> epath.Path:
+  """Downloads a repo's `*.safetensors` (+ index) from the HF Hub to `dest`."""
+  try:
+    from huggingface_hub import snapshot_download  # pylint: disable=g-import-not-at-top
+  except ImportError as e:
+    raise SystemExit(
+        "huggingface_hub is required for --repo; install with "
+        "`pip install huggingface_hub`."
+    ) from e
+  return epath.Path(
+      snapshot_download(
+          repo_id=repo_id,
+          local_dir=str(dest),
+          allow_patterns=["*.safetensors", "*.safetensors.index.json"],
+      )
+  )
+
+
+def _mirror_to_gcs(local_dir: epath.Path, gcs_uri: str) -> None:
+  """Mirrors a model dir to GCS via `gsutil -m rsync` (streams; idempotent)."""
+  subprocess.run(
+      ["gsutil", "-m", "rsync", "-r", str(local_dir), gcs_uri], check=True
+  )
+
+
+def _write_sharding(
+    model_dir: epath.Path, axis_size: int, strategy: str, out: str
+) -> int:
+  """Builds the sharding config from `model_dir` and writes it to `out`."""
+  cfg = build_config(model_dir, axis_size, strategy)
+  dest = epath.Path(out)
+  if dest.parent and "://" not in out:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+  dest.write_text(json.dumps(cfg, indent=2))
+  return len(cfg)
+
+
+_REPO = flags.DEFINE_string("repo", None, "HF Hub repo id to download.")
+_LOCAL_DIR = flags.DEFINE_string(
+    "local_dir",
+    None,
+    "Already-staged model dir (local or gs://) to read instead.",
+)
+_GCS = flags.DEFINE_string(
+    "gcs", None, "Mirror the model's safetensors to this gs:// bucket."
+)
+_SHARDING_OUT = flags.DEFINE_string(
+    "sharding_out", None, "Write the sharding JSON here (local or gs://)."
+)
+_AXIS_SIZE = flags.DEFINE_integer(
+    "axis_size",
+    None,
+    "Mesh axis size (= participating devices); needs --sharding_out.",
+)
+_STRATEGY = flags.DEFINE_enum(
+    "strategy",
+    "fsdp",
+    sorted(_STRATEGIES),
+    "fsdp splits dim 0 (contiguous); tp_inner splits the last dim.",
+)
+_DOWNLOAD_DIR = flags.DEFINE_string(
+    "download_dir", None, "Keep the --repo download here instead of a temp dir."
+)
+
+flags.mark_flags_as_mutual_exclusion(["repo", "local_dir"], required=True)
+
+
+def main(argv: list[str]) -> None:
+  del argv  # Unused; inputs come from flags.
+  if not _GCS.value and not _SHARDING_OUT.value:
+    raise app.UsageError("nothing to do: pass --gcs and/or --sharding_out.")
+  if _SHARDING_OUT.value and _AXIS_SIZE.value is None:
+    raise app.UsageError("--sharding_out requires --axis_size.")
+
+  def _run(model_dir: epath.Path) -> None:
+    if _GCS.value:
+      print(f">>> Mirroring {model_dir} -> {_GCS.value}")
+      _mirror_to_gcs(model_dir, _GCS.value)
+    if _SHARDING_OUT.value:
+      n = _write_sharding(
+          model_dir, _AXIS_SIZE.value, _STRATEGY.value, _SHARDING_OUT.value
+      )
+      print(f">>> Wrote {n} tensor entries to {_SHARDING_OUT.value}")
+
+  if _REPO.value:
+    if _DOWNLOAD_DIR.value:
+      _run(_snapshot_download(_REPO.value, epath.Path(_DOWNLOAD_DIR.value)))
+    else:
+      with tempfile.TemporaryDirectory(prefix="safetensors-prepare-") as td:
+        _run(_snapshot_download(_REPO.value, epath.Path(td)))
+  else:
+    _run(epath.Path(_LOCAL_DIR.value))
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
@@ -15,10 +15,11 @@
 """Defines `SafetensorsLayout`, a class to handle Safetensors checkpoint formats."""
 
 import asyncio
+from collections.abc import Awaitable
 import dataclasses
 import json
 import time
-from typing import Any, Awaitable, cast
+from typing import Any, cast
 
 from absl import logging
 import jax

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
@@ -396,6 +396,26 @@ def _build_transient_array(
     raise e
 
 
+def _record_read_stats(bytes_read: int, num_reads: int) -> None:
+  """Reports this host's safetensors read accounting via `jax.monitoring`.
+
+  Emitted once per load so a benchmark can compare this loader against the
+  sharding-driven one on the same per-host bytes/reads channel. It publishes
+  only `bytes_read` and `num_reads`; this loader reads each bundle in a single
+  contiguous read with no chunking, so `storage_reads` would equal `num_reads`.
+
+  Args:
+    bytes_read: Total data bytes this host read from storage.
+    num_reads: Number of read operations this host issued.
+  """
+  jax.monitoring.record_scalar(
+      "/jax/orbax/read/safetensors/bytes_read", float(bytes_read)
+  )
+  jax.monitoring.record_scalar(
+      "/jax/orbax/read/safetensors/num_reads", float(num_reads)
+  )
+
+
 class _SingleFileLoader:
   """Single-file loader for Safetensors checkpoints."""
 
@@ -442,8 +462,8 @@ class _SingleFileLoader:
       bundle_start_offset = 0
     return bundle_bytes, bundle_start_offset
 
-  async def load_single_host(self) -> dict[str, np.ndarray]:
-    """Loads tensors from a safetensors file into host NumPy arrays."""
+  async def load_single_host(self) -> tuple[dict[str, np.ndarray], int]:
+    """Loads all tensors into host NumPy arrays; returns (tensors, bytes_read)."""
     header, data_start_offset = await self.read_header()
     tensors = {}
     async with async_path.open_file(self.path, mode="rb") as f:
@@ -459,7 +479,7 @@ class _SingleFileLoader:
       if not np.isfinite(np_array).all():
         raise ValueError(f"Non-finite values found in tensor {name}.")
       tensors[name] = np_array
-    return tensors
+    return tensors, len(data_bytes)
 
   async def load_multi_host(
       self, abstract_state: dict[str, Any]
@@ -484,7 +504,8 @@ class _SingleFileLoader:
     Returns:
       A tuple containing:
         - A dictionary mapping tensor names to restored jax.Arrays.
-        - A dictionary containing metrics (io_time, reshard_time).
+        - A dictionary of metrics (io_time, reshard_time, bytes_read,
+          num_reads) for this host.
 
     Raises:
       ValueError: If the number of devices is not uniform across hosts, or if a
@@ -565,7 +586,13 @@ class _SingleFileLoader:
         )
         reshard_time += time.time() - t0
 
-    return restored_pytree, {"io_time": io_time, "reshard_time": reshard_time}
+    return restored_pytree, {
+        "io_time": io_time,
+        "reshard_time": reshard_time,
+        # This host reads its bundle in one contiguous read (or none if empty).
+        "bytes_read": len(bundle_bytes),
+        "num_reads": 1 if bundle_bytes else 0,
+    }
 
 
 class _MultiFileLoader:
@@ -592,11 +619,17 @@ class _MultiFileLoader:
       load_ops.append(loader.load_single_host())
 
     restored_pytree = {}
-    for file_tensors in await asyncio.gather(*load_ops):
+    total_bytes_read = 0
+    num_reads = 0
+    for file_tensors, bytes_read in await asyncio.gather(*load_ops):
+      total_bytes_read += bytes_read
+      num_reads += 1  # one whole-file data read per file.
       for name, arr in file_tensors.items():
         if name in restored_pytree:
           raise ValueError(f"Duplicate tensor {name} found in multiple files.")
         restored_pytree[name] = arr
+
+    _record_read_stats(total_bytes_read, num_reads)
 
     logging.info(
         "[safetensors][single-host] Loaded tensors in %.0fs",
@@ -644,13 +677,19 @@ class _MultiFileLoader:
     restored_pytree = {}
     total_io_time = 0.0
     total_reshard_time = 0.0
+    total_bytes_read = 0
+    total_num_reads = 0
     for file_tensors, metrics in await asyncio.gather(*load_ops):
       total_io_time += metrics["io_time"]
       total_reshard_time += metrics["reshard_time"]
+      total_bytes_read += metrics["bytes_read"]
+      total_num_reads += metrics["num_reads"]
       for name, arr in file_tensors.items():
         if name in restored_pytree:
           raise ValueError(f"Duplicate tensor {name} found in multiple files.")
         restored_pytree[name] = arr
+
+    _record_read_stats(total_bytes_read, total_num_reads)
 
     # Validate that all requested tensors were found in at least one file.
     for k in abstract_state:

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_test.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_test.py
@@ -380,5 +380,18 @@ class GetTensorBundlesTest(parameterized.TestCase):
     self.assertEqual(bundles, [['tensor1'], ['tensor2', 'tensor3']])
 
 
+class RecordReadStatsTest(absltest.TestCase):
+  """`_record_read_stats` reports per-host bytes/reads via jax.monitoring."""
+
+  def test_emits_bytes_and_reads_only(self):
+    with mock.patch.object(jax.monitoring, 'record_scalar') as rec:
+      safetensors_layout._record_read_stats(bytes_read=2048, num_reads=3)
+    emitted = {c.args[0]: c.args[1] for c in rec.call_args_list}
+    self.assertEqual(emitted['/jax/orbax/read/safetensors/bytes_read'], 2048.0)
+    self.assertEqual(emitted['/jax/orbax/read/safetensors/num_reads'], 3.0)
+    # storage_reads would equal num_reads for this loader, so it is not emitted.
+    self.assertNotIn('/jax/orbax/read/safetensors/storage_reads', emitted)
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
## Description

Adds a load-only benchmark for HuggingFace-format safetensors checkpoints under
`_src/testing/benchmarks/safetensor/`, for A/B-comparing the safetensors load
path across revisions:

- `SafetensorLoadBenchmark` generator + tiered model configs (GPT-2 through
  DeepSeek-V3 / Llama-3-405B, in leading-dim FSDP and inner-dim TP variants),
  staged by `prepare.py` — it downloads a model from the HF Hub, optionally
  mirrors it to GCS, and emits the per-tensor sharding spec read from the
  safetensors headers. Per-host SHA-256 digests carry load correctness.
- The current (transient-array) safetensors loader now self-reports per-host
  read accounting via `jax.monitoring`
  (`/jax/orbax/read/safetensors/bytes_read`, `num_reads`). It has no TensorStore
  counters, so this is what lets the benchmark's per-host bytes/reads card
  populate — and lets a future loader change be A/B'd against this baseline on
  the same channel. Telemetry only; load behavior is unchanged.

Builds on the per-name benchmark card work merged in #3395.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or a public API)
- [x] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover this change and pass locally.
- [x] Public APIs and non-trivial functions are documented.
- [ ] N/A — internal benchmark tooling + loader telemetry, not user-facing.
