### PR TITLE
fix(security): pin etils-actions/pypi-auto-publish to commit SHA in publish workflows

### DIFF
--- a/.github/workflows/auto-publish-dry-run.yml
+++ b/.github/workflows/auto-publish-dry-run.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'google/orbax'
     steps:
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1
       with:
         pypi-token: skip  # Skips PyPI upload
         # Omitting gh-token skips GitHub release creation

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     # 1. Publish the sub-packages first
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1
       with:
         pypi-token: ${{ secrets.PYPI_API_TOKEN_OBX_CKPT }}
         gh-token: ${{ secrets.GH_PUBLISH_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     # 1. Publish the sub-packages first
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1
       with:
         # NOTE: Do not use gh-token here, as it would conflict with orbax-checkpoint.
         pypi-token: ${{ secrets.PYPI_API_TOKEN_OBX_EXPT }}


### PR DESCRIPTION
## Summary

The `auto-publish.yml` and `auto-publish-dry-run.yml` workflows use a **mutable tag reference** for a third-party action:

```yaml
uses: etils-actions/pypi-auto-publish@v1   # ← tag-pinned, not SHA-pinned
```

`etils-actions/pypi-auto-publish` is a small third-party action (~10 GitHub stars). If the `v1` tag is silently redirected — via a compromised maintainer account, a tag deletion + recreation, or a GitHub account takeover — the malicious version executes **in the same job that holds `PYPI_API_TOKEN` and `GH_PUBLISH_TOKEN`**.

## Impact

- **`PYPI_API_TOKEN_OBX_CKPT`** — publishes `orbax-checkpoint` to PyPI. A compromised token enables injecting backdoored releases into a package installed across the JAX ecosystem.
- **`GH_PUBLISH_TOKEN`** — GitHub PAT; enables creating spurious tags/releases or further repo manipulation.
- Trigger: **every push to `main`** — no manual approval gate.

## Fix

Pin to the exact commit SHA of the current `v1` tag:

| Before | After |
|---|---|
| `etils-actions/pypi-auto-publish@v1` | `etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1` |

The SHA pins the action code to a specific immutable commit. The `# v1` comment preserves human readability. This is the approach recommended by the [GitHub security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and enforced by tools like OpenSSF Scorecards and `ratchet`.