### PR TITLE
Drive safetensors load by the target sharding with bounded concurrent ranged reads

### DIFF
--- a/checkpoint/CHANGELOG.md
+++ b/checkpoint/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce Memory Pressure from long held CPU buffers in Pathways MTC
 - Support explicit devices for Pathways MTC init
 
+### Changed
+
+- #v1 Drive the safetensors load by the target sharding: each process reads
+only the byte ranges its own devices need (coalesced under
+`SafetensorsOptions.max_over_read_ratio`, fetched as concurrent fixed-size
+ranged reads bounded by `MemoryOptions.read_concurrent_bytes`), replacing
+the transient-array resharding load. Supports arbitrary shardings,
+including inner-dimension partitions.
+
 ## [0.12.1] - 2026-06-24
 
 ### Added

--- a/checkpoint/CHANGELOG.md
+++ b/checkpoint/CHANGELOG.md
@@ -16,10 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - #v1 Drive the safetensors load by the target sharding: each process reads
 only the byte ranges its own devices need (coalesced under
-`SafetensorsOptions.max_over_read_ratio`, fetched as concurrent fixed-size
-ranged reads bounded by `MemoryOptions.read_concurrent_bytes`), replacing
-the transient-array resharding load. Supports arbitrary shardings,
-including inner-dimension partitions.
+`SafetensorsOptions.max_over_read_ratio`, fetched as concurrent ranged
+reads of `SafetensorsOptions.read_chunk_bytes` each, bounded by
+`MemoryOptions.read_concurrent_bytes`), replacing the transient-array
+resharding load. Supports arbitrary shardings, including inner-dimension
+partitions.
 
 ## [0.12.1] - 2026-06-24
 

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/configs/llama3-405b.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/configs/llama3-405b.yaml
@@ -8,8 +8,11 @@
 #     of byte runs to bin-pack);
 #   * per-host shard sizes are tiny relative to file sizes (4 GB
 #     shards out of 100+ GB files);
-#   * concurrent reads cap (`_MAX_CONCURRENT_READS`) is the active
-#     bottleneck, not bandwidth.
+#   * the byte budget (`max_in_flight_bytes`, default 2 GiB) governs
+#     concurrency by total bytes — so on this tier each read is small
+#     (~4 GB per host, easily within budget) and many reads run
+#     concurrently. Raise the budget on RAM-rich hosts to absorb the
+#     larger coalesced blocks cross-tensor coalescing produces.
 #
 # Llama 3 405B is gated; see safetensor_load_llama3-8b.yaml.
 # GCS pre-staging is *strongly* recommended -- 810 GB download per VM

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/configs/mistral7b_tp_ratio_sweep.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/configs/mistral7b_tp_ratio_sweep.yaml
@@ -1,0 +1,42 @@
+# Sweeps `safetensors_max_over_read_ratio` on Mistral 7B inner-dim TP.
+#
+# Standalone bench (not capture/compare): demonstrates the tradeoff the
+# new `max_over_read_ratio` knob controls on a real strided-shard load.
+# Same model + mesh as `mistral7b_tp_capture.yaml`; only the ratio varies.
+#
+# Per the design doc §10.3, raising the ratio trades per-host over-read
+# for fewer RTTs. On GCS, the win is large (~30 ms RTT per ranged GET).
+# This YAML measures the curve so the right default per backend is
+# data-driven rather than guessed.
+#
+# Run as:
+#   python -m orbax.checkpoint._src.testing.benchmarks.run_benchmarks \
+#     --config_file=checkpoint/.../configs/mistral7b_tp_ratio_sweep.yaml \
+#     --output_directory=gs://orbax-benchmarks/runs/$USER/ratio_sweep/
+#
+# Watch in the dashboard:
+#   * `6_io/file_reads_per_host_count` -- decreases as ratio rises.
+#   * `6_io/file_bytes_read_per_host` -- increases as ratio rises
+#     (bounded at `ratio x ideal`).
+#   * `load_4_throughput/load_total_gbps` -- the headline. The sweet
+#     spot is where RTT savings stop overcoming the over-read cost.
+#
+# Requires the new sharding-driven loader (`max_over_read_ratio` knob
+# is exposed only after the loader change merges).
+
+suite_name: "safetensor_load_mistral7b_tp_ratio_sweep"
+num_repeats: 4
+
+mesh_config:
+  mesh_axes: ["tp"]
+  ici_parallelism: {"tp": 8}
+
+benchmarks:
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+    options:
+      checkpoint_path: "gs://orbax-benchmarks/fixtures/mistral7b/"
+      sharding_config_path: "gs://orbax-benchmarks/sharding/mistral7b_tp8.json"
+      enable_trace: true
+      # The sweep. Each value becomes a separate run in the dashboard;
+      # the parallel-coordinates view colors them so the curve is visible.
+      safetensors_max_over_read_ratio: [2.0, 3.0, 4.0, 6.0]

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/configs/mistral7b_tp_ratio_sweep.yaml
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/configs/mistral7b_tp_ratio_sweep.yaml
@@ -2,12 +2,12 @@
 #
 # Standalone bench (not capture/compare): demonstrates the tradeoff the
 # new `max_over_read_ratio` knob controls on a real strided-shard load.
-# Same model + mesh as `mistral7b_tp_capture.yaml`; only the ratio varies.
+# Same model + mesh as `mistral7b_tp.yaml`; only the ratio varies.
 #
-# Per the design doc §10.3, raising the ratio trades per-host over-read
-# for fewer RTTs. On GCS, the win is large (~30 ms RTT per ranged GET).
-# This YAML measures the curve so the right default per backend is
-# data-driven rather than guessed.
+# Raising the ratio trades per-host over-read for fewer RTTs. On GCS,
+# the win is large (~30 ms RTT per ranged GET). This YAML measures the
+# curve so the right default per backend is data-driven rather than
+# guessed.
 #
 # Run as:
 #   python -m orbax.checkpoint._src.testing.benchmarks.run_benchmarks \
@@ -32,10 +32,10 @@ mesh_config:
   ici_parallelism: {"tp": 8}
 
 benchmarks:
-  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensor.load_benchmark.SafetensorLoadBenchmark"
+  - generator: "orbax.checkpoint._src.testing.benchmarks.safetensors.load_benchmark.SafetensorLoadBenchmark"
     options:
-      checkpoint_path: "gs://orbax-benchmarks/fixtures/mistral7b/"
-      sharding_config_path: "gs://orbax-benchmarks/sharding/mistral7b_tp8.json"
+      checkpoint_path: "gs://orbax-benchmarks/st_fixtures/mistral7b/"
+      sharding_config_path: "gs://orbax-benchmarks/st_fixtures/sharding/mistral7b_tp8.json"
       enable_trace: true
       # The sweep. Each value becomes a separate run in the dashboard;
       # the parallel-coordinates view colors them so the curve is visible.

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/load_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/load_benchmark.py
@@ -50,8 +50,9 @@ class SafetensorLoadBenchmarkOptions(benchmarks_core.BenchmarkOptions):
 
   Self-contained: builds its own `ocp.Context()` with the SAFETENSORS layout
   pinned from the load-side tuning knobs, so a single run can sweep e.g.
-  `use_load_and_broadcast` or `restore_concurrent_gb` for A/B comparison. Each
-  knob may be a single value or a list to expand into a parameter sweep.
+  `use_load_and_broadcast`, `restore_concurrent_gb`, or
+  `safetensors_max_over_read_ratio` for A/B comparison. Each knob may be a
+  single value or a list to expand into a parameter sweep.
 
   Attributes:
     checkpoint_path: Path (local or `gs://`) to a directory containing one or
@@ -74,6 +75,12 @@ class SafetensorLoadBenchmarkOptions(benchmarks_core.BenchmarkOptions):
       others instead of every replica reading from storage.
     restore_concurrent_gb: Cap on concurrent read bytes (in GiB); `None` leaves
       the Orbax default.
+    safetensors_max_over_read_ratio: Override for
+      `SafetensorsOptions.max_over_read_ratio`. Bounds per-host cluster egress
+      on strided shardings (inner-dim TP, HSDP). Sweep as `[2.0, 3.0, 4.0]` on a
+      TP variant to measure the read-count vs over-read tradeoff. `None`
+      (default) uses the loader's default (currently 2.0). In-flight read bytes
+      are bounded by `restore_concurrent_gb` (shared with the rest of restore).
     metric_tracemalloc_enabled: Whether to capture the tracemalloc metric
       (opt-in because its per-allocation snapshots are expensive).
   """
@@ -84,6 +91,7 @@ class SafetensorLoadBenchmarkOptions(benchmarks_core.BenchmarkOptions):
   reference_digests_path: str | None = None
   use_load_and_broadcast: bool | list[bool] = False
   restore_concurrent_gb: int | None | list[int | None] = None
+  safetensors_max_over_read_ratio: float | None | list[float | None] = None
   metric_tracemalloc_enabled: bool = False
 
   def is_valid(self) -> bool:
@@ -94,7 +102,10 @@ class SafetensorLoadBenchmarkOptions(benchmarks_core.BenchmarkOptions):
   @property
   def context(self) -> ocp.Context:
     ctx = ocp.Context(
-        checkpoint_layout=ocp.options.CheckpointLayout.SAFETENSORS
+        checkpoint_layout=ocp.options.CheckpointLayout.SAFETENSORS,
+        safetensors_options=ocp.options.SafetensorsOptions(
+            max_over_read_ratio=self.safetensors_max_over_read_ratio,
+        ),
     )
     # TODO(b/519204863): Fix type hint for args like list[T] | T
     ctx.array.loading.use_load_and_broadcast = self.use_load_and_broadcast

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/load_benchmark.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/load_benchmark.py
@@ -81,6 +81,12 @@ class SafetensorLoadBenchmarkOptions(benchmarks_core.BenchmarkOptions):
       TP variant to measure the read-count vs over-read tradeoff. `None`
       (default) uses the loader's default (currently 2.0). In-flight read bytes
       are bounded by `restore_concurrent_gb` (shared with the rest of restore).
+    safetensors_read_chunk_mb: Override for
+      `SafetensorsOptions.read_chunk_bytes`, in MiB. Coalesced blocks are
+      split at this size into concurrent ranged reads; sweep as
+      `[64, 128, 512]` to measure the request-count vs read-parallelism
+      tradeoff on a given storage backend. `None` (default) uses the loader's
+      default (currently 128 MiB).
     metric_tracemalloc_enabled: Whether to capture the tracemalloc metric
       (opt-in because its per-allocation snapshots are expensive).
   """
@@ -92,6 +98,7 @@ class SafetensorLoadBenchmarkOptions(benchmarks_core.BenchmarkOptions):
   use_load_and_broadcast: bool | list[bool] = False
   restore_concurrent_gb: int | None | list[int | None] = None
   safetensors_max_over_read_ratio: float | None | list[float | None] = None
+  safetensors_read_chunk_mb: int | None | list[int | None] = None
   metric_tracemalloc_enabled: bool = False
 
   def is_valid(self) -> bool:
@@ -105,6 +112,11 @@ class SafetensorLoadBenchmarkOptions(benchmarks_core.BenchmarkOptions):
         checkpoint_layout=ocp.options.CheckpointLayout.SAFETENSORS,
         safetensors_options=ocp.options.SafetensorsOptions(
             max_over_read_ratio=self.safetensors_max_over_read_ratio,
+            read_chunk_bytes=(
+                self.safetensors_read_chunk_mb * 1024**2
+                if self.safetensors_read_chunk_mb is not None
+                else None
+            ),
         ),
     )
     # TODO(b/519204863): Fix type hint for args like list[T] | T

--- a/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/load_benchmark_test.py
+++ b/checkpoint/orbax/checkpoint/_src/testing/benchmarks/safetensors/load_benchmark_test.py
@@ -55,6 +55,16 @@ class OptionsTest(absltest.TestCase):
         ocp.options.CheckpointLayout.SAFETENSORS,
     )
 
+  def test_context_maps_safetensors_knobs(self):
+    opts = slb.SafetensorLoadBenchmarkOptions(
+        checkpoint_path="/tmp/x",
+        safetensors_max_over_read_ratio=3.0,
+        safetensors_read_chunk_mb=64,
+    )
+    ctx = opts.context
+    self.assertEqual(ctx.safetensors_options.max_over_read_ratio, 3.0)
+    self.assertEqual(ctx.safetensors_options.read_chunk_bytes, 64 * 1024**2)
+
 
 class GenerationTest(absltest.TestCase):
 

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/context/options.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/context/options.py
@@ -16,10 +16,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import contextvars
 import dataclasses
 import enum
-from typing import Any, Callable, Protocol
+from typing import Any, Protocol
 
 from etils import epath
 import numpy as np
@@ -31,7 +32,6 @@ from orbax.checkpoint.experimental.v1._src.handlers import registration
 from orbax.checkpoint.experimental.v1._src.path import types as path_types
 from orbax.checkpoint.experimental.v1._src.serialization import types as serialization_types
 from orbax.checkpoint.experimental.v1._src.tree import types as tree_types
-
 
 FROZEN_IDS: contextvars.ContextVar[frozenset[int]] = contextvars.ContextVar(
     'orbax_frozen_option_ids', default=frozenset()
@@ -115,7 +115,9 @@ class AsyncOptions(_ActiveContextGuard):
     return v0_options_lib.AsyncOptions(
         timeout_secs=self.timeout_secs,
         post_finalization_callback=self.post_finalization_callback,
-        create_directories_asynchronously=self.create_directories_asynchronously,
+        create_directories_asynchronously=(
+            self.create_directories_asynchronously
+        ),
     )
 
 
@@ -484,8 +486,10 @@ class CheckpointablesOptions(_ActiveContextGuard):
   """
 
   registry: registration.CheckpointableHandlerRegistry = dataclasses.field(
-      default_factory=lambda: registration.ReadOnlyCheckpointableHandlerRegistry(
-          registration.local_registry(include_global_registry=True)
+      default_factory=lambda: (
+          registration.ReadOnlyCheckpointableHandlerRegistry(
+              registration.local_registry(include_global_registry=True)
+          )
       )
   )
 
@@ -533,11 +537,9 @@ class DeletionOptions(_ActiveContextGuard):
 
     todelete_full_path: str | None = None
 
-
   gcs_deletion_options: GcsDeletionOptions = dataclasses.field(
       default_factory=GcsDeletionOptions
   )
-
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -592,13 +594,20 @@ class MemoryOptions(_ActiveContextGuard):
 class SafetensorsOptions(_ActiveContextGuard):
   """Options for configuring Safetensors loading.
 
+  In-flight read bytes are bounded by `MemoryOptions.read_concurrent_bytes`,
+  shared with the rest of restore (the loader falls back to a 2 GiB default
+  when it is unset, since its streaming path needs a finite budget).
+
   Attributes:
-    ignore_load_sharding: If True, skips sharding of the tensors across
-      hosts/devices during load. Whole tensors will be present on each host,
-      allowing for efficient conversion.
+    max_over_read_ratio: Maximum tolerated `block_size / needed_bytes` when
+      coalescing per-host byte runs from one file into a single read. A higher
+      value collapses more requests at the cost of more over-read; a value of
+      1.0 disables any over-read. Worst-case per-host bytes from one file are
+      bounded at `max_over_read_ratio * ideal_bytes`. `None` selects an
+      implementation default (currently `2.0`).
   """
 
-  ignore_load_sharding: bool = False
+  max_over_read_ratio: float | None = None
 
 
 class CheckpointLayout(enum.Enum):

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/context/options.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/context/options.py
@@ -605,9 +605,18 @@ class SafetensorsOptions(_ActiveContextGuard):
       1.0 disables any over-read. Worst-case per-host bytes from one file are
       bounded at `max_over_read_ratio * ideal_bytes`. `None` selects an
       implementation default (currently `2.0`).
+    read_chunk_bytes: Target size of one ranged read. Coalesced blocks are
+      split at this size and the pieces are read concurrently, so it trades
+      storage request count against read parallelism: larger values issue
+      fewer requests (gentler on request-rate quotas), smaller values fetch
+      with more parallel streams. The effective chunk never exceeds the
+      in-flight budget (`MemoryOptions.read_concurrent_bytes`), which also
+      caps concurrent requests at `budget / read_chunk_bytes` per host.
+      `None` selects an implementation default (currently 128 MiB).
   """
 
   max_over_read_ratio: float | None = None
+  read_chunk_bytes: int | None = None
 
 
 class CheckpointLayout(enum.Enum):

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
@@ -12,21 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Defines `SafetensorsLayout`, a class to handle Safetensors checkpoint formats."""
+"""Defines `SafetensorsLayout`, the handler for Safetensors checkpoints.
+
+Loading is driven by the target sharding: each process resolves which shards of
+each tensor its own devices need, maps those shards to byte ranges in the file,
+and reads exactly those ranges. There is no cross-process communication and no
+XLA compilation -- resharding happens purely through which bytes each process
+reads. This mirrors how the v0 array deserializer
+(`_src/serialization/serialization.py`) drives reads from
+`jax.sharding.Sharding.devices_indices_map`, with hand-computed byte ranges
+standing in for TensorStore's chunk index.
+
+Byte runs from every tensor a process needs in one file are coalesced together
+by a per-file scheduler under a single bounded-over-read policy: a
+`max_over_read_ratio` cap on `block_size / needed_bytes` keeps cross-host
+egress from blowing up to N x file_size on inner-dim sharding. The scheduler
+then issues each coalesced block as one ranged read -- or streams it in
+budget-sized chunks when the block exceeds the in-flight byte budget
+(`MemoryOptions.read_concurrent_bytes`, the shared restore memory cap). Peak
+host memory beyond the destination shard buffers is bounded at that budget
+regardless of block, shard, or file size.
+The single-host degenerate case -- one process owns every byte of a file --
+collapses to one read per file when the file fits the budget, and a small
+number of back-to-back reads otherwise.
+"""
 
 import asyncio
-from collections.abc import Awaitable
+import collections
+from collections.abc import Awaitable, Callable, Sequence
 import dataclasses
+import itertools
 import json
-import time
-from typing import Any, cast
+import math
+from typing import Any, cast, NamedTuple
 
 from absl import logging
+import humanize
 import jax
 import jax.numpy as jnp
 import numpy as np
 from orbax.checkpoint._src.multihost import multihost
 from orbax.checkpoint._src.path import async_path
+from orbax.checkpoint._src.serialization import limits
 from orbax.checkpoint._src.tree import utils as tree_utils
 from orbax.checkpoint.experimental.v1._src.context import context as context_lib
 from orbax.checkpoint.experimental.v1._src.layout import checkpoint_layout
@@ -41,6 +68,38 @@ AbstractCheckpointable = checkpoint_layout.AbstractCheckpointable
 
 HEADER_NUM_BYTES = 8
 SAFETENSORS_SUFFIX = ".safetensors"
+
+# Per-file scheduler defaults. SafetensorsOptions can override either.
+#
+# `_DEFAULT_MAX_OVER_READ_RATIO` caps `block_size / needed_bytes` for any
+# coalesced read; a host's bytes pulled from one file are bounded at
+# `ratio * ideal_bytes`. The default trades up to 1x over-read for fewer
+# requests; the row-parallel inner-dim worst case (which would otherwise
+# collapse to "read the whole file on every host") is bounded at 2x and the
+# partitioner emits more, smaller reads instead.
+_DEFAULT_MAX_OVER_READ_RATIO = 2.0
+# Always coalesce runs separated by less than this gap, regardless of the
+# over-read ratio. Below roughly a page the per-read overhead -- a syscall
+# locally, an RTT on object storage -- dwarfs the cost of reading the gap, so a
+# strict ratio would otherwise shatter tiny strided reads into many microscopic
+# requests. Larger gaps stay governed by `max_over_read_ratio`, where the
+# read-count-vs-egress tradeoff is genuinely backend-dependent.
+_DEFAULT_MIN_COALESCE_GAP = 4096  # one page
+# `_DEFAULT_MAX_IN_FLIGHT_BYTES` caps total bytes the loader holds in flight
+# across all concurrent reads in one load call. A single coalesced block
+# larger than this budget is streamed in budget-sized chunks; smaller blocks
+# run concurrently up to the budget. Peak host memory beyond destination
+# shard buffers is bounded at `max_in_flight_bytes` regardless of block,
+# shard, or file size.
+_DEFAULT_MAX_IN_FLIGHT_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+
+# When the over-read cap fragments a load into many small reads -- the strided
+# inner-dim regime -- hint the user toward `max_over_read_ratio`. The warning
+# fires only when reads-per-file exceeds this factor *and* the achieved
+# over-read stayed near 1x (the cap blocked coalescing, rather than the load
+# genuinely spanning many files).
+_FRAGMENTED_READ_WARN_FACTOR = 8
+_FRAGMENTED_OVER_READ_CEILING = 1.2
 
 
 def _get_dtypes() -> dict[str, Any]:
@@ -65,715 +124,646 @@ def _get_dtypes() -> dict[str, Any]:
 
 
 def _get_array_properties(info: dict[str, Any]) -> tuple[tuple[int, ...], Any]:
-  """Parses shape and `dtype` from a safetensors tensor header."""
+  """Parses shape and dtype from one tensor's safetensors header entry."""
   try:
-    dtype_str = info["dtype"]
-    dtype = _get_dtypes()[dtype_str]
+    dtype = _get_dtypes()[info["dtype"]]
   except KeyError as e:
     raise ValueError(f"Unsupported dtype in SafeTensors header: {e}") from e
-  shape = tuple(info["shape"])
-  return shape, dtype
+  return tuple(info["shape"]), dtype
 
 
-def _should_replicate_array(shape: tuple[int, ...]) -> bool:
-  """Returns True if the array should be replicated across devices."""
-  return len(shape) == 0 or shape[0] < jax.local_device_count()
+async def _read_header(path: Path) -> tuple[dict[str, Any], int]:
+  """Reads a safetensors header, returning it and the data-section offset."""
+  async with async_path.open_file(path, mode="rb") as f:
+    if not (size_bytes := cast(bytes, await f.read(HEADER_NUM_BYTES))):
+      raise ValueError(f"Could not read header size from {path}.")
+    header_size = int.from_bytes(size_bytes, byteorder="little")
+    header_bytes = cast(bytes, await f.read(header_size))
+    if len(header_bytes) != header_size:
+      raise ValueError(f"Could not read header content from {path}.")
+    return json.loads(header_bytes), HEADER_NUM_BYTES + header_size
 
 
-def _get_tensor_bundles(
-    header: dict[str, Any], num_hosts: int
-) -> list[list[str]]:
-  """Partitions tensors in a file into contiguous bundles for each host.
+async def _discover_files(path: Path) -> list[Path]:
+  """Returns the `.safetensors` file(s) at `path` (a file or a directory)."""
+  if await async_path.is_dir(path):
+    return sorted(await async_path.glob(path, f"*{SAFETENSORS_SUFFIX}"))
+  return [path]
 
-  This method distributes tensors to hosts such that each host reads a
-  contiguous block of bytes from the file. It tries to make the total byte
-  size read by each host as close to 1/N as possible, where N is the number of
-  hosts.
 
-  TODO(b/496270336): Very large tensors should be subdivided among hosts. The
-  current approach loads each tensor wholly onto its assigned host. This is
-  efficient for checkpoints with lots of small tensors but can cause OOMs for
-  very large tensors.
+async def _check_file_length(
+    path: Path, header: dict[str, Any], data_start: int
+) -> None:
+  """Fails fast if `path` is too short to hold the tensors its header declares.
+
+  The header records each tensor's `data_offsets` relative to the start of the
+  data section (`data_start` bytes in). A truncated or partially-copied file
+  still parses, but the byte-range reads that follow would run past EOF and
+  surface as a confusing mid-load failure on whichever host owns the missing
+  bytes. One `stat` here turns that into a clear up-front error.
 
   Args:
-    header: The header of the safetensors file.
-    num_hosts: The number of hosts.
+    path: The `.safetensors` file to check.
+    header: The file's parsed JSON header, mapping tensor name to its entry.
+    data_start: Byte offset where the data section begins (`8 + header_size`).
+
+  Raises:
+    ValueError: If the file is shorter than the data its header declares.
+  """
+  required = data_start + max(
+      (
+          info["data_offsets"][1]
+          for name, info in header.items()
+          if name != "__metadata__"
+      ),
+      default=0,
+  )
+  actual = (await async_path.async_stat(path)).length
+  if actual < required:
+    raise ValueError(
+        f"SafeTensors file {path} is truncated: its header declares tensor data"
+        f" through byte {required}, but the file is only {actual} bytes."
+    )
+
+
+def _normalize_index(
+    index: tuple[Any, ...], global_shape: tuple[int, ...]
+) -> tuple[tuple[int, int], ...]:
+  """Converts a sharding index (tuple of slices/ints) into (start, stop) pairs."""
+  bounds = []
+  for dim_index, dim in zip(index, global_shape):
+    if isinstance(dim_index, slice):
+      if dim_index.step not in (None, 1):
+        raise ValueError(f"Strided shard index is unsupported: {dim_index}.")
+      start = dim_index.start or 0
+      stop = dim if dim_index.stop is None else dim_index.stop
+    else:
+      start, stop = int(dim_index), int(dim_index) + 1
+    bounds.append((start, stop))
+  return tuple(bounds)
+
+
+def _byte_strides(global_shape: tuple[int, ...], itemsize: int) -> list[int]:
+  """Row-major byte stride along each dimension."""
+  strides = [itemsize] * len(global_shape)
+  acc = itemsize
+  for i in range(len(global_shape) - 1, -1, -1):
+    strides[i] = acc
+    acc *= global_shape[i]
+  return strides
+
+
+def index_domain_to_byte_runs(
+    bounds: tuple[tuple[int, int], ...],
+    global_shape: tuple[int, ...],
+    itemsize: int,
+    tensor_base: int,
+) -> list[tuple[int, int]]:
+  """Maps one shard's index domain to `(offset, length)` byte runs in the file.
+
+  A safetensors tensor is a single contiguous row-major blob. The slice of it
+  a device owns is contiguous in the file only along trailing dimensions, so a
+  shard is a set of equally sized, equally spaced runs: exactly one run when
+  the shard splits only the leading dimension (the FSDP / 1-D case), and
+  several strided runs when it splits an inner dimension.
+
+  Args:
+    bounds: Per-dimension `(start, stop)` of the shard, from `_normalize_index`.
+    global_shape: Shape of the whole tensor.
+    itemsize: Bytes per element.
+    tensor_base: Absolute byte offset of the tensor's first element in the file.
 
   Returns:
-    A list of lists of tensor names, where each inner list contains the names
-    of the tensors assigned to that host.
+    A list of `(offset, length)` byte runs, sorted by offset.
   """
-  # Filter out metadata and sort tensors by their start offset in the file.
-  tensors = {k: v for k, v in header.items() if k != "__metadata__"}
-  sorted_tensors = sorted(
-      tensors.items(), key=lambda item: item[1]["data_offsets"][0]
-  )
-
-  if not sorted_tensors:
-    return [[] for _ in range(num_hosts)]
-
-  # Calculate total data size based on the last tensor's end offset.
-  total_size = sorted_tensors[-1][1]["data_offsets"][1]
-
-  # Greedily assign tensors to hosts.
-  bundles = [[] for _ in range(num_hosts)]
-  current_bundle = 0
-  cumulative_size = 0
-
-  for name, info in sorted_tensors:
-    start, end = info["data_offsets"]
-    tensor_size = end - start
-
-    if current_bundle < num_hosts - 1:
-      # Calculate target cumulative size for current host.
-      ideal_cumulative_size = (current_bundle + 1) * (total_size / num_hosts)
-
-      # Decide whether to cut to next host or keep in current bundle.
-      dist_if_cut = abs(cumulative_size - ideal_cumulative_size)
-      dist_if_keep = abs(
-          (cumulative_size + tensor_size) - ideal_cumulative_size
-      )
-
-      if dist_if_cut < dist_if_keep and cumulative_size > 0:
-        current_bundle += 1
-
-    bundles[current_bundle].append(name)
-    cumulative_size += tensor_size
-
-  return bundles
-
-
-def _create_global_mesh() -> tuple[jax.sharding.Mesh, list[list[jax.Device]]]:
-  """Creates a global mesh and returns it along with devices by host and count."""
-  devices_by_host = np.asarray(jax.devices()).reshape(
-      multihost.process_count(), jax.local_device_count()
-  )
-
-  for d in devices_by_host:
-    if len(d) != jax.local_device_count():
-      raise ValueError("Number of devices must be the same across all hosts.")
-
-  global_mesh = jax.sharding.Mesh(
-      np.array(devices_by_host), ("hosts", "devices")
-  )
-  return global_mesh, devices_by_host  # pyrefly: ignore[bad-return]
-
-
-def _get_abstract_transient_array(
-    shape: tuple[int, ...],
-    dtype: np.dtype,
-    global_mesh: jax.sharding.Mesh,
-    num_hosts: int,
-) -> jax.ShapeDtypeStruct:
-  """Determines the sharding strategy and shape for the transient array."""
-  num_devices_per_host = jax.local_device_count()
-
-  if _should_replicate_array(shape):
-    # Cannot shard across devices, so replicate as a fallback.
-    sharding = jax.sharding.NamedSharding(
-        global_mesh, jax.sharding.PartitionSpec("hosts")
-    )
-    transient_shape = (num_hosts,) + shape
-  else:
-    # Enforce that the first dimension is divisible by the number of
-    # devices per host. This allows us to shard the tensor across local
-    # devices in host memory.
-    # TODO(b/496270336): relax this constraint
-    if shape[0] % num_devices_per_host != 0:
-      raise ValueError(
-          f"First dimension {shape[0]} is not divisible"
-          f" by number of devices per host ({num_devices_per_host})."
-      )
-    # Fully shard across all devices. No replication. Keeps memory usage low.
-    sharding = jax.sharding.NamedSharding(
-        global_mesh, jax.sharding.PartitionSpec("hosts", "devices")
-    )
-    transient_shape = (num_hosts,) + shape
-
-  return jax.ShapeDtypeStruct(
-      shape=transient_shape, dtype=dtype, sharding=sharding
-  )
-
-
-def _get_current_shard_shape(shape: tuple[int, ...]) -> tuple[int, ...]:
-  """Calculates current shard shape."""
-  num_devices_per_host = jax.local_device_count()
-
-  if _should_replicate_array(shape):
-    return (1,) + shape
-  else:
-    shard_size = shape[0] // num_devices_per_host
-    return (1, shard_size) + shape[1:]
-
-
-def _get_zero_shard_view(
-    zero_buf: jax.Array, current_shard_shape: tuple[int, ...]
-) -> jax.Array:
-  """Returns a view of the shared zero buffer for a non-owner shard."""
-  slices = [slice(0, 1)]
-  for s_size in current_shard_shape[1:]:
-    slices.append(slice(0, s_size))
-
-  # Pad with 0 for remaining dimensions to reduce rank if needed.
-  while len(slices) < len(zero_buf.shape):
-    slices.append(0)  # pyrefly: ignore[bad-argument-type]
-
-  return zero_buf[tuple(slices)]
-
-
-def _calculate_max_shard_shapes(
-    abstract_pytree: dict[str, Any], header: dict[str, Any]
-) -> dict[np.dtype, list[int]]:
-  """Calculates maximum shard shapes per dtype."""
-  max_shard_shape_per_dtype = {}
-  for name, _ in abstract_pytree.items():
-    if name not in header:
-      continue
-    info = header[name]
-    shape, dtype = _get_array_properties(info)
-    current_shard_shape = _get_current_shard_shape(shape)
-
-    if dtype not in max_shard_shape_per_dtype:
-      max_shard_shape_per_dtype[dtype] = [1]
-
-    max_shape = max_shard_shape_per_dtype[dtype]
-
-    while len(max_shape) < len(current_shard_shape):
-      max_shape.append(0)
-
-    for i in range(1, len(current_shard_shape)):
-      max_shape[i] = max(max_shape[i], current_shard_shape[i])
-  return max_shard_shape_per_dtype
-
-
-def _create_shared_zero_buffers(
-    max_shard_shape_per_dtype: dict[np.dtype, list[int]],
-    local_devices: list[jax.Device],
-) -> dict[tuple[jax.Device, np.dtype], jax.Array]:
-  """Creates shared zero buffers on local devices."""
-  zero_buffers = {}
-  for dtype, max_shape in max_shard_shape_per_dtype.items():
-    for d in local_devices:
-      zero_buffers[(d, dtype)] = jnp.zeros(
-          tuple(max_shape), dtype=dtype, device=d
-      )
-  return zero_buffers
-
-
-def _create_data_buffer(
-    np_array: np.ndarray,
-    device: jax.Device,
-    shard_size: int | None,
-    shard_index: int,
-) -> jax.Array:
-  """Creates a data buffer for a device."""
-  if shard_size is None:
-    return jnp.expand_dims(jax.device_put(np_array, device), axis=0)
-  else:
-    shard_start = shard_index * shard_size
-    shard_end = (shard_index + 1) * shard_size
-    tensor_shard = np_array[shard_start:shard_end]
-    return jnp.expand_dims(jax.device_put(tensor_shard, device), axis=0)
-
-
-def _extract_tensor_from_bundle(
-    info: dict[str, Any],
-    bundle_bytes: bytes,
-    bundle_start_offset: int,
-    shape: tuple[int, ...],
-    dtype: np.dtype,
-) -> np.ndarray:
-  """Extracts tensor data from the read buffer."""
-  start_offset, end_offset = info["data_offsets"]
-  rel_start = start_offset - bundle_start_offset
-  rel_end = end_offset - bundle_start_offset
-  tensor_mv = memoryview(bundle_bytes)[rel_start:rel_end]
-  return np.frombuffer(tensor_mv, dtype=dtype).reshape(shape)
-
-
-def _reshard_transient_array(
-    global_transient_array: jax.Array,
-    target_sharding: jax.sharding.Sharding | None,
-    global_mesh: jax.sharding.Mesh,
-) -> jax.Array:
-  """Reduces the transient array and reshards to the target sharding."""
-  if target_sharding is not None:
-    out_sharding = target_sharding
-  else:
-    out_sharding = jax.sharding.NamedSharding(
-        global_mesh, jax.sharding.PartitionSpec()
-    )
-
-  return jax.jit(
-      lambda x: jnp.sum(x, axis=0).astype(x.dtype), out_shardings=out_sharding
-  )(global_transient_array)
-
-
-@dataclasses.dataclass
-class _LoadContext:
-  host_id: int
-  num_hosts: int
-  global_mesh: jax.sharding.Mesh
-  devices_by_host: list[list[jax.Device]]
-  bundle_bytes: bytes
-  bundle_start_offset: int
-  zero_buffers: dict[tuple[jax.Device, np.dtype], jax.Array]
-
-
-def _build_array_on_single_device(
-    info: dict[str, Any], owner: int, ctx: _LoadContext
-) -> jax.Array:
-  """Builds a global JAX array placed on a single device."""
-  shape, dtype = _get_array_properties(info)
-  target_device = ctx.devices_by_host[owner][0]
-  single_device_sharding = jax.sharding.SingleDeviceSharding(target_device)
-
-  if ctx.host_id == owner:
-    if not ctx.bundle_bytes:
-      np_array = np.zeros(shape, dtype=dtype)
+  if (ndim := len(global_shape)) == 0:  # Scalar.
+    return [(tensor_base, itemsize)]
+  strides = _byte_strides(global_shape, itemsize)
+  full_trailing = 0
+  for i in range(ndim - 1, -1, -1):
+    if bounds[i] == (0, global_shape[i]):
+      full_trailing += 1
     else:
-      np_array = _extract_tensor_from_bundle(
-          info, ctx.bundle_bytes, ctx.bundle_start_offset, shape, dtype
-      )
-    device_array = jax.device_put(np_array, target_device)
-    device_buffers = [device_array]
-  else:
-    device_buffers = []
-
-  return jax.make_array_from_single_device_arrays(
-      shape, single_device_sharding, device_buffers, dtype=dtype
-  )
-
-
-def _build_transient_array(
-    name: str, info: dict[str, Any], owner: int, ctx: _LoadContext
-) -> jax.Array:
-  """Builds transient array for general resharding case."""
-  shape, dtype = _get_array_properties(info)
-  num_devices_per_host = jax.local_device_count()
-  if _should_replicate_array(shape):
-    shard_size = None
-  else:
-    shard_size = shape[0] // num_devices_per_host
-
-  np_array = None
-  if ctx.host_id == owner:
-    np_array = _extract_tensor_from_bundle(
-        info, ctx.bundle_bytes, ctx.bundle_start_offset, shape, dtype
-    )
-
-  device_buffers = []
-  for i, d in enumerate(ctx.devices_by_host[ctx.host_id]):
-    if ctx.host_id == owner:
-      device_buffers.append(
-          _create_data_buffer(
-              np_array,  # pyrefly: ignore[bad-argument-type]
-              d,
-              shard_size,
-              i,
-          )
-      )
-    else:
-      zero_buf = ctx.zero_buffers[(d, dtype)]
-      current_shard_shape = _get_current_shard_shape(shape)
-      device_buffers.append(_get_zero_shard_view(zero_buf, current_shard_shape))
-
-  abstract_transient = _get_abstract_transient_array(
-      shape, dtype, ctx.global_mesh, ctx.num_hosts
-  )
-
-  try:
-    return jax.make_array_from_single_device_arrays(
-        abstract_transient.shape,
-        abstract_transient.sharding,
-        device_buffers,
-    )
-  except Exception as e:
-    logging.error(
-        "Failed make_array_from_single_device_arrays for %s: %s", name, e
-    )
-    raise e
+      break
+  if (boundary := ndim - full_trailing - 1) < 0:
+    return [(tensor_base, strides[0] * global_shape[0])]
+  run_length = (bounds[boundary][1] - bounds[boundary][0]) * strides[boundary]
+  run_base = tensor_base + bounds[boundary][0] * strides[boundary]
+  outer_ranges = [range(bounds[i][0], bounds[i][1]) for i in range(boundary)]
+  runs = []
+  for outer_index in itertools.product(*outer_ranges):
+    offset = run_base
+    for dim, coord in enumerate(outer_index):
+      offset += coord * strides[dim]
+    runs.append((offset, run_length))
+  runs.sort()
+  return runs
 
 
-def _record_read_stats(bytes_read: int, num_reads: int) -> None:
-  """Reports this host's safetensors read accounting via `jax.monitoring`.
+@dataclasses.dataclass(frozen=True)
+class _CoalescedBlock:
+  """One scheduled read covering several registered runs."""
 
-  Emitted once per load so a benchmark can compare this loader against the
-  sharding-driven one on the same per-host bytes/reads channel. It publishes
-  only `bytes_read` and `num_reads`; this loader reads each bundle in a single
-  contiguous read with no chunking, so `storage_reads` would equal `num_reads`.
+  start: int  # Absolute byte offset of the read.
+  end: int  # Exclusive end byte offset.
+  members: tuple[int, ...]  # Indices into the scheduler's request list.
+
+
+def _partition_runs(
+    runs: Sequence[tuple[int, int]],
+    max_over_read_ratio: float,
+    min_coalesce_gap: int = _DEFAULT_MIN_COALESCE_GAP,
+) -> list[_CoalescedBlock]:
+  """Greedily partitions `(offset, length)` runs into coalesced read blocks.
+
+  Each emitted block is read with one ranged read (or streamed in budget-sized
+  chunks by `_PerFileScheduler` when oversized) and demultiplexed back to its
+  member runs. The partitioner absorbs the next run into the current block when
+  *either* of two conditions holds:
+
+  - `block_size / needed_bytes <= max_over_read_ratio` -- bounding per-host
+    egress amplification. With `max_over_read_ratio == 2.0`, a host pulls at
+    most `2x` the bytes it actually needs from this file.
+  - the gap to the next run is `<= min_coalesce_gap` -- an absolute floor. The
+    ratio test is purely relative, so it would otherwise reject merging tiny
+    runs across tiny gaps, shattering strided reads into many microscopic
+    requests; below ~a page the per-read overhead dominates and reading the
+    gap is always cheaper than a second request.
+
+  Block size is intentionally unbounded here. Peak in-flight memory is bounded
+  separately by the scheduler's byte budget (`max_in_flight_bytes`), which
+  also enforces correctness for any block too large to read in one go. This
+  separation makes the partition policy purely about over-read and the
+  budget purely about memory -- each knob expressing one concern.
+
+  The single-host degenerate case -- this process needs every byte of the
+  file -- has ratio `1.0` everywhere and collapses to a single block per file.
+  FSDP with one contiguous shard per host per file likewise collapses to one
+  block per host.
 
   Args:
-    bytes_read: Total data bytes this host read from storage.
-    num_reads: Number of read operations this host issued.
+    runs: `(offset, length)` byte runs; need not be sorted.
+    max_over_read_ratio: Upper bound on `block_size / needed_bytes` per block.
+      Must be `>= 1.0`; `1.0` disables any over-read.
+    min_coalesce_gap: Runs separated by at most this many bytes are always
+      merged, regardless of the ratio. `0` disables the floor (pure ratio).
+
+  Returns:
+    A list of `_CoalescedBlock` covering every input run, with each block's
+    `members` tuple recording the indices (into the original `runs`) it
+    serves. Members are in the order the partitioner encountered them after
+    sorting by offset.
   """
-  jax.monitoring.record_scalar(
-      "/jax/orbax/read/safetensors/bytes_read", float(bytes_read)
-  )
-  jax.monitoring.record_scalar(
-      "/jax/orbax/read/safetensors/num_reads", float(num_reads)
-  )
-
-
-class _SingleFileLoader:
-  """Single-file loader for Safetensors checkpoints."""
-
-  def __init__(self, path: Path):
-    self.path = path
-
-  async def read_header(self) -> tuple[dict[str, Any], int]:
-    """Reads a safetensors file header, returning the header and data start offset."""
-    async with async_path.open_file(self.path, mode="rb") as f:
-      header_size_bytes = await f.read(HEADER_NUM_BYTES)
-      if not header_size_bytes:
-        raise ValueError("Could not read header size from safetensors file.")
-
-      header_size = int.from_bytes(header_size_bytes, byteorder="little")  # pyrefly: ignore[bad-argument-type]
-      header_bytes = await f.read(header_size)
-      if len(header_bytes) != header_size:
-        raise ValueError("Could not read header content from safetensors file.")
-
-      header = json.loads(header_bytes)
-      data_start_offset = HEADER_NUM_BYTES + header_size
-      return header, data_start_offset
-
-  async def _read_bundle(
-      self,
-      bundles: list[list[str]],
-      host_id: int,
-      header: dict[str, Any],
-      data_start_offset: int,
-  ) -> tuple[bytes, int]:
-    """Reads the assigned bundle of tensors in a single contiguous read."""
-    my_bundle = bundles[host_id]
-    if my_bundle:
-      first_tensor = my_bundle[0]
-      last_tensor = my_bundle[-1]
-      bundle_start_offset = header[first_tensor]["data_offsets"][0]
-      bundle_end_offset = header[last_tensor]["data_offsets"][1]
-      bundle_num_bytes = bundle_end_offset - bundle_start_offset
-
-      async with async_path.open_file(self.path, mode="rb") as f:
-        await f.seek(data_start_offset + bundle_start_offset)
-        bundle_bytes = cast(bytes, await f.read(bundle_num_bytes))
+  if not runs:
+    return []
+  if max_over_read_ratio < 1.0:
+    raise ValueError(
+        f"max_over_read_ratio must be >= 1.0, got {max_over_read_ratio}."
+    )
+  indexed = sorted(enumerate(runs), key=lambda x: x[1][0])
+  blocks: list[_CoalescedBlock] = []
+  cur_start: int | None = None
+  cur_end = 0
+  cur_needed = 0
+  cur_members: list[int] = []
+  for orig_idx, (offset, length) in indexed:
+    end = offset + length
+    if cur_start is None:
+      cur_start, cur_end = offset, end
+      cur_needed = length
+      cur_members = [orig_idx]
+      continue
+    gap = offset - cur_end
+    new_end = max(cur_end, end)
+    new_size = new_end - cur_start
+    new_needed = cur_needed + length
+    if gap <= min_coalesce_gap or new_size <= max_over_read_ratio * new_needed:
+      cur_end = new_end
+      cur_needed = new_needed
+      cur_members.append(orig_idx)
     else:
-      bundle_bytes = b""
-      bundle_start_offset = 0
-    return bundle_bytes, bundle_start_offset
+      blocks.append(_CoalescedBlock(cur_start, cur_end, tuple(cur_members)))
+      cur_start, cur_end = offset, end
+      cur_needed = length
+      cur_members = [orig_idx]
+  if cur_start is not None:
+    blocks.append(_CoalescedBlock(cur_start, cur_end, tuple(cur_members)))
+  return blocks
 
-  async def load_single_host(self) -> tuple[dict[str, np.ndarray], int]:
-    """Loads all tensors into host NumPy arrays; returns (tensors, bytes_read)."""
-    header, data_start_offset = await self.read_header()
-    tensors = {}
-    async with async_path.open_file(self.path, mode="rb") as f:
-      await f.seek(data_start_offset)
-      data_bytes = await f.read()
-    for name, info in header.items():
-      if name == "__metadata__":
-        continue
-      shape, dtype = _get_array_properties(info)
-      start_offset, end_offset = info["data_offsets"]
-      tensor_bytes = data_bytes[start_offset:end_offset]
-      np_array = np.frombuffer(tensor_bytes, dtype=dtype).reshape(shape)  # pyrefly: ignore[no-matching-overload]
-      if not np.isfinite(np_array).all():
-        raise ValueError(f"Non-finite values found in tensor {name}.")
-      tensors[name] = np_array
-    return tensors, len(data_bytes)
 
-  async def load_multi_host(
-      self, abstract_state: dict[str, Any]
-  ) -> tuple[dict[str, Any], dict[str, float]]:
-    """Loads tensors from a single safetensors file in multi-host mode.
+def _replicated_sharding() -> jax.sharding.Sharding:
+  """A `NamedSharding` that fully replicates an array across all devices."""
+  mesh = jax.sharding.Mesh(np.asarray(jax.devices()), ("_safetensors_replica",))
+  return jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
 
-    This method optimizes loading by:
-    1. Partitioning tensors among hosts based on their file offsets to ensure
-       each host performs a single contiguous read.
-    2. Loading data into a transient array with a leading dummy 'hosts' axis
-       to allow a whole tensor to be present on a single host and sharded
-       exclusively across that host's local devices. This minimizes peak memory
-       usage.
-    3. Optional reduction of the global transient array to the target sharding.
-       This can be skipped in cases like simple checkpoint conversion which
-       requires no data processing.
+
+class _FileEntry(NamedTuple):
+  """Where to find one tensor in the on-disk checkpoint."""
+
+  path: Path  # The .safetensors file this tensor lives in.
+  info: dict[str, Any]  # The tensor's entry from the file's header.
+  data_start: int  # Byte offset of the file's data section.
+
+
+_RunCallback = Callable[[memoryview], None]
+
+
+class _ReadStats(NamedTuple):
+  """Per-file read accounting, aggregated for the fragmentation hint."""
+
+  needed_bytes: int  # Bytes the registered runs actually need.
+  read_bytes: int  # Bytes the coalesced blocks pull (>= needed_bytes).
+  num_reads: int  # Coalesced blocks (ranged-read requests; ~1 per file ideal).
+  num_gets: int  # Actual storage GETs (>= num_reads; splits blocks > budget).
+
+
+class _PerFileScheduler:
+  """Coalesces and issues reads for one safetensors file.
+
+  Callers `register(offset, length, callback)` synchronously while they plan
+  their per-tensor reads. After all registrations complete, `execute()`
+  partitions the registered runs under the over-read ratio cap, then for
+  each coalesced block issues one ranged read -- or streams the block in
+  budget-sized chunks if it exceeds `max_in_flight_bytes`. Each chunk's
+  bytes are dispatched to every registered callback whose range intersects
+  it, sliced to the run-local bytes the callback expects.
+
+  Callback contract: a callback for a registered run may be invoked
+  multiple times, always in increasing offset order, each invocation
+  carrying a contiguous sub-range of the run's bytes. The callback should
+  write the bytes into its destination buffer starting at the cursor
+  position equal to "total bytes already delivered to this callback." The
+  helpers `_register_*_tensor_reads` in this file follow that pattern.
+
+  Concurrency: `register()` must finish for every tensor that touches this
+  file before `execute()` runs; otherwise a late registration would be
+  silently dropped. The `SafetensorsLayout._load` orchestration arranges
+  this by performing all registrations synchronously before scheduling any
+  scheduler `execute()` task. Peak in-flight memory is bounded at the
+  shared budget regardless of how many schedulers run concurrently.
+  """
+
+  def __init__(
+      self,
+      path: Path,
+      byte_budget: limits.LimitInFlightBytes,
+      max_over_read_ratio: float,
+  ):
+    self._path = path
+    self._budget = byte_budget
+    self._max_over_read_ratio = max_over_read_ratio
+    self._requests: list[tuple[int, int, _RunCallback]] = []
+
+  def register(self, offset: int, length: int, callback: _RunCallback) -> None:
+    """Records a byte range this host needs and the callback to receive it."""
+    self._requests.append((offset, length, callback))
+
+  async def execute(self) -> _ReadStats:
+    """Reads all registered byte runs and returns this file's read accounting."""
+    if not self._requests:
+      return _ReadStats(needed_bytes=0, read_bytes=0, num_reads=0, num_gets=0)
+    runs = [(off, length) for off, length, _ in self._requests]
+    blocks = _partition_runs(runs, self._max_over_read_ratio)
+    try:
+      gets_per_block = await asyncio.gather(
+          *[self._read_block(b) for b in blocks]
+      )
+    finally:
+      # Drop callback closures so any buffers they captured can be GC'd as
+      # soon as their callers release them.
+      self._requests = []
+    return _ReadStats(
+        needed_bytes=sum(length for _, length in runs),
+        read_bytes=sum(b.end - b.start for b in blocks),
+        num_reads=len(blocks),
+        num_gets=sum(gets_per_block),
+    )
+
+  async def _read_block(self, block: _CoalescedBlock) -> int:
+    """Reads one coalesced block, streaming in chunks if oversized.
 
     Args:
-      abstract_state: A flat dictionary mapping tensor names to
-        jax.ShapeDtypeStruct objects specifying target shape and sharding.
+      block: The coalesced byte range to read from this file.
 
     Returns:
-      A tuple containing:
-        - A dictionary mapping tensor names to restored jax.Arrays.
-        - A dictionary of metrics (io_time, reshard_time, bytes_read,
-          num_reads) for this host.
-
-    Raises:
-      ValueError: If the number of devices is not uniform across hosts, or if a
-        sharded tensor's first dimension is not divisible by the number of
-        devices per host.
-      KeyError: If a tensor in the abstract_state is not found in the
-        safetensors file.
+      The number of storage GETs issued for the block -- one per chunk, so a
+      block within the in-flight budget is a single GET and a larger one is
+      several.
     """
-    io_time = 0.0
-    reshard_time = 0.0
+    # `LimitInFlightBytes` reserves strictly fewer bytes than its max, and the
+    # limiter is sized one over `max_in_flight_bytes` (see `_load`), so the
+    # largest reservable chunk is exactly `max_in_flight_bytes`.
+    chunk_cap = self._budget.max_bytes - 1
+    pos = block.start
+    gets = 0
+    while pos < block.end:
+      chunk_end = min(pos + chunk_cap, block.end)
+      chunk_len = chunk_end - pos
+      async with limits.reserved_bytes(self._budget, chunk_len):
+        async with async_path.open_file(self._path, mode="rb") as f:
+          await f.seek(pos)
+          # `AsyncFile.read` is declared `bytes | str`; `mode="rb"` guarantees
+          # bytes at runtime but pytype can't narrow that statically.
+          chunk_bytes = cast(bytes, await f.read(chunk_len))
+        mv = memoryview(chunk_bytes)
+        self._dispatch_chunk(block, mv, pos, chunk_len)
+        # Drop our refs; the buffer can be GC'd once any memoryviews the
+        # callbacks may have retained go out of scope.
+        del mv, chunk_bytes
+      gets += 1
+      pos = chunk_end
+    return gets
 
-    num_hosts = multihost.process_count()
-
-    global_mesh, devices_by_host = _create_global_mesh()
-
-    host_id = jax.process_index()
-
-    t0 = time.time()
-    header, data_start_offset = await self.read_header()
-    io_time += time.time() - t0
-
-    # Partition tensors among hosts based on file offsets for contiguous I/O.
-    # TODO(b/496270336): Use the partial_load flag in Context to allow for
-    # loading a subset of keys.
-    bundles = _get_tensor_bundles(header, num_hosts)
-
-    # Map each tensor to its owner host.
-    tensor_to_owner = {}
-    for h, bundle in enumerate(bundles):
-      for name in bundle:
-        tensor_to_owner[name] = h
-
-    restored_pytree = {}
-
-    t0 = time.time()
-    bundle_bytes, bundle_start_offset = await self._read_bundle(
-        bundles, host_id, header, data_start_offset
-    )
-    io_time += time.time() - t0
-
-    if not context_lib.get_context().safetensors_options.ignore_load_sharding:
-      max_shard_shape_per_dtype = _calculate_max_shard_shapes(
-          abstract_state,
-          header,
-      )
-      zero_buffers = _create_shared_zero_buffers(
-          max_shard_shape_per_dtype, devices_by_host[host_id]
-      )
-    else:
-      zero_buffers = {}
-
-    ctx = _LoadContext(
-        host_id=host_id,
-        num_hosts=num_hosts,
-        global_mesh=global_mesh,
-        devices_by_host=devices_by_host,
-        bundle_bytes=bundle_bytes,
-        bundle_start_offset=bundle_start_offset,
-        zero_buffers=zero_buffers,
-    )
-
-    # Process each tensor in the requested PyTree.
-    for name, abstract_leaf in abstract_state.items():
-      if name not in header:
-        continue
-
-      owner = tensor_to_owner.get(name, 0)
-      info = header[name]
-      target_sharding = abstract_leaf.sharding
-
-      if context_lib.get_context().safetensors_options.ignore_load_sharding:
-        restored_pytree[name] = _build_array_on_single_device(info, owner, ctx)
-      else:
-        global_transient_array = _build_transient_array(name, info, owner, ctx)
-        t0 = time.time()
-        restored_pytree[name] = _reshard_transient_array(
-            global_transient_array, target_sharding, global_mesh
-        )
-        reshard_time += time.time() - t0
-
-    return restored_pytree, {
-        "io_time": io_time,
-        "reshard_time": reshard_time,
-        # This host reads its bundle in one contiguous read (or none if empty).
-        "bytes_read": len(bundle_bytes),
-        "num_reads": 1 if bundle_bytes else 0,
-    }
-
-
-class _MultiFileLoader:
-  """Multi-file loader for Safetensors checkpoints."""
-
-  def __init__(self, path: Path):
-    self.path = path
-
-  async def _get_loaders(self) -> list[_SingleFileLoader]:
-    """Returns the list of SingleFileLoaders."""
-    if await async_path.is_dir(self.path):
-      paths = sorted(await async_path.glob(self.path, f"*{SAFETENSORS_SUFFIX}"))
-    else:
-      paths = [self.path]
-    return [_SingleFileLoader(path) for path in paths]
-
-  async def _load_single_host(self, abstract_state: dict[str, Any]) -> Any:
-    """Loads a safetensors checkpoint on a single host."""
-    # Return NumPy arrays.
-    # Load from all files and merge.
-    start = time.time()
-    load_ops = []
-    for loader in await self._get_loaders():
-      load_ops.append(loader.load_single_host())
-
-    restored_pytree = {}
-    total_bytes_read = 0
-    num_reads = 0
-    for file_tensors, bytes_read in await asyncio.gather(*load_ops):
-      total_bytes_read += bytes_read
-      num_reads += 1  # one whole-file data read per file.
-      for name, arr in file_tensors.items():
-        if name in restored_pytree:
-          raise ValueError(f"Duplicate tensor {name} found in multiple files.")
-        restored_pytree[name] = arr
-
-    _record_read_stats(total_bytes_read, num_reads)
-
-    logging.info(
-        "[safetensors][single-host] Loaded tensors in %.0fs, num_reads=%d,"
-        " bytes_read=%d",
-        time.time() - start,
-        num_reads,
-        total_bytes_read,
-    )
-    if not abstract_state:
-      return restored_pytree
-
-    start = time.time()
-    for k in abstract_state:
-      if k not in restored_pytree:
-        raise KeyError(f"Tensor '{k}' not found in Safetensors checkpoint.")
-
-    restored_pytree = {
-        k: jax.device_put(
-            restored_pytree[k],
-            device=abstract_state[k].sharding,
-        )
-        for k in abstract_state
-    }
-    logging.info(
-        "[safetensors][single-host] Host-to-device transfer in %.0fs",
-        time.time() - start,
-    )
-    return restored_pytree
-
-  async def _load_multi_host(
-      self, abstract_state: dict[str, Any] | None
-  ) -> Any:
-    """Loads a safetensors checkpoint on multiple hosts."""
-    if not abstract_state:
-      raise ValueError(
-          "abstract_state must be provided for multi-host loading."
-      )
-
-    loaders = await self._get_loaders()
-
-    # Call load_multi_host on each loader concurrently.
-    # Each loader handles loading from a single file.
-    start = time.time()
-    load_ops = []
-    for loader in loaders:
-      load_ops.append(loader.load_multi_host(abstract_state))
-
-    restored_pytree = {}
-    total_io_time = 0.0
-    total_reshard_time = 0.0
-    total_bytes_read = 0
-    total_num_reads = 0
-    for file_tensors, metrics in await asyncio.gather(*load_ops):
-      total_io_time += metrics["io_time"]
-      total_reshard_time += metrics["reshard_time"]
-      total_bytes_read += metrics["bytes_read"]
-      total_num_reads += metrics["num_reads"]
-      for name, arr in file_tensors.items():
-        if name in restored_pytree:
-          raise ValueError(f"Duplicate tensor {name} found in multiple files.")
-        restored_pytree[name] = arr
-
-    _record_read_stats(total_bytes_read, total_num_reads)
-
-    # Validate that all requested tensors were found in at least one file.
-    for k in abstract_state:
-      if k not in restored_pytree:
-        raise KeyError(f"Tensor '{k}' not found in Safetensors checkpoint.")
-
-    logging.info(
-        "[safetensors][multi-host] Loaded and resharded %d tensors from %d"
-        " files in %.2fs (io=%.2fs, reshard=%.2fs, bytes_read=%d,"
-        " num_reads=%d)",
-        len(restored_pytree),
-        len(loaders),
-        time.time() - start,
-        total_io_time,
-        total_reshard_time,
-        total_bytes_read,
-        total_num_reads,
-    )
-
-    return restored_pytree
-
-  async def load_safetensors(
+  def _dispatch_chunk(
       self,
-      abstract_state: dict[str, Any] | None = None,
-  ) -> Any:
-    """Calls the correct safetensors loading function."""
-    if abstract_state is not None and not tree_utils.is_flat_dict(
-        abstract_state
-    ):
-      raise ValueError("The PyTree is not a flat dictionary.")
+      block: _CoalescedBlock,
+      mv: memoryview,
+      chunk_start: int,
+      chunk_len: int,
+  ) -> None:
+    """Invokes every member's callback with the slice of `mv` it owns.
 
-    if multihost.process_count() > 1:
-      return await self._load_multi_host(abstract_state)
-    else:
-      return await self._load_single_host(abstract_state)  # pyrefly: ignore[bad-argument-type]
+    For each registered run in `block`, computes the intersection with the
+    chunk `[chunk_start, chunk_start + chunk_len)` and -- if non-empty --
+    invokes the callback with the corresponding slice of `mv`. Runs that do
+    not intersect this chunk are skipped (they will be served by another
+    chunk in the same block).
 
-  async def load_metadata(self):
-    """Loads the metadata from a safetensors checkpoint."""
-    start = time.time()
-    metadata = {}
-    custom_metadata = {}
+    Args:
+      block: The coalesced block whose member runs may intersect the chunk.
+      mv: A memoryview over the bytes of the current chunk.
+      chunk_start: Absolute file offset where the chunk begins.
+      chunk_len: Length of the chunk in bytes.
+    """
+    chunk_end = chunk_start + chunk_len
+    for member_idx in block.members:
+      run_offset, run_length, callback = self._requests[member_idx]
+      run_end = run_offset + run_length
+      hit_start = max(chunk_start, run_offset)
+      hit_end = min(chunk_end, run_end)
+      if hit_start < hit_end:
+        local_start = hit_start - chunk_start
+        local_end = hit_end - chunk_start
+        callback(mv[local_start:local_end])
 
-    # Track the latest commit timestamp.
-    commit_timestamp_nsecs = None
 
-    for loader in await self._get_loaders():
-      header, _ = await loader.read_header()
-      stat = await async_path.async_stat(loader.path)
-      ts = int(stat.mtime)
-      if commit_timestamp_nsecs is None or ts > commit_timestamp_nsecs:
-        commit_timestamp_nsecs = ts
+def _allocate_buffer(
+    shape: tuple[int, ...], dtype: np.dtype
+) -> tuple[np.ndarray, np.ndarray]:
+  """Allocates a contiguous buffer + a flat `uint8` view over its bytes.
 
-      for name, info in header.items():
-        if name == "__metadata__":
-          # TODO(abhisekar): Consider warning on conflicting metadata keys.
-          # If conflicting keys exist, last write wins.
-          if info:
-            custom_metadata.update(info)
-          continue
-        if name in metadata:
-          raise ValueError(f"Duplicate tensor {name} found in multiple files.")
-        shape, dtype = _get_array_properties(info)
-        metadata[name] = jax.ShapeDtypeStruct(shape=shape, dtype=dtype)
+  The flat view is the canonical write-target for byte-level callbacks; it
+  works uniformly for scalars (`shape == ()`), 1-D, and N-D buffers, where
+  `np.ndarray.view(uint8)` on a 0-D array does not.
 
-    logging.info("[safetensors] Loaded metadata in %.0fs", time.time() - start)
-    return metadata_types.CheckpointMetadata(
-        path=self.path,
-        metadata=metadata,
-        commit_timestamp_nsecs=commit_timestamp_nsecs,
-        custom_metadata=custom_metadata,
+  Args:
+    shape: Shape of the typed buffer to allocate.
+    dtype: Element dtype of the typed buffer.
+
+  Returns:
+    A `(buffer, flat_u8)` pair: the typed `shape`-shaped array and a flat
+    `uint8` view aliasing the same memory.
+  """
+  num_elements = math.prod(shape) if shape else 1
+  flat_u8 = np.empty(num_elements * dtype.itemsize, dtype=np.uint8)
+  buf = flat_u8.view(dtype).reshape(shape)
+  return buf, flat_u8
+
+
+def _make_cursor_receive(dst: np.ndarray) -> _RunCallback:
+  """Builds a callback that appends successive chunks into a flat buffer.
+
+  Implements the partial-delivery contract from `_PerFileScheduler`: each
+  invocation writes the chunk's bytes at the cursor position and advances
+  the cursor by the chunk length. After all expected chunks arrive, the
+  cursor equals `len(dst)`.
+
+  Args:
+    dst: Flat destination buffer the chunks are written into.
+
+  Returns:
+    A callback that writes each received chunk at the running cursor.
+  """
+  cursor = [0]
+
+  def receive(chunk: memoryview) -> None:
+    n = len(chunk)
+    end = cursor[0] + n
+    dst[cursor[0] : end] = np.frombuffer(chunk, dtype=np.uint8)
+    cursor[0] = end
+
+  return receive
+
+
+def _register_whole_tensor_reads(
+    entry: _FileEntry,
+    scheduler: _PerFileScheduler,
+) -> Callable[[], np.ndarray]:
+  """Sync: pre-allocates the destination array and registers one read.
+
+  Used when no `abstract_state` is given -- there is no target sharding to
+  drive a partial read, so each tensor is materialised in full on this host.
+  The scheduler writes directly into the pre-allocated array; the returned
+  builder function just returns it.
+
+  Args:
+    entry: The file entry describing the tensor's location and header info.
+    scheduler: The per-file read scheduler the read is registered with.
+
+  Returns:
+    A builder that returns the fully materialised array after execution.
+  """
+  shape, dtype = _get_array_properties(entry.info)
+  dtype = np.dtype(dtype)
+  begin, end = entry.info["data_offsets"]
+  buf, flat_u8 = _allocate_buffer(shape, dtype)
+  scheduler.register(
+      entry.data_start + begin, end - begin, _make_cursor_receive(flat_u8)
+  )
+
+  def build() -> np.ndarray:
+    return buf
+
+  return build
+
+
+def _register_sharded_tensor_reads(
+    entry: _FileEntry,
+    abstract_leaf: Any,
+    scheduler: _PerFileScheduler,
+) -> Callable[[], jax.Array]:
+  """Sync: pre-allocates one shard buffer per local-device shard.
+
+  For each unique index domain owned by one of this process's devices, the
+  shard buffer is allocated once. Each of the shard's byte runs is
+  registered with a callback that copies its bytes into the buffer at the
+  correct row offset. The returned builder turns the populated buffers
+  (after `scheduler.execute()`) into a sharded `jax.Array`.
+
+  Args:
+    entry: The file entry describing the tensor's location and header info.
+    abstract_leaf: The abstract array (shape, dtype, sharding) to build.
+    scheduler: The per-file read scheduler the reads are registered with.
+
+  Returns:
+    A builder that assembles the populated shard buffers into a `jax.Array`.
+
+  Raises:
+    ValueError: If the abstract state's shape disagrees with the checkpoint.
+  """
+  file_shape, file_dtype = _get_array_properties(entry.info)
+  file_dtype = np.dtype(file_dtype)
+  tensor_base = entry.data_start + entry.info["data_offsets"][0]
+
+  global_shape = tuple(abstract_leaf.shape)
+  out_dtype = np.dtype(abstract_leaf.dtype)
+  if global_shape != file_shape:
+    raise ValueError(
+        f"Shape mismatch: abstract state has {global_shape}, the checkpoint"
+        f" has {file_shape}."
     )
+  sharding = getattr(abstract_leaf, "sharding", None) or _replicated_sharding()
+
+  this_process = multihost.process_index()
+  index_to_devices: dict[tuple[tuple[int, int], ...], list[jax.Device]] = (
+      collections.defaultdict(list)
+  )
+  for device, index in sharding.devices_indices_map(global_shape).items():
+    if device.process_index == this_process:
+      index_to_devices[_normalize_index(index, global_shape)].append(device)
+
+  shard_specs: list[tuple[np.ndarray, list[jax.Device]]] = []
+  for bounds, devices in index_to_devices.items():
+    shard_shape = tuple(stop - start for start, stop in bounds)
+    shard_buf, shard_flat_u8 = _allocate_buffer(shard_shape, file_dtype)
+    runs = index_domain_to_byte_runs(
+        bounds, global_shape, file_dtype.itemsize, tensor_base
+    )
+    # Runs are already sorted by offset; their in-memory destination is the
+    # corresponding prefix of `shard_flat_u8` in the same order.
+    write_offset = 0
+    for off, length in runs:
+      end_byte = write_offset + length
+      scheduler.register(
+          off,
+          length,
+          _make_cursor_receive(shard_flat_u8[write_offset:end_byte]),
+      )
+      write_offset = end_byte
+    shard_specs.append((shard_buf, devices))
+
+  def build() -> jax.Array:
+    arrays: list[jax.Array] = []
+    # Consume front-to-back, releasing each shard's host buffer once its data
+    # is on-device instead of holding every buffer until the load returns.
+    # Popping here also frees the file_dtype original the moment `astype` makes
+    # the out_dtype copy, so a conversion's transient overlaps just one shard.
+    # `pop(0)` preserves order; the per-process shard count is small.
+    while shard_specs:
+      shard_buf, devices = shard_specs.pop(0)
+      if out_dtype != file_dtype:
+        shard_buf = shard_buf.astype(out_dtype)
+      for d in devices:
+        arrays.append(
+            jax.device_put(shard_buf, jax.sharding.SingleDeviceSharding(d))
+        )
+      del shard_buf
+    # `dtype` is required when a process contributes no shards (it cannot be
+    # inferred from an empty buffer list).
+    return jax.make_array_from_single_device_arrays(
+        global_shape, sharding, arrays, dtype=out_dtype
+    )
+
+  return build
+
+
+def _record_read_stats(stats: Sequence[_ReadStats]) -> None:
+  """Reports this host's read accounting via `jax.monitoring`.
+
+  Emitted once per load with the per-host totals -- a single scalar per name,
+  since a metric collector keyed by name would keep only the last of repeated
+  emissions. Mirrors how the TensorStore restore path self-reports
+  `/jax/orbax/read/...`, so a benchmark can capture safetensors reads through
+  the standard jax.monitoring listener with no dependency on this loader.
+
+  Two read counts are reported: `num_reads` is the coalesced ranged-read
+  requests (~1 per file when fully coalesced), and `storage_reads` is the
+  actual GETs issued, which is >= `num_reads` because a block larger than the
+  in-flight budget is fetched in several chunks.
+
+  Args:
+    stats: Per-file read accounting from each scheduler's `execute()`.
+  """
+  jax.monitoring.record_scalar(
+      "/jax/orbax/read/safetensors/bytes_read",
+      float(sum(s.read_bytes for s in stats)),
+  )
+  jax.monitoring.record_scalar(
+      "/jax/orbax/read/safetensors/num_reads",
+      float(sum(s.num_reads for s in stats)),
+  )
+  jax.monitoring.record_scalar(
+      "/jax/orbax/read/safetensors/storage_reads",
+      float(sum(s.num_gets for s in stats)),
+  )
+
+
+def _warn_if_reads_fragmented(
+    stats: Sequence[_ReadStats],
+    num_files: int,
+    max_over_read_ratio_is_default: bool,
+) -> None:
+  """Logs a one-shot hint when the over-read cap fragmented the load.
+
+  In the strided inner-dim regime the `max_over_read_ratio` cap rejects merges
+  and the load degrades into many small ranged reads -- RTT-bound and slow on
+  object storage. This surfaces that case so a slow load is diagnosable without
+  profiling. It fires once, only on the primary process, and only when the user
+  is on the default ratio (someone who set the knob has already weighed the
+  tradeoff). The signal is a high reads-per-file count together with an achieved
+  over-read near 1x -- exactly "the cap blocked coalescing" rather than "the
+  load genuinely spans many files."
+
+  Args:
+    stats: Per-file read accounting from each scheduler's `execute()`.
+    num_files: Number of distinct files the load read from.
+    max_over_read_ratio_is_default: Whether the user left `max_over_read_ratio`
+      unset; only then is "raise the ratio" actionable advice.
+  """
+  if not max_over_read_ratio_is_default or num_files == 0:
+    return
+  if multihost.process_index() != 0:
+    return
+  total_needed = sum(s.needed_bytes for s in stats)
+  total_read = sum(s.read_bytes for s in stats)
+  total_reads = sum(s.num_reads for s in stats)
+  if total_needed == 0:
+    return
+  achieved_over_read = total_read / total_needed
+  if (
+      total_reads <= _FRAGMENTED_READ_WARN_FACTOR * num_files
+      or achieved_over_read >= _FRAGMENTED_OVER_READ_CEILING
+  ):
+    return
+  logging.warning(
+      "Safetensors load issued %d ranged reads for %s across %d file(s)"
+      " (achieved over-read %.2fx). The target sharding produces strided reads"
+      " that the default max_over_read_ratio=%.1f keeps fragmented; raising"
+      " SafetensorsOptions.max_over_read_ratio trades bounded over-read for far"
+      " fewer reads (notably faster on object storage).",
+      total_reads,
+      humanize.naturalsize(total_needed, binary=True),
+      num_files,
+      achieved_over_read,
+      _DEFAULT_MAX_OVER_READ_RATIO,
+  )
 
 
 class SafetensorsLayout(CheckpointLayout):
-  """SafetensorsLayout.
+  """Handles checkpoints in the HuggingFace Safetensors format.
 
-  This class defines a class to handle Safetensors checkpoint formats. It
-  inherits abstract methods from :py:class:`~.CheckpointLayout`.
-  It performs a few core functions:
-    - Resolves handlers for saving and loading.
-    - Saves and loads checkpointables to/from individual subdirectories by
-    delegating to the resolved handlers.
+  Inherits the abstract methods of :py:class:`~.CheckpointLayout`. Loading is
+  resharding-aware: see the module docstring. Saving is not yet supported.
   """
 
   def __init__(self):
@@ -781,6 +771,40 @@ class SafetensorsLayout(CheckpointLayout):
       raise ValueError(
           "SafetensorsLayout is not supported on Pathways backend."
       )
+
+  async def validate_checkpointables(self, path: Path):
+    """Validates that `path` is a SafeTensors file or a directory of them."""
+    if await async_path.is_file(path):
+      if path.suffix == SAFETENSORS_SUFFIX:
+        return
+      raise InvalidLayoutError(
+          f"Failed to interpret path {path} as a SafeTensors checkpoint. A"
+          " SafeTensors checkpoint must be a file with the"
+          f" '{SAFETENSORS_SUFFIX}' suffix."
+      )
+    elif await async_path.is_dir(path):
+      files = list(await async_path.glob(path, f"*{SAFETENSORS_SUFFIX}"))
+      if not files:
+        raise InvalidLayoutError(
+            f"Directory {path} does not contain any '{SAFETENSORS_SUFFIX}'"
+            " files."
+        )
+    else:
+      raise InvalidLayoutError(
+          f"Path {path} is neither a file nor a directory or does not exist."
+      )
+
+  async def get_checkpointable_names(  # pyrefly: ignore[bad-override]
+      self, path: Path
+  ) -> list[str]:
+    del path
+    return []
+
+  async def validate(
+      self, path: Path, checkpointable_name: str | None
+  ) -> None:
+    """No-op: there is nothing PyTree-specific to validate."""
+    del path, checkpointable_name
 
   async def checkpointables_metadata(
       self, path: Path
@@ -796,35 +820,30 @@ class SafetensorsLayout(CheckpointLayout):
   ) -> metadata_types.CheckpointMetadata[AbstractCheckpointable]:
     """Returns the flat checkpoint metadata for the Safetensors checkpoint."""
     del checkpointable_name  # Safetensors is always flat; name is unused.
-    return await _MultiFileLoader(path).load_metadata()
-
-  async def validate_checkpointables(self, path: Path):
-    if await async_path.is_file(path):
-      if path.suffix == SAFETENSORS_SUFFIX:
-        return
-      raise InvalidLayoutError(
-          f"Failed to interpret path {path} as a SafeTensors checkpoint. A"
-          " SafeTensors checkpoint must be a file with the"
-          f" '{SAFETENSORS_SUFFIX}' suffix."
-      )
-    elif await async_path.is_dir(path):
-      # Check if it contains any .safetensors files
-      files = list(await async_path.glob(path, f"*{SAFETENSORS_SUFFIX}"))
-      if not files:
-        raise InvalidLayoutError(
-            f"Directory {path} does not contain any '{SAFETENSORS_SUFFIX}'"
-            " files."
-        )
-    else:
-      raise InvalidLayoutError(
-          f"Path {path} is neither a file nor a directory or does not exist."
-      )
-
-  async def get_checkpointable_names(self, path: Path) -> list[str]:  # pyrefly: ignore[bad-override]
-    return []
-
-  async def validate(self, path: Path, checkpointable_name: str | None) -> None:
-    return
+    item_metadata: dict[str, jax.ShapeDtypeStruct] = {}
+    custom_metadata: dict[str, Any] = {}
+    commit_timestamp_nsecs: int | None = None
+    for file_path in await _discover_files(path):
+      header, _ = await _read_header(file_path)
+      stat = await async_path.async_stat(file_path)
+      ts = int(stat.mtime)
+      if commit_timestamp_nsecs is None or ts > commit_timestamp_nsecs:
+        commit_timestamp_nsecs = ts
+      for name, info in header.items():
+        if name == "__metadata__":
+          if info:
+            custom_metadata.update(info)
+          continue
+        if name in item_metadata:
+          raise ValueError(f"Duplicate tensor {name} found in multiple files.")
+        shape, dtype = _get_array_properties(info)
+        item_metadata[name] = jax.ShapeDtypeStruct(shape=shape, dtype=dtype)
+    return metadata_types.CheckpointMetadata(
+        path=path,
+        metadata=item_metadata,
+        commit_timestamp_nsecs=commit_timestamp_nsecs,
+        custom_metadata=custom_metadata,
+    )
 
   async def load(
       self,
@@ -832,24 +851,31 @@ class SafetensorsLayout(CheckpointLayout):
       checkpointable_name: str | None = None,
       abstract_state: AbstractCheckpointable | None = None,
   ) -> Awaitable[Checkpointable]:
-    """Loads a NumPy checkpoint file.
-
-    If `abstract_state` is provided, it attempts to load numpy arrays as
-    sharded `jax.Arrays` onto devices.
+    """Loads a flat PyTree of arrays from a SafeTensors checkpoint.
 
     Args:
-      path: The path to load the checkpoint from.
-      checkpointable_name: The name of the pytree checkpointable to load,
-        unsused in this case.
-      abstract_state: An optional PyTree of abstract arrays specifying sharding
-        information.
+      path: A `.safetensors` file, or a directory containing such files.
+      checkpointable_name: Unused; SafeTensors checkpoints expose one
+        checkpointable.
+      abstract_state: An optional flat dict mapping tensor name to an abstract
+        leaf (`jax.ShapeDtypeStruct`). When provided, each leaf's sharding
+        drives the load: every process reads only the byte ranges its own
+        devices need. When `None`, every tensor is materialised in full on
+        this host (single-process only).
 
     Returns:
-      An awaitable containing the loaded PyTree.
+      An awaitable resolving to the loaded flat dict of arrays.
+
+    Raises:
+      ValueError: If `abstract_state` is provided but is not a flat dict.
     """
     del checkpointable_name
-    self._loader = _MultiFileLoader(path)
-    return self._loader.load_safetensors(abstract_state)
+    if abstract_state is not None and not tree_utils.is_flat_dict(
+        abstract_state
+    ):
+      raise ValueError("The PyTree is not a flat dictionary.")
+    file_index = await self._build_file_index(path)
+    return self._load(file_index, abstract_state)
 
   async def load_checkpointables(
       self,
@@ -867,7 +893,102 @@ class SafetensorsLayout(CheckpointLayout):
       *,
       checkpointables: dict[str, Checkpointable],
   ) -> Awaitable[None]:
-    """Saves the checkpoint to the given directory."""
+    """Raises: saving to Safetensors is not supported."""
+    del path, checkpointables
     raise NotImplementedError(
         "Saving to Safetensors format is not supported yet."
     )
+
+  async def _build_file_index(self, path: Path) -> dict[str, _FileEntry]:
+    """Maps each tensor name to where to find it (`_FileEntry`)."""
+    file_index: dict[str, _FileEntry] = {}
+    for file_path in await _discover_files(path):
+      header, data_start = await _read_header(file_path)
+      await _check_file_length(file_path, header, data_start)
+      for name, info in header.items():
+        if name == "__metadata__":
+          continue
+        if name in file_index:
+          raise ValueError(f"Duplicate tensor {name} found in multiple files.")
+        file_index[name] = _FileEntry(file_path, info, data_start)
+    return file_index
+
+  async def _load(
+      self,
+      file_index: dict[str, _FileEntry],
+      abstract_state: dict[str, Any] | None,
+  ) -> dict[str, Any]:
+    """Background load phase: registers reads, runs schedulers, assembles."""
+    context = context_lib.get_context()
+    opts = context.safetensors_options
+    max_over_read_ratio = (
+        opts.max_over_read_ratio
+        if opts.max_over_read_ratio is not None
+        else _DEFAULT_MAX_OVER_READ_RATIO
+    )
+    # In-flight read bytes reuse the shared restore knob,
+    # `MemoryOptions.read_concurrent_bytes` (the same limit TensorStore restore
+    # uses). `None` means "no limit" there, but the streaming/chunk-sizing here
+    # needs a finite budget, so fall back to the loader default.
+    read_concurrent_bytes = context.memory_options.read_concurrent_bytes
+    max_in_flight_bytes = (
+        read_concurrent_bytes
+        if read_concurrent_bytes is not None
+        else _DEFAULT_MAX_IN_FLIGHT_BYTES
+    )
+    # One shared limiter across every file's scheduler. Peak in-flight memory
+    # for the entire load is bounded at `max_in_flight_bytes` regardless of
+    # how many files or how large each file is. `LimitInFlightBytes` reserves
+    # strictly fewer bytes than its max, so size it one over: a single chunk
+    # can then reserve the full `max_in_flight_bytes`, and concurrent
+    # reservations still sum to at most `max_in_flight_bytes`.
+    byte_budget = limits.LimitInFlightBytes(max_in_flight_bytes + 1)
+    schedulers: dict[Path, _PerFileScheduler] = {}
+
+    def scheduler_for(file_path: Path) -> _PerFileScheduler:
+      if (sched := schedulers.get(file_path)) is None:
+        sched = _PerFileScheduler(file_path, byte_budget, max_over_read_ratio)
+        schedulers[file_path] = sched
+      return sched
+
+    if abstract_state is None:
+      if multihost.process_count() > 1:
+        raise ValueError(
+            "abstract_state must be provided for multi-process loading."
+        )
+      names = list(file_index.keys())
+    else:
+      for name in abstract_state:
+        if name not in file_index:
+          raise KeyError(
+              f"Tensor '{name}' not found in Safetensors checkpoint."
+          )
+      names = sorted(abstract_state)
+
+    # Phase 1 (sync): register every byte range this process needs with the
+    # per-file schedulers and pre-allocate the destination buffers. Each
+    # register returns a `build()` that turns the (yet-unfilled) buffers
+    # into a `jax.Array` once the schedulers have run.
+    build_fns: list[Callable[[], Any]] = []
+    for name in names:
+      entry = file_index[name]
+      sched = scheduler_for(entry.path)
+      if abstract_state is None:
+        build_fns.append(_register_whole_tensor_reads(entry, sched))
+      else:
+        build_fns.append(
+            _register_sharded_tensor_reads(entry, abstract_state[name], sched)
+        )
+
+    # Phase 2 (async): all reads in parallel, bounded by the shared limiter.
+    # The scheduler's callbacks fill the pre-allocated buffers in place; no
+    # intermediate byte slices are held in futures.
+    stats = await asyncio.gather(*[s.execute() for s in schedulers.values()])
+    _record_read_stats(stats)
+    _warn_if_reads_fragmented(
+        stats, len(schedulers), opts.max_over_read_ratio is None
+    )
+
+    # Phase 3 (sync): build `jax.Array`s from the now-populated buffers.
+    arrays = [fn() for fn in build_fns]
+    return dict(zip(names, arrays))

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
@@ -23,18 +23,19 @@ reads. This mirrors how the v0 array deserializer
 `jax.sharding.Sharding.devices_indices_map`, with hand-computed byte ranges
 standing in for TensorStore's chunk index.
 
-Byte runs from every tensor a process needs in one file are coalesced together
-by a per-file scheduler under a single bounded-over-read policy: a
-`max_over_read_ratio` cap on `block_size / needed_bytes` keeps cross-host
-egress from blowing up to N x file_size on inner-dim sharding. The scheduler
-then issues each coalesced block as one ranged read -- or streams it in
-budget-sized chunks when the block exceeds the in-flight byte budget
-(`MemoryOptions.read_concurrent_bytes`, the shared restore memory cap). Peak
-host memory beyond the destination shard buffers is bounded at that budget
-regardless of block, shard, or file size.
-The single-host degenerate case -- one process owns every byte of a file --
-collapses to one read per file when the file fits the budget, and a small
-number of back-to-back reads otherwise.
+Byte runs from every tensor a process needs in one file are coalesced under a
+single bounded-over-read policy: a `max_over_read_ratio` cap on
+`block_size / needed_bytes` keeps cross-host egress from blowing up to
+N x file_size on inner-dim sharding. Each coalesced block is then split at a
+fixed chunk size and the chunks are read concurrently, with total in-flight
+bytes bounded by the shared restore budget
+(`MemoryOptions.read_concurrent_bytes`). Peak host memory beyond the
+destination shard buffers is bounded at that budget regardless of block,
+shard, or file size, while a block larger than one chunk -- the single-host
+whole-file case especially -- is fetched as parallel ranged reads instead of
+one long single-stream read. As each file's reads complete, its tensors are
+assembled into `jax.Array`s and their host buffers released while other files
+are still reading.
 """
 
 import asyncio
@@ -86,12 +87,18 @@ _DEFAULT_MAX_OVER_READ_RATIO = 2.0
 # read-count-vs-egress tradeoff is genuinely backend-dependent.
 _DEFAULT_MIN_COALESCE_GAP = 4096  # one page
 # `_DEFAULT_MAX_IN_FLIGHT_BYTES` caps total bytes the loader holds in flight
-# across all concurrent reads in one load call. A single coalesced block
-# larger than this budget is streamed in budget-sized chunks; smaller blocks
-# run concurrently up to the budget. Peak host memory beyond destination
-# shard buffers is bounded at `max_in_flight_bytes` regardless of block,
-# shard, or file size.
+# across all concurrent reads in one load call. Chunks run concurrently up to
+# the budget, so peak host memory beyond destination shard buffers is bounded
+# at `max_in_flight_bytes` regardless of block, shard, or file size.
 _DEFAULT_MAX_IN_FLIGHT_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+# Coalesced blocks are split at this size and the pieces are read
+# concurrently (subject to the in-flight budget). One ranged read runs at
+# single-stream throughput -- on object storage a small fraction of what
+# concurrent range reads achieve -- so a large block is fetched as parallel
+# chunks rather than one long read. 128 MiB keeps per-request overhead
+# negligible while the default 2 GiB budget still admits 16 concurrent
+# streams.
+_DEFAULT_READ_CHUNK_BYTES = 128 * 1024 * 1024  # 128 MiB
 
 # When the over-read cap fragments a load into many small reads -- the strided
 # inner-dim regime -- hint the user toward `max_over_read_ratio`. The warning
@@ -149,6 +156,27 @@ async def _discover_files(path: Path) -> list[Path]:
   if await async_path.is_dir(path):
     return sorted(await async_path.glob(path, f"*{SAFETENSORS_SUFFIX}"))
   return [path]
+
+
+async def _read_all_headers(
+    path: Path,
+) -> list[tuple[Path, dict[str, Any], int]]:
+  """Reads every file's header concurrently.
+
+  A sharded HuggingFace checkpoint can span hundreds of files; reading their
+  headers one after another costs one storage round trip each, so they are
+  fetched in parallel.
+
+  Args:
+    path: A `.safetensors` file, or a directory containing such files.
+
+  Returns:
+    One `(file_path, header, data_start)` tuple per file, in sorted file
+    order.
+  """
+  files = await _discover_files(path)
+  headers = await asyncio.gather(*[_read_header(f) for f in files])
+  return [(f, h, ds) for f, (h, ds) in zip(files, headers)]
 
 
 async def _check_file_length(
@@ -276,10 +304,10 @@ def _partition_runs(
 ) -> list[_CoalescedBlock]:
   """Greedily partitions `(offset, length)` runs into coalesced read blocks.
 
-  Each emitted block is read with one ranged read (or streamed in budget-sized
-  chunks by `_PerFileScheduler` when oversized) and demultiplexed back to its
-  member runs. The partitioner absorbs the next run into the current block when
-  *either* of two conditions holds:
+  Each emitted block is split at the read chunk size into one or more ranged
+  reads and demultiplexed back to its member runs (`_plan_chunk_reads`). The
+  partitioner absorbs the next run into the current block when *either* of two
+  conditions holds:
 
   - `block_size / needed_bytes <= max_over_read_ratio` -- bounding per-host
     egress amplification. With `max_over_read_ratio == 2.0`, a host pulls at
@@ -291,8 +319,8 @@ def _partition_runs(
     gap is always cheaper than a second request.
 
   Block size is intentionally unbounded here. Peak in-flight memory is bounded
-  separately by the scheduler's byte budget (`max_in_flight_bytes`), which
-  also enforces correctness for any block too large to read in one go. This
+  separately by the shared byte budget (`max_in_flight_bytes`), which also
+  enforces correctness for any block too large to read in one go. This
   separation makes the partition policy purely about over-read and the
   budget purely about memory -- each knob expressing one concern.
 
@@ -365,146 +393,149 @@ class _FileEntry(NamedTuple):
   data_start: int  # Byte offset of the file's data section.
 
 
-_RunCallback = Callable[[memoryview], None]
+class _Read(NamedTuple):
+  """One byte run a tensor needs, with its destination buffer."""
+
+  offset: int  # Absolute byte offset of the run in the file.
+  length: int  # Length of the run in bytes.
+  dst: np.ndarray  # Flat `uint8` destination view, `length` bytes long.
+
+
+class _ChunkWrite(NamedTuple):
+  """One precomputed chunk-to-buffer copy."""
+
+  dst: np.ndarray  # Flat `uint8` destination view, sliced to the copy length.
+  start: int  # Chunk-local start of the source bytes.
+  stop: int  # Chunk-local end of the source bytes.
+
+
+class _ChunkRead(NamedTuple):
+  """One ranged read and the buffer copies its bytes serve."""
+
+  offset: int  # Absolute byte offset of the read.
+  length: int  # Length of the read in bytes.
+  writes: tuple[_ChunkWrite, ...]
 
 
 class _ReadStats(NamedTuple):
   """Per-file read accounting, aggregated for the fragmentation hint."""
 
-  needed_bytes: int  # Bytes the registered runs actually need.
+  needed_bytes: int  # Bytes the planned runs actually need.
   read_bytes: int  # Bytes the coalesced blocks pull (>= needed_bytes).
   num_reads: int  # Coalesced blocks (ranged-read requests; ~1 per file ideal).
-  num_gets: int  # Actual storage GETs (>= num_reads; splits blocks > budget).
+  num_gets: int  # Actual storage GETs (>= num_reads; blocks split per chunk).
 
 
-class _PerFileScheduler:
-  """Coalesces and issues reads for one safetensors file.
+def _plan_chunk_reads(
+    reads: Sequence[_Read],
+    max_over_read_ratio: float,
+    chunk_bytes: int,
+) -> tuple[list[_ChunkRead], _ReadStats]:
+  """Plans the ranged reads serving one file's byte runs.
 
-  Callers `register(offset, length, callback)` synchronously while they plan
-  their per-tensor reads. After all registrations complete, `execute()`
-  partitions the registered runs under the over-read ratio cap, then for
-  each coalesced block issues one ranged read -- or streams the block in
-  budget-sized chunks if it exceeds `max_in_flight_bytes`. Each chunk's
-  bytes are dispatched to every registered callback whose range intersects
-  it, sliced to the run-local bytes the callback expects.
+  The runs are coalesced into blocks under the over-read ratio cap
+  (`_partition_runs`), then each block is split at `chunk_bytes` so that a
+  large block becomes several concurrent ranged reads instead of one long
+  single-stream read. Every chunk carries its precomputed buffer copies, so
+  chunks can complete in any order and no per-run state is needed at read
+  time.
 
-  Callback contract: a callback for a registered run may be invoked
-  multiple times, always in increasing offset order, each invocation
-  carrying a contiguous sub-range of the run's bytes. The callback should
-  write the bytes into its destination buffer starting at the cursor
-  position equal to "total bytes already delivered to this callback." The
-  helpers `_register_*_tensor_reads` in this file follow that pattern.
+  Args:
+    reads: The byte runs to serve, each with its destination buffer.
+    max_over_read_ratio: Upper bound on `block_size / needed_bytes` per block.
+    chunk_bytes: Maximum size of one ranged read. Must be positive and at
+      most the in-flight byte budget, so any single chunk can be reserved.
 
-  Concurrency: `register()` must finish for every tensor that touches this
-  file before `execute()` runs; otherwise a late registration would be
-  silently dropped. The `SafetensorsLayout._load` orchestration arranges
-  this by performing all registrations synchronously before scheduling any
-  scheduler `execute()` task. Peak in-flight memory is bounded at the
-  shared budget regardless of how many schedulers run concurrently.
+  Returns:
+    The chunk reads covering every run, and the file's read accounting.
   """
+  blocks = _partition_runs(
+      [(r.offset, r.length) for r in reads], max_over_read_ratio
+  )
+  chunks: list[_ChunkRead] = []
+  for block in blocks:
+    members = block.members  # Sorted by run offset (see `_partition_runs`).
+    first = 0
+    for pos in range(block.start, block.end, chunk_bytes):
+      chunk_end = min(pos + chunk_bytes, block.end)
+      # Runs are offset-sorted, so a member fully below `pos` stays consumed
+      # for every later chunk of this block.
+      while first < len(members):
+        r = reads[members[first]]
+        if r.offset + r.length > pos:
+          break
+        first += 1
+      writes = []
+      for member in itertools.islice(members, first, None):
+        r = reads[member]
+        if r.offset >= chunk_end:
+          break
+        lo = max(r.offset, pos)
+        hi = min(r.offset + r.length, chunk_end)
+        if lo < hi:
+          writes.append(
+              _ChunkWrite(
+                  dst=r.dst[lo - r.offset : hi - r.offset],
+                  start=lo - pos,
+                  stop=hi - pos,
+              )
+          )
+      chunks.append(_ChunkRead(pos, chunk_end - pos, tuple(writes)))
+  return chunks, _ReadStats(
+      needed_bytes=sum(r.length for r in reads),
+      read_bytes=sum(b.end - b.start for b in blocks),
+      num_reads=len(blocks),
+      num_gets=len(chunks),
+  )
 
-  def __init__(
-      self,
-      path: Path,
-      byte_budget: limits.LimitInFlightBytes,
-      max_over_read_ratio: float,
-  ):
-    self._path = path
-    self._budget = byte_budget
-    self._max_over_read_ratio = max_over_read_ratio
-    self._requests: list[tuple[int, int, _RunCallback]] = []
 
-  def register(self, offset: int, length: int, callback: _RunCallback) -> None:
-    """Records a byte range this host needs and the callback to receive it."""
-    self._requests.append((offset, length, callback))
+async def _read_chunk(
+    path: Path, chunk: _ChunkRead, byte_budget: limits.LimitInFlightBytes
+) -> None:
+  """Reads one chunk and copies its bytes into the destination buffers.
 
-  async def execute(self) -> _ReadStats:
-    """Reads all registered byte runs and returns this file's read accounting."""
-    if not self._requests:
-      return _ReadStats(needed_bytes=0, read_bytes=0, num_reads=0, num_gets=0)
-    runs = [(off, length) for off, length, _ in self._requests]
-    blocks = _partition_runs(runs, self._max_over_read_ratio)
-    try:
-      gets_per_block = await asyncio.gather(
-          *[self._read_block(b) for b in blocks]
-      )
-    finally:
-      # Drop callback closures so any buffers they captured can be GC'd as
-      # soon as their callers release them.
-      self._requests = []
-    return _ReadStats(
-        needed_bytes=sum(length for _, length in runs),
-        read_bytes=sum(b.end - b.start for b in blocks),
-        num_reads=len(blocks),
-        num_gets=sum(gets_per_block),
-    )
+  Args:
+    path: The file to read from. Each read opens its own handle, so chunks
+      are safe to issue concurrently.
+    chunk: The byte range to read and the buffer copies it serves.
+    byte_budget: The shared in-flight byte limiter; the chunk's bytes stay
+      reserved until they have been copied out.
+  """
+  async with limits.reserved_bytes(byte_budget, chunk.length):
+    async with async_path.open_file(path, mode="rb") as f:
+      await f.seek(chunk.offset)
+      # `AsyncFile.read` is declared `bytes | str`; `mode="rb"` guarantees
+      # bytes at runtime but pytype can't narrow that statically.
+      data = cast(bytes, await f.read(chunk.length))
+    src = memoryview(data)
+    for w in chunk.writes:
+      w.dst[:] = np.frombuffer(src[w.start : w.stop], dtype=np.uint8)
 
-  async def _read_block(self, block: _CoalescedBlock) -> int:
-    """Reads one coalesced block, streaming in chunks if oversized.
 
-    Args:
-      block: The coalesced byte range to read from this file.
+async def _read_file(
+    path: Path,
+    reads: Sequence[_Read],
+    byte_budget: limits.LimitInFlightBytes,
+    max_over_read_ratio: float,
+    chunk_bytes: int,
+) -> _ReadStats:
+  """Serves all of one file's byte runs with concurrent ranged reads.
 
-    Returns:
-      The number of storage GETs issued for the block -- one per chunk, so a
-      block within the in-flight budget is a single GET and a larger one is
-      several.
-    """
-    # `LimitInFlightBytes` reserves strictly fewer bytes than its max, and the
-    # limiter is sized one over `max_in_flight_bytes` (see `_load`), so the
-    # largest reservable chunk is exactly `max_in_flight_bytes`.
-    chunk_cap = self._budget.max_bytes - 1
-    pos = block.start
-    gets = 0
-    while pos < block.end:
-      chunk_end = min(pos + chunk_cap, block.end)
-      chunk_len = chunk_end - pos
-      async with limits.reserved_bytes(self._budget, chunk_len):
-        async with async_path.open_file(self._path, mode="rb") as f:
-          await f.seek(pos)
-          # `AsyncFile.read` is declared `bytes | str`; `mode="rb"` guarantees
-          # bytes at runtime but pytype can't narrow that statically.
-          chunk_bytes = cast(bytes, await f.read(chunk_len))
-        mv = memoryview(chunk_bytes)
-        self._dispatch_chunk(block, mv, pos, chunk_len)
-        # Drop our refs; the buffer can be GC'd once any memoryviews the
-        # callbacks may have retained go out of scope.
-        del mv, chunk_bytes
-      gets += 1
-      pos = chunk_end
-    return gets
+  Args:
+    path: The `.safetensors` file to read from.
+    reads: The byte runs this host needs from the file.
+    byte_budget: The shared in-flight byte limiter (shared across files).
+    max_over_read_ratio: Upper bound on `block_size / needed_bytes` per block.
+    chunk_bytes: Maximum size of one ranged read.
 
-  def _dispatch_chunk(
-      self,
-      block: _CoalescedBlock,
-      mv: memoryview,
-      chunk_start: int,
-      chunk_len: int,
-  ) -> None:
-    """Invokes every member's callback with the slice of `mv` it owns.
-
-    For each registered run in `block`, computes the intersection with the
-    chunk `[chunk_start, chunk_start + chunk_len)` and -- if non-empty --
-    invokes the callback with the corresponding slice of `mv`. Runs that do
-    not intersect this chunk are skipped (they will be served by another
-    chunk in the same block).
-
-    Args:
-      block: The coalesced block whose member runs may intersect the chunk.
-      mv: A memoryview over the bytes of the current chunk.
-      chunk_start: Absolute file offset where the chunk begins.
-      chunk_len: Length of the chunk in bytes.
-    """
-    chunk_end = chunk_start + chunk_len
-    for member_idx in block.members:
-      run_offset, run_length, callback = self._requests[member_idx]
-      run_end = run_offset + run_length
-      hit_start = max(chunk_start, run_offset)
-      hit_end = min(chunk_end, run_end)
-      if hit_start < hit_end:
-        local_start = hit_start - chunk_start
-        local_end = hit_end - chunk_start
-        callback(mv[local_start:local_end])
+  Returns:
+    The file's read accounting.
+  """
+  if not reads:
+    return _ReadStats(needed_bytes=0, read_bytes=0, num_reads=0, num_gets=0)
+  chunks, stats = _plan_chunk_reads(reads, max_over_read_ratio, chunk_bytes)
+  await asyncio.gather(*[_read_chunk(path, c, byte_budget) for c in chunks])
+  return stats
 
 
 def _allocate_buffer(
@@ -512,7 +543,7 @@ def _allocate_buffer(
 ) -> tuple[np.ndarray, np.ndarray]:
   """Allocates a contiguous buffer + a flat `uint8` view over its bytes.
 
-  The flat view is the canonical write-target for byte-level callbacks; it
+  The flat view is the canonical write-target for byte-level chunk copies; it
   works uniformly for scalars (`shape == ()`), 1-D, and N-D buffers, where
   `np.ndarray.view(uint8)` on a 0-D array does not.
 
@@ -530,83 +561,48 @@ def _allocate_buffer(
   return buf, flat_u8
 
 
-def _make_cursor_receive(dst: np.ndarray) -> _RunCallback:
-  """Builds a callback that appends successive chunks into a flat buffer.
-
-  Implements the partial-delivery contract from `_PerFileScheduler`: each
-  invocation writes the chunk's bytes at the cursor position and advances
-  the cursor by the chunk length. After all expected chunks arrive, the
-  cursor equals `len(dst)`.
-
-  Args:
-    dst: Flat destination buffer the chunks are written into.
-
-  Returns:
-    A callback that writes each received chunk at the running cursor.
-  """
-  cursor = [0]
-
-  def receive(chunk: memoryview) -> None:
-    n = len(chunk)
-    end = cursor[0] + n
-    dst[cursor[0] : end] = np.frombuffer(chunk, dtype=np.uint8)
-    cursor[0] = end
-
-  return receive
-
-
-def _register_whole_tensor_reads(
+def _plan_whole_tensor(
     entry: _FileEntry,
-    scheduler: _PerFileScheduler,
-) -> Callable[[], np.ndarray]:
-  """Sync: pre-allocates the destination array and registers one read.
+) -> tuple[list[_Read], Callable[[], np.ndarray]]:
+  """Plans one full-tensor read into a host array.
 
   Used when no `abstract_state` is given -- there is no target sharding to
   drive a partial read, so each tensor is materialised in full on this host.
-  The scheduler writes directly into the pre-allocated array; the returned
-  builder function just returns it.
+  The chunk reads write directly into the pre-allocated array; the returned
+  builder just returns it.
 
   Args:
     entry: The file entry describing the tensor's location and header info.
-    scheduler: The per-file read scheduler the read is registered with.
 
   Returns:
-    A builder that returns the fully materialised array after execution.
+    The tensor's byte runs, and a builder that returns the materialised
+    array once they have been read.
   """
   shape, dtype = _get_array_properties(entry.info)
   dtype = np.dtype(dtype)
   begin, end = entry.info["data_offsets"]
   buf, flat_u8 = _allocate_buffer(shape, dtype)
-  scheduler.register(
-      entry.data_start + begin, end - begin, _make_cursor_receive(flat_u8)
-  )
-
-  def build() -> np.ndarray:
-    return buf
-
-  return build
+  return [_Read(entry.data_start + begin, end - begin, flat_u8)], lambda: buf
 
 
-def _register_sharded_tensor_reads(
+def _plan_sharded_tensor(
     entry: _FileEntry,
     abstract_leaf: Any,
-    scheduler: _PerFileScheduler,
-) -> Callable[[], jax.Array]:
-  """Sync: pre-allocates one shard buffer per local-device shard.
+) -> tuple[list[_Read], Callable[[], jax.Array]]:
+  """Plans the shard reads this process's devices need for one tensor.
 
   For each unique index domain owned by one of this process's devices, the
-  shard buffer is allocated once. Each of the shard's byte runs is
-  registered with a callback that copies its bytes into the buffer at the
-  correct row offset. The returned builder turns the populated buffers
-  (after `scheduler.execute()`) into a sharded `jax.Array`.
+  shard buffer is allocated once, and each of the shard's byte runs targets
+  the prefix of that buffer it occupies. The returned builder turns the
+  populated buffers into a sharded `jax.Array`.
 
   Args:
     entry: The file entry describing the tensor's location and header info.
     abstract_leaf: The abstract array (shape, dtype, sharding) to build.
-    scheduler: The per-file read scheduler the reads are registered with.
 
   Returns:
-    A builder that assembles the populated shard buffers into a `jax.Array`.
+    The tensor's byte runs, and a builder that assembles the populated shard
+    buffers into a `jax.Array` once they have been read.
 
   Raises:
     ValueError: If the abstract state's shape disagrees with the checkpoint.
@@ -632,6 +628,7 @@ def _register_sharded_tensor_reads(
     if device.process_index == this_process:
       index_to_devices[_normalize_index(index, global_shape)].append(device)
 
+  reads: list[_Read] = []
   shard_specs: list[tuple[np.ndarray, list[jax.Device]]] = []
   for bounds, devices in index_to_devices.items():
     shard_shape = tuple(stop - start for start, stop in bounds)
@@ -644,11 +641,7 @@ def _register_sharded_tensor_reads(
     write_offset = 0
     for off, length in runs:
       end_byte = write_offset + length
-      scheduler.register(
-          off,
-          length,
-          _make_cursor_receive(shard_flat_u8[write_offset:end_byte]),
-      )
+      reads.append(_Read(off, length, shard_flat_u8[write_offset:end_byte]))
       write_offset = end_byte
     shard_specs.append((shard_buf, devices))
 
@@ -674,7 +667,7 @@ def _register_sharded_tensor_reads(
         global_shape, sharding, arrays, dtype=out_dtype
     )
 
-  return build
+  return reads, build
 
 
 def _record_read_stats(stats: Sequence[_ReadStats]) -> None:
@@ -686,13 +679,13 @@ def _record_read_stats(stats: Sequence[_ReadStats]) -> None:
   `/jax/orbax/read/...`, so a benchmark can capture safetensors reads through
   the standard jax.monitoring listener with no dependency on this loader.
 
-  Two read counts are reported: `num_reads` is the coalesced ranged-read
-  requests (~1 per file when fully coalesced), and `storage_reads` is the
-  actual GETs issued, which is >= `num_reads` because a block larger than the
-  in-flight budget is fetched in several chunks.
+  Two read counts are reported: `num_reads` is the coalesced blocks (~1 per
+  file when fully coalesced), and `storage_reads` is the actual GETs issued,
+  which is >= `num_reads` because a block larger than the read chunk size is
+  fetched as several concurrent ranged reads.
 
   Args:
-    stats: Per-file read accounting from each scheduler's `execute()`.
+    stats: Per-file read accounting from each file's reads.
   """
   jax.monitoring.record_scalar(
       "/jax/orbax/read/safetensors/bytes_read",
@@ -725,7 +718,7 @@ def _warn_if_reads_fragmented(
   load genuinely spans many files."
 
   Args:
-    stats: Per-file read accounting from each scheduler's `execute()`.
+    stats: Per-file read accounting from each file's reads.
     num_files: Number of distinct files the load read from.
     max_over_read_ratio_is_default: Whether the user left `max_over_read_ratio`
       unset; only then is "raise the ratio" actionable advice.
@@ -820,15 +813,16 @@ class SafetensorsLayout(CheckpointLayout):
   ) -> metadata_types.CheckpointMetadata[AbstractCheckpointable]:
     """Returns the flat checkpoint metadata for the Safetensors checkpoint."""
     del checkpointable_name  # Safetensors is always flat; name is unused.
+    entries = await _read_all_headers(path)
+    stats = await asyncio.gather(
+        *[async_path.async_stat(file_path) for file_path, _, _ in entries]
+    )
+    commit_timestamp_nsecs = (
+        max(int(stat.mtime) for stat in stats) if stats else None
+    )
     item_metadata: dict[str, jax.ShapeDtypeStruct] = {}
     custom_metadata: dict[str, Any] = {}
-    commit_timestamp_nsecs: int | None = None
-    for file_path in await _discover_files(path):
-      header, _ = await _read_header(file_path)
-      stat = await async_path.async_stat(file_path)
-      ts = int(stat.mtime)
-      if commit_timestamp_nsecs is None or ts > commit_timestamp_nsecs:
-        commit_timestamp_nsecs = ts
+    for _, header, _ in entries:
       for name, info in header.items():
         if name == "__metadata__":
           if info:
@@ -901,10 +895,12 @@ class SafetensorsLayout(CheckpointLayout):
 
   async def _build_file_index(self, path: Path) -> dict[str, _FileEntry]:
     """Maps each tensor name to where to find it (`_FileEntry`)."""
+    entries = await _read_all_headers(path)
+    await asyncio.gather(
+        *[_check_file_length(f, header, ds) for f, header, ds in entries]
+    )
     file_index: dict[str, _FileEntry] = {}
-    for file_path in await _discover_files(path):
-      header, data_start = await _read_header(file_path)
-      await _check_file_length(file_path, header, data_start)
+    for file_path, header, data_start in entries:
       for name, info in header.items():
         if name == "__metadata__":
           continue
@@ -918,7 +914,7 @@ class SafetensorsLayout(CheckpointLayout):
       file_index: dict[str, _FileEntry],
       abstract_state: dict[str, Any] | None,
   ) -> dict[str, Any]:
-    """Background load phase: registers reads, runs schedulers, assembles."""
+    """Background load phase: plans reads, reads files, assembles arrays."""
     context = context_lib.get_context()
     opts = context.safetensors_options
     max_over_read_ratio = (
@@ -928,28 +924,22 @@ class SafetensorsLayout(CheckpointLayout):
     )
     # In-flight read bytes reuse the shared restore knob,
     # `MemoryOptions.read_concurrent_bytes` (the same limit TensorStore restore
-    # uses). `None` means "no limit" there, but the streaming/chunk-sizing here
-    # needs a finite budget, so fall back to the loader default.
+    # uses). `None` means "no limit" there, but the chunk sizing here needs a
+    # finite budget, so fall back to the loader default.
     read_concurrent_bytes = context.memory_options.read_concurrent_bytes
     max_in_flight_bytes = (
         read_concurrent_bytes
         if read_concurrent_bytes is not None
         else _DEFAULT_MAX_IN_FLIGHT_BYTES
     )
-    # One shared limiter across every file's scheduler. Peak in-flight memory
-    # for the entire load is bounded at `max_in_flight_bytes` regardless of
-    # how many files or how large each file is. `LimitInFlightBytes` reserves
-    # strictly fewer bytes than its max, so size it one over: a single chunk
-    # can then reserve the full `max_in_flight_bytes`, and concurrent
-    # reservations still sum to at most `max_in_flight_bytes`.
+    chunk_bytes = min(_DEFAULT_READ_CHUNK_BYTES, max_in_flight_bytes)
+    # One shared limiter across every file. Peak in-flight memory for the
+    # entire load is bounded at `max_in_flight_bytes` regardless of how many
+    # files or how large each file is. `LimitInFlightBytes` reserves strictly
+    # fewer bytes than its max, so size it one over: a single chunk can then
+    # reserve the full `max_in_flight_bytes`, and concurrent reservations
+    # still sum to at most `max_in_flight_bytes`.
     byte_budget = limits.LimitInFlightBytes(max_in_flight_bytes + 1)
-    schedulers: dict[Path, _PerFileScheduler] = {}
-
-    def scheduler_for(file_path: Path) -> _PerFileScheduler:
-      if (sched := schedulers.get(file_path)) is None:
-        sched = _PerFileScheduler(file_path, byte_budget, max_over_read_ratio)
-        schedulers[file_path] = sched
-      return sched
 
     if abstract_state is None:
       if multihost.process_count() > 1:
@@ -965,30 +955,47 @@ class SafetensorsLayout(CheckpointLayout):
           )
       names = sorted(abstract_state)
 
-    # Phase 1 (sync): register every byte range this process needs with the
-    # per-file schedulers and pre-allocate the destination buffers. Each
-    # register returns a `build()` that turns the (yet-unfilled) buffers
-    # into a `jax.Array` once the schedulers have run.
-    build_fns: list[Callable[[], Any]] = []
+    # Phase 1 (sync): compute every byte range this process needs, grouped by
+    # file, and pre-allocate the destination buffers. Each tensor's `build()`
+    # turns its (yet-unfilled) buffers into an array once its file is read.
+    reads_by_file: dict[Path, list[_Read]] = collections.defaultdict(list)
+    builds_by_file: dict[Path, list[tuple[str, Callable[[], Any]]]] = (
+        collections.defaultdict(list)
+    )
     for name in names:
       entry = file_index[name]
-      sched = scheduler_for(entry.path)
       if abstract_state is None:
-        build_fns.append(_register_whole_tensor_reads(entry, sched))
+        reads, build = _plan_whole_tensor(entry)
       else:
-        build_fns.append(
-            _register_sharded_tensor_reads(entry, abstract_state[name], sched)
-        )
+        reads, build = _plan_sharded_tensor(entry, abstract_state[name])
+      reads_by_file[entry.path].extend(reads)
+      builds_by_file[entry.path].append((name, build))
 
-    # Phase 2 (async): all reads in parallel, bounded by the shared limiter.
-    # The scheduler's callbacks fill the pre-allocated buffers in place; no
-    # intermediate byte slices are held in futures.
-    stats = await asyncio.gather(*[s.execute() for s in schedulers.values()])
+    # Phase 2 (async): every file's chunks in parallel, bounded together by
+    # the shared limiter. The chunk reads fill the pre-allocated buffers in
+    # place. As soon as one file completes, its tensors are assembled --
+    # overlapping host-to-device transfer with the remaining reads -- and
+    # their host buffers are released.
+    arrays: dict[str, Any] = {}
+
+    async def load_file(file_path: Path) -> _ReadStats:
+      stats = await _read_file(
+          file_path,
+          reads_by_file[file_path],
+          byte_budget,
+          max_over_read_ratio,
+          chunk_bytes,
+      )
+      # Drop the read plan so each shard's host memory can be released as
+      # `build()` moves it on-device.
+      del reads_by_file[file_path]
+      for name, build in builds_by_file[file_path]:
+        arrays[name] = build()
+      return stats
+
+    stats = await asyncio.gather(*map(load_file, list(reads_by_file)))
     _record_read_stats(stats)
     _warn_if_reads_fragmented(
-        stats, len(schedulers), opts.max_over_read_ratio is None
+        stats, len(builds_by_file), opts.max_over_read_ratio is None
     )
-
-    # Phase 3 (sync): build `jax.Array`s from the now-populated buffers.
-    arrays = [fn() for fn in build_fns]
-    return dict(zip(names, arrays))
+    return {name: arrays[name] for name in names}

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
@@ -70,7 +70,9 @@ AbstractCheckpointable = checkpoint_layout.AbstractCheckpointable
 HEADER_NUM_BYTES = 8
 SAFETENSORS_SUFFIX = ".safetensors"
 
-# Per-file scheduler defaults. SafetensorsOptions can override either.
+# Read-planning defaults. `SafetensorsOptions` overrides the over-read ratio
+# (`max_over_read_ratio`) and the chunk size (`read_chunk_bytes`); the
+# in-flight budget comes from `MemoryOptions.read_concurrent_bytes`.
 #
 # `_DEFAULT_MAX_OVER_READ_RATIO` caps `block_size / needed_bytes` for any
 # coalesced read; a host's bytes pulled from one file are bounded at
@@ -932,7 +934,16 @@ class SafetensorsLayout(CheckpointLayout):
         if read_concurrent_bytes is not None
         else _DEFAULT_MAX_IN_FLIGHT_BYTES
     )
-    chunk_bytes = min(_DEFAULT_READ_CHUNK_BYTES, max_in_flight_bytes)
+    read_chunk_bytes = (
+        opts.read_chunk_bytes
+        if opts.read_chunk_bytes is not None
+        else _DEFAULT_READ_CHUNK_BYTES
+    )
+    if read_chunk_bytes <= 0:
+      raise ValueError(
+          f"read_chunk_bytes must be positive, got {read_chunk_bytes}."
+      )
+    chunk_bytes = min(read_chunk_bytes, max_in_flight_bytes)
     # One shared limiter across every file. Peak in-flight memory for the
     # entire load is bounded at `max_in_flight_bytes` regardless of how many
     # files or how large each file is. `LimitInFlightBytes` reserves strictly

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_multiprocess_test.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_multiprocess_test.py
@@ -17,6 +17,7 @@
 import gc
 import tracemalloc
 import unittest
+
 from absl.testing import parameterized
 from etils import epath
 import jax
@@ -26,6 +27,7 @@ import numpy as np
 from orbax.checkpoint import test_utils
 from orbax.checkpoint._src.testing import multiprocess_test
 from orbax.checkpoint.experimental.v1._src.context import context as context_lib
+from orbax.checkpoint.experimental.v1._src.context import options as options_lib
 from orbax.checkpoint.experimental.v1._src.layout import safetensors_layout
 import safetensors.numpy
 
@@ -90,9 +92,7 @@ class ShardedSafetensorsLayoutTest(
 
     devices = jax.devices()
     mesh_shape = (len(devices) // 2, 2)
-    self.mesh = Mesh(
-        np.array(devices).reshape(mesh_shape), ("data", "model")
-    )
+    self.mesh = Mesh(np.array(devices).reshape(mesh_shape), ("data", "model"))
     test_utils.sync_global_processes("setUp")
 
   def tearDown(self):
@@ -133,7 +133,7 @@ class ShardedSafetensorsLayoutTest(
 
     # Create the tensor to save
     if not array_shape:
-      tensor_to_save = np.float32(1.0)
+      tensor_to_save = np.array(1.0, dtype=np.float32)
     else:
       num_elements = np.prod(array_shape)
       tensor_to_save = np.arange(num_elements, dtype=np.float32).reshape(
@@ -162,87 +162,6 @@ class ShardedSafetensorsLayoutTest(
 
     self.assertEqual(restored_tensor.sharding, expected_tensor.sharding)
     test_utils.assert_array_equal(self, expected_tensor, restored_tensor)
-
-  async def test_load_without_global_reshard_single_tensor(self):
-    """Tests loading with ignore_load_sharding=True with a single tensor."""
-    array_shape = (4, 4)
-    tensor_to_save = np.arange(16, dtype=np.float32).reshape(array_shape)
-    tensor_data = {"params.tensor": tensor_to_save}
-
-    st_path = self.test_dir / f"{self.id()}.safetensors"
-    if jax.process_index() == 0:
-      np_save_file(tensor_data, st_path)
-    test_utils.sync_global_processes(self.id())
-
-    abstract_sharding = NamedSharding(self.mesh, PartitionSpec("data", "model"))
-    abstract_state = {
-        "params.tensor": jax.ShapeDtypeStruct(
-            shape=array_shape, dtype=np.float32, sharding=abstract_sharding
-        ),
-    }
-
-    layout = SafetensorsLayout()
-    ctx = context_lib.Context()
-    ctx.safetensors.ignore_load_sharding = True
-    with ctx:
-      restore_fn = await layout.load(
-          st_path, abstract_state=abstract_state
-      )
-      restored_pytree = await restore_fn
-    restored_tensor = restored_pytree["params.tensor"]
-
-    self.assertEqual(restored_tensor.shape, array_shape)
-
-    if len(restored_tensor.addressable_shards) == 1:
-      np.testing.assert_array_equal(
-          restored_tensor.addressable_shards[0].data, tensor_to_save
-      )
-    else:
-      self.assertEmpty(restored_tensor.addressable_shards)
-
-  async def test_load_without_global_reshard_multi_tensor(self):
-    """Tests loading with ignore_load_sharding=True with multiple tensors."""
-    array_shape = (4, 4)
-    tensor_data = {
-        f"params.tensor_{i}": (
-            np.arange(16, dtype=np.float32).reshape(array_shape) + i
-        )
-        for i in range(4)
-    }
-
-    st_path = self.test_dir / f"{self.id()}.safetensors"
-    if jax.process_index() == 0:
-      np_save_file(tensor_data, st_path)
-    test_utils.sync_global_processes(self.id())
-
-    abstract_sharding = NamedSharding(self.mesh, PartitionSpec("data", "model"))
-    abstract_state = {
-        f"params.tensor_{i}": jax.ShapeDtypeStruct(
-            shape=array_shape, dtype=np.float32, sharding=abstract_sharding
-        )
-        for i in range(4)
-    }
-
-    layout = SafetensorsLayout()
-    ctx = context_lib.Context()
-    ctx.safetensors.ignore_load_sharding = True
-    with ctx:
-      restore_fn = await layout.load(st_path, abstract_state=abstract_state)
-      restored_pytree = await restore_fn
-
-    # Tensors are expected to be distributed among hosts.
-    # With 4 hosts and 4 equal sized tensors, each host should own one.
-    for i in range(4):
-      tensor_name = f"params.tensor_{i}"
-      restored_tensor = restored_pytree[tensor_name]
-      self.assertEqual(restored_tensor.shape, array_shape)
-
-      if len(restored_tensor.addressable_shards) == 1:
-        np.testing.assert_array_equal(
-            restored_tensor.addressable_shards[0].data, tensor_data[tensor_name]
-        )
-      else:
-        self.assertEmpty(restored_tensor.addressable_shards)
 
   async def test_load_multi_host_memory_efficiency(self):
     """Verifies that non-owner hosts don't materialize full zero buffers."""
@@ -279,64 +198,16 @@ class ShardedSafetensorsLayoutTest(
 
     tracemalloc.start()
 
-    restore_fn = await layout.load(
-        file_path,
-        abstract_state=abstract_pytree,
-    )
-    pytree = await restore_fn
-
-    jax.block_until_ready(pytree)
-
-    unused_current, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-
-    # Peak memory should be dominated by owned tensors (approx 100MB).
-    # Will also contain a single zero buffer of 4MB to be used in place of all
-    # non-owned tensors.
-    # If non-owned tensors were materialized, it would be 400MB.
-    tensors_per_host = num_tensors // jax.process_count()
-    expected_peak = bytes_per_tensor * (tensors_per_host + 1)
-    fudge_factor = 1.2  # Account for overhead, Python objects, etc.
-
-    self.assertLess(peak, fudge_factor * expected_peak)
-
-  async def test_load_without_global_reshard_memory_efficiency(self):
-    """Verifies that non-owner hosts don't materialize full zero buffers when ignore_load_sharding=True."""
-    num_tensors = 100
-    tensor_shape = (1024, 1024)  # 1M elements = 4MB for float32
-    # Total logical size for 100 tensors = 400MB.
-    num_elements = np.prod(tensor_shape)
-    bytes_per_tensor = num_elements * np.dtype(np.float32).itemsize
-
-    abstract_sharding = NamedSharding(self.mesh, PartitionSpec("data", "model"))
-
-    abstract_pytree = {
-        f"tensor_{i}": jax.ShapeDtypeStruct(
-            shape=tensor_shape, dtype=np.float32, sharding=abstract_sharding
+    # Pin a small in-flight budget so the loader streams reads instead of
+    # holding every per-host shard concurrently. With the 2 GiB default the
+    # whole per-host read set (plus coalescing over-read) is in flight at
+    # once and peak runs ~2x destination size; the budget is the knob that
+    # makes the peak-near-destination guarantee actually hold and testable.
+    with context_lib.Context(
+        memory_options=options_lib.MemoryOptions(
+            read_concurrent_bytes=8 * 1024 * 1024
         )
-        for i in range(num_tensors)
-    }
-
-    file_path = self.test_dir / "dummy_no_reshard.safetensors"
-
-    if jax.process_index() == 0:
-      tensors = {
-          f"tensor_{i}": np.zeros(tensor_shape, dtype=np.float32)
-          for i in range(num_tensors)
-      }
-      safetensors.numpy.save_file(tensors, file_path)
-      del tensors
-      gc.collect()
-
-    test_utils.sync_global_processes(self.id())
-
-    layout = SafetensorsLayout()
-
-    tracemalloc.start()
-
-    ctx = context_lib.Context()
-    ctx.safetensors.ignore_load_sharding = True
-    with ctx:
+    ):
       restore_fn = await layout.load(
           file_path,
           abstract_state=abstract_pytree,
@@ -348,11 +219,18 @@ class ShardedSafetensorsLayoutTest(
     unused_current, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
 
-    # Peak memory should be dominated by owned tensors (approx 100MB).
-    # If non-owned tensors were materialized, it would be 400MB.
+    # Peak memory is dominated by this host's addressable share of every
+    # tensor (~100 MB for tensors_per_host = 25 and bytes_per_tensor = 4 MB).
+    # On top of that the loader holds:
+    #   * a few coalesced read blocks in flight at any moment (bounded by
+    #     `_MAX_CONCURRENT_READS * coalesce_max_merged_bytes`); and
+    #   * the usual JAX / NumPy object overhead for hundreds of sharded
+    #     `jax.Array`s and per-shard `NamedSharding` references.
+    # If non-owner hosts were materializing zero buffers instead -- the
+    # regression this test guards against -- the peak would be ~400 MB.
     tensors_per_host = num_tensors // jax.process_count()
     expected_peak = bytes_per_tensor * (tensors_per_host + 1)
-    fudge_factor = 1.2  # Account for overhead, Python objects, etc.
+    fudge_factor = 1.5  # in-flight reads + JAX object overhead
 
     self.assertLess(peak, fudge_factor * expected_peak)
 

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_test.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_test.py
@@ -20,6 +20,9 @@ from absl.testing import parameterized
 from etils import epath
 import jax
 import numpy as np
+from orbax.checkpoint._src.serialization import limits
+from orbax.checkpoint.experimental.v1._src.context import context as context_lib
+from orbax.checkpoint.experimental.v1._src.context import options as options_lib
 from orbax.checkpoint.experimental.v1._src.layout import checkpoint_layout
 from orbax.checkpoint.experimental.v1._src.layout import safetensors_layout
 from orbax.checkpoint.experimental.v1._src.metadata import types as metadata_types
@@ -55,7 +58,10 @@ class SafetensorsLayoutTest(
         self.safetensors_path,
         metadata=self.custom_metadata,
     )
-    saving.save(self.orbax_path, self.object_to_save)  # pyrefly: ignore[bad-argument-type]
+    saving.save(
+        self.orbax_path,
+        self.object_to_save,  # pyrefly: ignore[bad-argument-type]
+    )
 
   async def test_valid_safetensors_checkpoint(self):
     layout = SafetensorsLayout()
@@ -84,14 +90,14 @@ class SafetensorsLayoutTest(
           np.float64,
           np.bool_,
           jax.numpy.bfloat16,
-          jax.numpy.float8_e4m3fn
+          jax.numpy.float8_e4m3fn,
       ]
   )
   async def test_load_safetensors_checkpoint(self, dtype: np.dtype):
     """Tests loading a SafeTensors checkpoint with various dtypes."""
     test_path = (
         epath.Path(self.test_dir.full_path)
-        / f'test_{dtype.__name__}.safetensors'  # pyrefly: ignore[missing-attribute]
+        / f'test_{dtype.__name__}.safetensors'  # pyrefly: ignore
     )
     if dtype == np.bool_:
       arr = np.array([True, False, True, False])
@@ -101,18 +107,25 @@ class SafetensorsLayoutTest(
     obj_to_save = {'x': arr, 'y': np.array([1, 2, 3], dtype=np.int32)}
     np_save_file(obj_to_save, test_path)
 
-    # Load the checkpoint
     layout = SafetensorsLayout()
     restore_fn = await layout.load(test_path)
     pytree = await restore_fn
 
-    # Verify restored data
-    # TODO(b/430651483)
     if np.issubdtype(dtype, np.floating):
       np.testing.assert_allclose(pytree['x'], obj_to_save['x'], strict=True)
     else:
       np.testing.assert_array_equal(pytree['x'], obj_to_save['x'], strict=True)
     np.testing.assert_array_equal(pytree['y'], obj_to_save['y'])
+
+  async def test_load_truncated_file_raises(self):
+    # A partially-copied checkpoint: drop the last data bytes so the file is
+    # shorter than its header declares. The length check runs in load()'s setup
+    # phase, so load() itself raises before any byte-range read is issued.
+    full = self.safetensors_path.read_bytes()
+    self.safetensors_path.write_bytes(full[:-8])
+    layout = SafetensorsLayout()
+    with self.assertRaisesRegex(ValueError, 'truncated'):
+      await layout.load(self.safetensors_path)
 
   async def test_load_fails_with_incomplete_dtypes(self):
     incomplete_dtypes = {
@@ -330,59 +343,561 @@ class SafetensorsLayoutDirectoryTest(
     with self.assertRaisesRegex(KeyError, "Tensor 'e' not found"):
       await restore_fn
 
+  async def test_load_directory_duplicate_tensor_raises(self):
+    # Save the same tensor name into a second file.
+    dup_file = self.checkpoint_dir / 'part_dup.safetensors'
+    np_save_file({'a': np.array([99, 99], dtype=np.int32)}, dup_file)
+    layout = SafetensorsLayout()
+    with self.assertRaisesRegex(ValueError, 'Duplicate tensor a'):
+      restore_fn = await layout.load(self.checkpoint_dir)
+      await restore_fn
 
-class GetTensorBundlesTest(parameterized.TestCase):
 
-  def test_empty_header(self):
-    header = {}
-    bundles = safetensors_layout._get_tensor_bundles(header, num_hosts=2)
-    self.assertEqual(bundles, [[], []])
+class IndexDomainToByteRunsTest(parameterized.TestCase):
 
-  def test_single_tensor(self):
-    header = {
-        'tensor1': {'data_offsets': [0, 100]},
-    }
-    bundles = safetensors_layout._get_tensor_bundles(header, num_hosts=2)
-    self.assertEqual(bundles, [['tensor1'], []])
+  def test_scalar(self):
+    runs = safetensors_layout.index_domain_to_byte_runs(
+        bounds=(), global_shape=(), itemsize=4, tensor_base=128
+    )
+    self.assertEqual(runs, [(128, 4)])
 
-  def test_equal_distribution(self):
-    header = {
-        'tensor1': {'data_offsets': [0, 100]},
-        'tensor2': {'data_offsets': [100, 200]},
-    }
-    bundles = safetensors_layout._get_tensor_bundles(header, num_hosts=2)
-    self.assertEqual(bundles, [['tensor1'], ['tensor2']])
+  def test_whole_tensor_is_one_run(self):
+    runs = safetensors_layout.index_domain_to_byte_runs(
+        bounds=((0, 4), (0, 8)),
+        global_shape=(4, 8),
+        itemsize=4,
+        tensor_base=0,
+    )
+    self.assertEqual(runs, [(0, 4 * 8 * 4)])
 
-  def test_unequal_distribution_contiguous(self):
-    header = {
-        'tensor1': {'data_offsets': [0, 100]},
-        'tensor2': {'data_offsets': [100, 150]},
-        'tensor3': {'data_offsets': [150, 300]},
-    }
-    bundles = safetensors_layout._get_tensor_bundles(header, num_hosts=2)
-    self.assertEqual(bundles, [['tensor1', 'tensor2'], ['tensor3']])
+  def test_leading_dimension_shard_is_one_run(self):
+    runs = safetensors_layout.index_domain_to_byte_runs(
+        bounds=((0, 2), (0, 8)),
+        global_shape=(4, 8),
+        itemsize=4,
+        tensor_base=0,
+    )
+    self.assertEqual(runs, [(0, 2 * 8 * 4)])
 
-  def test_unequal_distribution_greedy_choice(self):
-    header = {
-        'tensor1': {'data_offsets': [0, 100]},
-        'tensor2': {'data_offsets': [100, 250]},
-        'tensor3': {'data_offsets': [250, 300]},
-    }
-    bundles = safetensors_layout._get_tensor_bundles(header, num_hosts=2)
-    self.assertEqual(bundles, [['tensor1'], ['tensor2', 'tensor3']])
+  def test_one_dimensional_shard_is_one_run(self):
+    runs = safetensors_layout.index_domain_to_byte_runs(
+        bounds=((2, 4),), global_shape=(8,), itemsize=4, tensor_base=64
+    )
+    self.assertEqual(runs, [(64 + 2 * 4, 2 * 4)])
+
+  def test_inner_dimension_shard_is_strided(self):
+    runs = safetensors_layout.index_domain_to_byte_runs(
+        bounds=((0, 4), (0, 4)),
+        global_shape=(4, 8),
+        itemsize=4,
+        tensor_base=0,
+    )
+    # 4 rows, each containing a 4-element slice (16 bytes), stride 32 bytes.
+    self.assertEqual(runs, [(0, 16), (32, 16), (64, 16), (96, 16)])
+
+  def test_non_zero_start_leading_shard(self):
+    runs = safetensors_layout.index_domain_to_byte_runs(
+        bounds=((2, 4), (0, 8)),
+        global_shape=(4, 8),
+        itemsize=4,
+        tensor_base=128,
+    )
+    self.assertEqual(runs, [(128 + 2 * 32, 2 * 32)])
+
+  def test_partial_in_both_dimensions(self):
+    runs = safetensors_layout.index_domain_to_byte_runs(
+        bounds=((1, 3), (2, 6)),
+        global_shape=(4, 8),
+        itemsize=4,
+        tensor_base=0,
+    )
+    # 2 rows (1, 2), each 4 elements wide starting at col 2 (offset 8 bytes).
+    self.assertEqual(runs, [(32 + 8, 16), (64 + 8, 16)])
+
+  def test_three_dimensional_middle_dimension_partial(self):
+    runs = safetensors_layout.index_domain_to_byte_runs(
+        bounds=((0, 2), (1, 3), (0, 4)),
+        global_shape=(2, 4, 4),
+        itemsize=4,
+        tensor_base=0,
+    )
+    # boundary = 1 (middle dim partial). Per outer i in (0, 1):
+    #   run_base + i * stride[0] = (0|1) * 64
+    #   + bounds[1][0] * stride[1] = 1 * 16
+    #   length = (3-1) * 16 = 32
+    self.assertEqual(runs, [(16, 32), (64 + 16, 32)])
+
+  def test_non_four_byte_itemsize(self):
+    runs = safetensors_layout.index_domain_to_byte_runs(
+        bounds=((0, 4), (0, 4)),
+        global_shape=(4, 8),
+        itemsize=2,
+        tensor_base=0,
+    )
+    self.assertEqual(runs, [(0, 8), (16, 8), (32, 8), (48, 8)])
+
+
+class ByteMathHelpersTest(parameterized.TestCase):
+
+  def test_normalize_index_slices(self):
+    self.assertEqual(
+        safetensors_layout._normalize_index(
+            (slice(0, 2), slice(3, 7)), (8, 16)
+        ),
+        ((0, 2), (3, 7)),
+    )
+
+  def test_normalize_index_open_ended(self):
+    self.assertEqual(
+        safetensors_layout._normalize_index(
+            (slice(None, None), slice(4, None)), (8, 16)
+        ),
+        ((0, 8), (4, 16)),
+    )
+
+  def test_normalize_index_integer(self):
+    self.assertEqual(
+        safetensors_layout._normalize_index((2, slice(None, None)), (8, 16)),
+        ((2, 3), (0, 16)),
+    )
+
+  def test_normalize_index_strided_raises(self):
+    with self.assertRaisesRegex(ValueError, 'Strided shard index'):
+      safetensors_layout._normalize_index((slice(0, 4, 2),), (8,))
+
+  @parameterized.named_parameters(
+      ('1d_f32', (16,), 4, [4]),
+      ('2d_f32', (4, 8), 4, [32, 4]),
+      ('3d_f32', (2, 3, 4), 4, [48, 16, 4]),
+      ('2d_bf16', (4, 8), 2, [16, 2]),
+  )
+  def test_byte_strides(self, shape, itemsize, expected):
+    self.assertEqual(
+        safetensors_layout._byte_strides(shape, itemsize), expected
+    )
+
+
+class PartitionRunsTest(parameterized.TestCase):
+
+  def test_empty(self):
+    self.assertEqual(
+        safetensors_layout._partition_runs([], max_over_read_ratio=2.0), []
+    )
+
+  def test_single_run_is_one_block(self):
+    blocks = safetensors_layout._partition_runs(
+        [(100, 50)], max_over_read_ratio=2.0
+    )
+    self.assertEqual(
+        blocks,
+        [safetensors_layout._CoalescedBlock(100, 150, (0,))],
+    )
+
+  def test_adjacent_runs_collapse_into_one_block(self):
+    blocks = safetensors_layout._partition_runs(
+        [(0, 100), (100, 50), (150, 50)], max_over_read_ratio=1.0
+    )
+    # Densely packed -> ratio 1.0 -> one block.
+    self.assertEqual(len(blocks), 1)
+    self.assertEqual((blocks[0].start, blocks[0].end), (0, 200))
+    self.assertEqual(blocks[0].members, (0, 1, 2))
+
+  def test_ratio_bound_prevents_excess_over_read(self):
+    # Two 1 KB runs separated by 3 KB gap -> block extent 5 KB, needed 2 KB,
+    # ratio 2.5 > 2.0 cap -> must split. The gap is below the default page
+    # floor, so disable it to exercise the ratio in isolation.
+    blocks = safetensors_layout._partition_runs(
+        [(0, 1024), (4096, 1024)], max_over_read_ratio=2.0, min_coalesce_gap=0
+    )
+    self.assertEqual(len(blocks), 2)
+    self.assertEqual((blocks[0].start, blocks[0].end), (0, 1024))
+    self.assertEqual((blocks[1].start, blocks[1].end), (4096, 4096 + 1024))
+
+  def test_ratio_bound_allows_when_ratio_within_cap(self):
+    # Same two runs but cap is 2.5 -> coalesces.
+    blocks = safetensors_layout._partition_runs(
+        [(0, 1024), (4096, 1024)], max_over_read_ratio=2.5
+    )
+    self.assertEqual(len(blocks), 1)
+    self.assertEqual((blocks[0].start, blocks[0].end), (0, 5120))
+    self.assertEqual(blocks[0].members, (0, 1))
+
+  def test_large_dense_block_is_not_capped_by_partition(self):
+    # Block size is intentionally unbounded in partition; the scheduler's
+    # byte budget handles oversized blocks by streaming. A single 1 GiB run
+    # is one block of 1 GiB regardless of any "size cap" -- there isn't one.
+    blocks = safetensors_layout._partition_runs(
+        [(0, 1 << 30)], max_over_read_ratio=1.0
+    )
+    self.assertEqual(len(blocks), 1)
+    self.assertEqual(blocks[0].end - blocks[0].start, 1 << 30)
+
+  def test_sorts_unsorted_input(self):
+    blocks = safetensors_layout._partition_runs(
+        [(200, 50), (0, 100), (100, 100)], max_over_read_ratio=1.0
+    )
+    self.assertEqual(len(blocks), 1)
+    # Members are reported in sorted order of offset.
+    self.assertEqual(blocks[0].members, (1, 2, 0))
+
+  def test_inner_dim_strided_collapses_when_ratio_allows(self):
+    # 8 strided runs of 8 bytes each, stride 16. needed=64, extent=120,
+    # ratio=1.875 < 2.0 -> coalesces to 1 block.
+    runs = [(i * 16, 8) for i in range(8)]
+    blocks = safetensors_layout._partition_runs(runs, max_over_read_ratio=2.0)
+    self.assertEqual(len(blocks), 1)
+    self.assertEqual(blocks[0].end - blocks[0].start, 120)
+
+  def test_inner_dim_strided_partitions_when_ratio_too_high(self):
+    # 4 strided runs, stride 64, length 8. needed=32, extent=200, ratio=6.25.
+    # With cap 2.0 and the floor disabled -> single-run blocks. (The 56-byte
+    # gaps are below the default page floor; the floor case is covered below.)
+    runs = [(i * 64, 8) for i in range(4)]
+    blocks = safetensors_layout._partition_runs(
+        runs, max_over_read_ratio=2.0, min_coalesce_gap=0
+    )
+    self.assertEqual(len(blocks), 4)
+    for b in blocks:
+      self.assertEqual(b.end - b.start, 8)
+
+  def test_small_gap_coalesces_despite_ratio(self):
+    # Two 8-byte runs split by a 192-byte gap: ratio 13x >> 2.0, but the gap is
+    # well below the page floor, so they coalesce into one read (the worked
+    # inner-dim example) rather than shattering into microscopic requests.
+    blocks = safetensors_layout._partition_runs(
+        [(0, 8), (200, 8)], max_over_read_ratio=2.0
+    )
+    self.assertEqual(len(blocks), 1)
+    self.assertEqual((blocks[0].start, blocks[0].end), (0, 208))
+
+  def test_gap_above_floor_respects_ratio(self):
+    # An 8 KB gap is above the page floor, so the ratio governs again and a
+    # huge over-read ratio splits the runs into separate reads.
+    blocks = safetensors_layout._partition_runs(
+        [(0, 8), (8192, 8)], max_over_read_ratio=2.0
+    )
+    self.assertEqual(len(blocks), 2)
+
+  def test_explicit_larger_floor_coalesces_above_default(self):
+    # Raising the floor past the gap coalesces what the default would split.
+    blocks = safetensors_layout._partition_runs(
+        [(0, 8), (8192, 8)], max_over_read_ratio=2.0, min_coalesce_gap=16384
+    )
+    self.assertEqual(len(blocks), 1)
+
+  def test_invalid_ratio_raises(self):
+    with self.assertRaisesRegex(ValueError, 'max_over_read_ratio'):
+      safetensors_layout._partition_runs([(0, 100)], max_over_read_ratio=0.5)
+
+
+class PerFileSchedulerTest(
+    unittest.IsolatedAsyncioTestCase, parameterized.TestCase
+):
+  """End-to-end correctness of the per-file scheduler.
+
+  The partition policy is exercised separately in `PartitionRunsTest`; here we
+  verify the scheduler delivers the right bytes to each registered callback.
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.test_dir = self.create_tempdir()
+    self.file_path = epath.Path(self.test_dir.full_path) / 'data.bin'
+    self.payload = bytes(range(256)) * 16  # 4 KB of varied bytes
+    self.file_path.write_bytes(self.payload)
+
+  async def _run(self, ratio, budget_bytes, offsets, lengths):
+    """Registers `(offset, length)` pairs; returns the bytes each received.
+
+    Concatenates successive chunk deliveries per registration to verify
+    correctness under both single-read and streamed-chunk paths.
+    """
+    # +1 mirrors `_load`: LimitInFlightBytes reserves strictly fewer than its
+    # max, so the largest reservable chunk is `budget_bytes`.
+    budget = limits.LimitInFlightBytes(budget_bytes + 1)
+    sched = safetensors_layout._PerFileScheduler(
+        self.file_path, budget, max_over_read_ratio=ratio
+    )
+    received: list[bytearray] = [bytearray() for _ in offsets]
+
+    def make_cb(idx):
+      def cb(chunk):
+        received[idx].extend(bytes(chunk))
+
+      return cb
+
+    for i, (o, l) in enumerate(zip(offsets, lengths)):
+      sched.register(o, l, make_cb(i))
+    await sched.execute()
+    return [bytes(b) for b in received]
+
+  async def test_delivers_bytes_for_dense_runs(self):
+    offsets, lengths = [0, 16, 32, 48], [16, 16, 16, 16]
+    received = await self._run(1.0, 1 << 20, offsets, lengths)
+    for i, b in enumerate(received):
+      self.assertEqual(b, self.payload[i * 16 : (i + 1) * 16])
+
+  async def test_delivers_bytes_for_sparse_runs(self):
+    offsets = [0, 1024, 2048]
+    received = await self._run(1.5, 1 << 20, offsets, [16] * 3)
+    for off, b in zip(offsets, received):
+      self.assertEqual(b, self.payload[off : off + 16])
+
+  async def test_delivers_bytes_when_budget_streams_block(self):
+    # 5 dense 16-byte runs coalesce into one 80-byte block (ratio 1.0).
+    # Budget 64 forces the scheduler to stream the block in two chunks
+    # (64 + 16). Each callback may be invoked twice; concatenated bytes
+    # must equal the source slice.
+    offsets = [0, 16, 32, 48, 64]
+    received = await self._run(1.0, 64, offsets, [16] * 5)
+    for off, b in zip(offsets, received):
+      self.assertEqual(b, self.payload[off : off + 16])
+
+  async def test_delivers_bytes_when_budget_smaller_than_single_run(self):
+    # One 64-byte run with a 16-byte budget -> 4 chunks of 16 each. The
+    # callback is invoked 4 times in offset order.
+    received = await self._run(1.0, 16, [0], [64])
+    self.assertEqual(received[0], self.payload[:64])
+
+  async def test_execute_returns_read_stats(self):
+    # 4 dense 16-byte runs coalesce into one 64-byte block (ratio 1.0); the
+    # huge budget reads it in a single ranged GET.
+    budget = limits.LimitInFlightBytes((1 << 20) + 1)
+    sched = safetensors_layout._PerFileScheduler(
+        self.file_path, budget, max_over_read_ratio=1.0
+    )
+    for o in (0, 16, 32, 48):
+      sched.register(o, 16, lambda chunk: None)
+    stats = await sched.execute()
+    self.assertEqual(stats.needed_bytes, 64)
+    self.assertEqual(stats.read_bytes, 64)
+    self.assertEqual(stats.num_reads, 1)
+    self.assertEqual(stats.num_gets, 1)  # fits the budget -> single GET.
+
+  async def test_execute_stats_count_block_and_stream_chunks(self):
+    # One 64-byte run with a 16-byte budget streams in 4 chunks. It is still a
+    # single coalesced block (num_reads == 1), but four actual GETs are issued
+    # (num_gets == 4).
+    budget = limits.LimitInFlightBytes(16 + 1)
+    sched = safetensors_layout._PerFileScheduler(
+        self.file_path, budget, max_over_read_ratio=1.0
+    )
+    sched.register(0, 64, lambda chunk: None)
+    stats = await sched.execute()
+    self.assertEqual(stats.read_bytes, 64)
+    self.assertEqual(stats.num_reads, 1)
+    self.assertEqual(stats.num_gets, 4)
+
+  async def test_execute_with_no_registrations_is_noop(self):
+    budget = limits.LimitInFlightBytes(1 << 20)
+    sched = safetensors_layout._PerFileScheduler(
+        self.file_path, budget, max_over_read_ratio=2.0
+    )
+    await sched.execute()  # must not raise, must not open the file.
+
+  async def test_read_failure_raises(self):
+    budget = limits.LimitInFlightBytes(1 << 20)
+    sched = safetensors_layout._PerFileScheduler(
+        epath.Path('/nonexistent/path.bin'),
+        budget,
+        max_over_read_ratio=2.0,
+    )
+    sched.register(0, 16, lambda chunk: None)
+    sched.register(16, 16, lambda chunk: None)
+    with self.assertRaises(Exception):
+      await sched.execute()
 
 
 class RecordReadStatsTest(absltest.TestCase):
-  """`_record_read_stats` reports per-host bytes/reads via jax.monitoring."""
+  """`_record_read_stats` reports per-host totals via jax.monitoring."""
 
-  def test_emits_bytes_and_reads_only(self):
+  def test_emits_per_host_totals(self):
+    stats = [
+        safetensors_layout._ReadStats(
+            needed_bytes=40, read_bytes=64, num_reads=1, num_gets=1
+        ),
+        safetensors_layout._ReadStats(
+            needed_bytes=16, read_bytes=20, num_reads=2, num_gets=5
+        ),
+    ]
     with mock.patch.object(jax.monitoring, 'record_scalar') as rec:
-      safetensors_layout._record_read_stats(bytes_read=2048, num_reads=3)
+      safetensors_layout._record_read_stats(stats)
     emitted = {c.args[0]: c.args[1] for c in rec.call_args_list}
-    self.assertEqual(emitted['/jax/orbax/read/safetensors/bytes_read'], 2048.0)
+    self.assertEqual(emitted['/jax/orbax/read/safetensors/bytes_read'], 84.0)
     self.assertEqual(emitted['/jax/orbax/read/safetensors/num_reads'], 3.0)
-    # storage_reads would equal num_reads for this loader, so it is not emitted.
-    self.assertNotIn('/jax/orbax/read/safetensors/storage_reads', emitted)
+    self.assertEqual(
+        emitted['/jax/orbax/read/safetensors/storage_reads'], 6.0
+    )
+
+
+class FragmentationWarningTest(parameterized.TestCase):
+  """`_warn_if_reads_fragmented` fires only in the cap-bound strided regime."""
+
+  def _stats(self, needed, read, reads):
+    return safetensors_layout._ReadStats(
+        needed_bytes=needed, read_bytes=read, num_reads=reads, num_gets=reads
+    )
+
+  def test_warns_when_fragmented_on_default_ratio(self):
+    # 512 reads for 1 file, achieved over-read 1.0x -> the cap is fragmenting.
+    stats = [self._stats(needed=8192, read=8192, reads=512)]
+    with mock.patch.object(safetensors_layout.logging, 'warning') as warn:
+      safetensors_layout._warn_if_reads_fragmented(
+          stats, num_files=1, max_over_read_ratio_is_default=True
+      )
+    warn.assert_called_once()
+
+  def test_no_warn_when_coalesced(self):
+    # One read per file -> healthy load, no hint.
+    stats = [self._stats(needed=8192, read=8192, reads=1)]
+    with mock.patch.object(safetensors_layout.logging, 'warning') as warn:
+      safetensors_layout._warn_if_reads_fragmented(
+          stats, num_files=1, max_over_read_ratio_is_default=True
+      )
+    warn.assert_not_called()
+
+  def test_no_warn_when_over_read_high(self):
+    # Many reads but over-read near the cap -> coalescing happened, not the
+    # fragmented regime.
+    stats = [self._stats(needed=8192, read=16384, reads=512)]
+    with mock.patch.object(safetensors_layout.logging, 'warning') as warn:
+      safetensors_layout._warn_if_reads_fragmented(
+          stats, num_files=1, max_over_read_ratio_is_default=True
+      )
+    warn.assert_not_called()
+
+  def test_no_warn_when_user_set_ratio(self):
+    # User already engaged with the knob -> stay quiet.
+    stats = [self._stats(needed=8192, read=8192, reads=512)]
+    with mock.patch.object(safetensors_layout.logging, 'warning') as warn:
+      safetensors_layout._warn_if_reads_fragmented(
+          stats, num_files=1, max_over_read_ratio_is_default=False
+      )
+    warn.assert_not_called()
+
+
+class SafetensorsLayoutEdgeCaseTest(
+    unittest.IsolatedAsyncioTestCase, parameterized.TestCase
+):
+
+  def setUp(self):
+    super().setUp()
+    self.test_dir = self.create_tempdir()
+    self.file_path = epath.Path(self.test_dir.full_path) / 'edge.safetensors'
+
+  async def test_shape_mismatch_raises(self):
+    np_save_file({'a': np.arange(8, dtype=np.float32)}, self.file_path)
+    layout = SafetensorsLayout()
+    tree = {'a': jax.ShapeDtypeStruct(shape=(4,), dtype=np.float32)}
+    restore_fn = await layout.load(self.file_path, abstract_state=tree)
+    with self.assertRaisesRegex(ValueError, 'Shape mismatch'):
+      await restore_fn
+
+  async def test_dtype_cast_on_load(self):
+    np_save_file({'a': np.arange(8, dtype=np.int32)}, self.file_path)
+    layout = SafetensorsLayout()
+    # Requesting float32 from an int32 file -> cast applied during assembly.
+    # int32 -> float32 stays within JAX's default supported dtypes (no need
+    # for jax_enable_x64).
+    tree = {'a': jax.ShapeDtypeStruct(shape=(8,), dtype=np.float32)}
+    restore_fn = await layout.load(self.file_path, abstract_state=tree)
+    pytree = await restore_fn
+    self.assertEqual(pytree['a'].dtype, np.float32)
+    np.testing.assert_allclose(pytree['a'], np.arange(8, dtype=np.float32))
+
+  async def test_scalar_loads(self):
+    np_save_file({'s': np.array(3.14, dtype=np.float32)}, self.file_path)
+    layout = SafetensorsLayout()
+    restore_fn = await layout.load(self.file_path)
+    pytree = await restore_fn
+    np.testing.assert_allclose(pytree['s'], 3.14)
+
+  async def test_nested_abstract_state_raises(self):
+    np_save_file({'a': np.arange(8, dtype=np.float32)}, self.file_path)
+    layout = SafetensorsLayout()
+    nested = {
+        'group': {'a': jax.ShapeDtypeStruct(shape=(8,), dtype=np.float32)}
+    }
+    with self.assertRaisesRegex(ValueError, 'not a flat dictionary'):
+      await layout.load(self.file_path, abstract_state=nested)
+
+  async def test_empty_abstract_state_returns_empty(self):
+    np_save_file({'a': np.arange(8, dtype=np.float32)}, self.file_path)
+    layout = SafetensorsLayout()
+    restore_fn = await layout.load(self.file_path, abstract_state={})
+    pytree = await restore_fn
+    self.assertEqual(pytree, {})
+
+  async def test_options_override_partition_defaults(self):
+    np_save_file({'a': np.arange(8, dtype=np.float32)}, self.file_path)
+    layout = SafetensorsLayout()
+    # ratio 1.0 forces per-tensor block isolation; a tiny budget forces the
+    # scheduler to stream each block in multiple chunks. Correctness must
+    # hold under both -- callbacks must reassemble bytes across calls.
+    with context_lib.Context(
+        memory_options=options_lib.MemoryOptions(read_concurrent_bytes=16),
+        safetensors_options=options_lib.SafetensorsOptions(
+            max_over_read_ratio=1.0,
+        ),
+    ):
+      restore_fn = await layout.load(self.file_path)
+      pytree = await restore_fn
+    np.testing.assert_allclose(pytree['a'], np.arange(8, dtype=np.float32))
+
+
+class SingleHostOneReadInvariantTest(
+    unittest.IsolatedAsyncioTestCase, parameterized.TestCase
+):
+  """Verifies the single-host-degenerate-case property: 1 file = 1 read."""
+
+  def setUp(self):
+    super().setUp()
+    self.test_dir = self.create_tempdir()
+    self.file_path = epath.Path(self.test_dir.full_path) / 'pack.safetensors'
+    # Multiple densely-packed tensors in one file.
+    np_save_file(
+        {f'tensor_{i}': np.arange(64, dtype=np.float32) for i in range(8)},
+        self.file_path,
+    )
+
+  async def _count_reads_during_load(self, abstract_state=None):
+    read_count = 0
+    original = safetensors_layout._PerFileScheduler._read_block
+
+    async def counting_read_block(self, block):
+      nonlocal read_count
+      read_count += 1
+      return await original(self, block)
+
+    layout = SafetensorsLayout()
+    with mock.patch.object(
+        safetensors_layout._PerFileScheduler,
+        '_read_block',
+        new=counting_read_block,
+    ):
+      restore_fn = await layout.load(
+          self.file_path, abstract_state=abstract_state
+      )
+      _ = await restore_fn
+    return read_count
+
+  async def test_whole_file_load_is_one_read(self):
+    # No abstract_state -> whole tensors -> all densely packed -> 1 read.
+    self.assertEqual(await self._count_reads_during_load(), 1)
+
+  async def test_sharded_to_all_local_devices_is_one_read(self):
+    # All devices addressable on single host, all tensors needed -> 1 read.
+    if jax.local_device_count() < 1:
+      self.skipTest('Requires at least one local device.')
+    mesh = jax.sharding.Mesh(np.array(jax.devices()), ('x',))
+    sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+    abstract_state = {
+        f'tensor_{i}': jax.ShapeDtypeStruct(
+            shape=(64,), dtype=np.float32, sharding=sharding
+        )
+        for i in range(8)
+    }
+    self.assertEqual(await self._count_reads_during_load(abstract_state), 1)
 
 
 if __name__ == '__main__':

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_test.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_test.py
@@ -850,6 +850,38 @@ class SafetensorsLayoutEdgeCaseTest(
       pytree = await restore_fn
     np.testing.assert_allclose(pytree['a'], np.arange(8, dtype=np.float32))
 
+  async def test_read_chunk_bytes_option_splits_reads(self):
+    # One 32-byte tensor with a 16-byte chunk size: still one coalesced
+    # block, but two storage GETs. Pins that the option reaches the planner.
+    np_save_file({'a': np.arange(8, dtype=np.float32)}, self.file_path)
+    layout = SafetensorsLayout()
+    with mock.patch.object(jax.monitoring, 'record_scalar') as rec:
+      with context_lib.Context(
+          safetensors_options=options_lib.SafetensorsOptions(
+              read_chunk_bytes=16,
+          ),
+      ):
+        restore_fn = await layout.load(self.file_path)
+        pytree = await restore_fn
+    emitted = {c.args[0]: c.args[1] for c in rec.call_args_list}
+    self.assertEqual(emitted['/jax/orbax/read/safetensors/num_reads'], 1.0)
+    self.assertEqual(
+        emitted['/jax/orbax/read/safetensors/storage_reads'], 2.0
+    )
+    np.testing.assert_allclose(pytree['a'], np.arange(8, dtype=np.float32))
+
+  async def test_non_positive_read_chunk_bytes_raises(self):
+    np_save_file({'a': np.arange(8, dtype=np.float32)}, self.file_path)
+    layout = SafetensorsLayout()
+    with context_lib.Context(
+        safetensors_options=options_lib.SafetensorsOptions(
+            read_chunk_bytes=0,
+        ),
+    ):
+      restore_fn = await layout.load(self.file_path)
+      with self.assertRaisesRegex(ValueError, 'read_chunk_bytes'):
+        await restore_fn
+
 
 class SingleHostOneReadInvariantTest(
     unittest.IsolatedAsyncioTestCase, parameterized.TestCase

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_test.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_test.py
@@ -523,9 +523,9 @@ class PartitionRunsTest(parameterized.TestCase):
     self.assertEqual(blocks[0].members, (0, 1))
 
   def test_large_dense_block_is_not_capped_by_partition(self):
-    # Block size is intentionally unbounded in partition; the scheduler's
-    # byte budget handles oversized blocks by streaming. A single 1 GiB run
-    # is one block of 1 GiB regardless of any "size cap" -- there isn't one.
+    # Block size is intentionally unbounded in partition; oversized blocks
+    # are split at the read chunk size later. A single 1 GiB run is one
+    # block of 1 GiB regardless of any "size cap" -- there isn't one.
     blocks = safetensors_layout._partition_runs(
         [(0, 1 << 30)], max_over_read_ratio=1.0
     )
@@ -590,13 +590,12 @@ class PartitionRunsTest(parameterized.TestCase):
       safetensors_layout._partition_runs([(0, 100)], max_over_read_ratio=0.5)
 
 
-class PerFileSchedulerTest(
-    unittest.IsolatedAsyncioTestCase, parameterized.TestCase
-):
-  """End-to-end correctness of the per-file scheduler.
+class FileReadTest(unittest.IsolatedAsyncioTestCase, parameterized.TestCase):
+  """End-to-end correctness of `_plan_chunk_reads` + `_read_file`.
 
   The partition policy is exercised separately in `PartitionRunsTest`; here we
-  verify the scheduler delivers the right bytes to each registered callback.
+  verify the planned chunk reads deliver the right bytes to each destination
+  buffer, under both single-chunk and split-block paths.
   """
 
   def setUp(self):
@@ -606,30 +605,23 @@ class PerFileSchedulerTest(
     self.payload = bytes(range(256)) * 16  # 4 KB of varied bytes
     self.file_path.write_bytes(self.payload)
 
-  async def _run(self, ratio, budget_bytes, offsets, lengths):
-    """Registers `(offset, length)` pairs; returns the bytes each received.
-
-    Concatenates successive chunk deliveries per registration to verify
-    correctness under both single-read and streamed-chunk paths.
-    """
+  async def _run(self, ratio, chunk_bytes, offsets, lengths):
+    """Reads `(offset, length)` runs; returns the bytes each received."""
     # +1 mirrors `_load`: LimitInFlightBytes reserves strictly fewer than its
-    # max, so the largest reservable chunk is `budget_bytes`.
-    budget = limits.LimitInFlightBytes(budget_bytes + 1)
-    sched = safetensors_layout._PerFileScheduler(
-        self.file_path, budget, max_over_read_ratio=ratio
+    # max, so the largest reservable chunk is `chunk_bytes`.
+    budget = limits.LimitInFlightBytes(chunk_bytes + 1)
+    reads = [
+        safetensors_layout._Read(o, l, np.zeros(l, dtype=np.uint8))
+        for o, l in zip(offsets, lengths)
+    ]
+    await safetensors_layout._read_file(
+        self.file_path,
+        reads,
+        budget,
+        max_over_read_ratio=ratio,
+        chunk_bytes=chunk_bytes,
     )
-    received: list[bytearray] = [bytearray() for _ in offsets]
-
-    def make_cb(idx):
-      def cb(chunk):
-        received[idx].extend(bytes(chunk))
-
-      return cb
-
-    for i, (o, l) in enumerate(zip(offsets, lengths)):
-      sched.register(o, l, make_cb(i))
-    await sched.execute()
-    return [bytes(b) for b in received]
+    return [r.dst.tobytes() for r in reads]
 
   async def test_delivers_bytes_for_dense_runs(self):
     offsets, lengths = [0, 16, 32, 48], [16, 16, 16, 16]
@@ -643,69 +635,83 @@ class PerFileSchedulerTest(
     for off, b in zip(offsets, received):
       self.assertEqual(b, self.payload[off : off + 16])
 
-  async def test_delivers_bytes_when_budget_streams_block(self):
-    # 5 dense 16-byte runs coalesce into one 80-byte block (ratio 1.0).
-    # Budget 64 forces the scheduler to stream the block in two chunks
-    # (64 + 16). Each callback may be invoked twice; concatenated bytes
-    # must equal the source slice.
+  async def test_delivers_bytes_when_block_splits_into_chunks(self):
+    # 5 dense 16-byte runs coalesce into one 80-byte block (ratio 1.0). A
+    # 64-byte chunk size splits the block into two reads (64 + 16); the run
+    # straddling the boundary is served by both.
     offsets = [0, 16, 32, 48, 64]
     received = await self._run(1.0, 64, offsets, [16] * 5)
     for off, b in zip(offsets, received):
       self.assertEqual(b, self.payload[off : off + 16])
 
-  async def test_delivers_bytes_when_budget_smaller_than_single_run(self):
-    # One 64-byte run with a 16-byte budget -> 4 chunks of 16 each. The
-    # callback is invoked 4 times in offset order.
+  async def test_delivers_bytes_when_chunk_smaller_than_single_run(self):
+    # One 64-byte run with a 16-byte chunk size -> 4 reads, each serving a
+    # quarter of the run.
     received = await self._run(1.0, 16, [0], [64])
     self.assertEqual(received[0], self.payload[:64])
 
-  async def test_execute_returns_read_stats(self):
+  async def test_read_file_returns_read_stats(self):
     # 4 dense 16-byte runs coalesce into one 64-byte block (ratio 1.0); the
-    # huge budget reads it in a single ranged GET.
+    # huge chunk size reads it in a single ranged GET.
     budget = limits.LimitInFlightBytes((1 << 20) + 1)
-    sched = safetensors_layout._PerFileScheduler(
-        self.file_path, budget, max_over_read_ratio=1.0
+    reads = [
+        safetensors_layout._Read(o, 16, np.zeros(16, dtype=np.uint8))
+        for o in (0, 16, 32, 48)
+    ]
+    stats = await safetensors_layout._read_file(
+        self.file_path,
+        reads,
+        budget,
+        max_over_read_ratio=1.0,
+        chunk_bytes=1 << 20,
     )
-    for o in (0, 16, 32, 48):
-      sched.register(o, 16, lambda chunk: None)
-    stats = await sched.execute()
     self.assertEqual(stats.needed_bytes, 64)
     self.assertEqual(stats.read_bytes, 64)
     self.assertEqual(stats.num_reads, 1)
-    self.assertEqual(stats.num_gets, 1)  # fits the budget -> single GET.
+    self.assertEqual(stats.num_gets, 1)  # fits one chunk -> single GET.
 
-  async def test_execute_stats_count_block_and_stream_chunks(self):
-    # One 64-byte run with a 16-byte budget streams in 4 chunks. It is still a
-    # single coalesced block (num_reads == 1), but four actual GETs are issued
-    # (num_gets == 4).
+  async def test_stats_count_block_and_split_chunks(self):
+    # One 64-byte run with a 16-byte chunk size splits into 4 reads. It is
+    # still a single coalesced block (num_reads == 1), but four actual GETs
+    # are issued (num_gets == 4).
     budget = limits.LimitInFlightBytes(16 + 1)
-    sched = safetensors_layout._PerFileScheduler(
-        self.file_path, budget, max_over_read_ratio=1.0
+    reads = [safetensors_layout._Read(0, 64, np.zeros(64, dtype=np.uint8))]
+    stats = await safetensors_layout._read_file(
+        self.file_path,
+        reads,
+        budget,
+        max_over_read_ratio=1.0,
+        chunk_bytes=16,
     )
-    sched.register(0, 64, lambda chunk: None)
-    stats = await sched.execute()
     self.assertEqual(stats.read_bytes, 64)
     self.assertEqual(stats.num_reads, 1)
     self.assertEqual(stats.num_gets, 4)
 
-  async def test_execute_with_no_registrations_is_noop(self):
+  async def test_read_file_with_no_reads_is_noop(self):
     budget = limits.LimitInFlightBytes(1 << 20)
-    sched = safetensors_layout._PerFileScheduler(
-        self.file_path, budget, max_over_read_ratio=2.0
-    )
-    await sched.execute()  # must not raise, must not open the file.
+    stats = await safetensors_layout._read_file(
+        self.file_path,
+        [],
+        budget,
+        max_over_read_ratio=2.0,
+        chunk_bytes=1 << 20,
+    )  # must not raise, must not open the file.
+    self.assertEqual(stats.num_gets, 0)
 
   async def test_read_failure_raises(self):
     budget = limits.LimitInFlightBytes(1 << 20)
-    sched = safetensors_layout._PerFileScheduler(
-        epath.Path('/nonexistent/path.bin'),
-        budget,
-        max_over_read_ratio=2.0,
-    )
-    sched.register(0, 16, lambda chunk: None)
-    sched.register(16, 16, lambda chunk: None)
+    reads = [
+        safetensors_layout._Read(o, 16, np.zeros(16, dtype=np.uint8))
+        for o in (0, 16)
+    ]
     with self.assertRaises(Exception):
-      await sched.execute()
+      await safetensors_layout._read_file(
+          epath.Path('/nonexistent/path.bin'),
+          reads,
+          budget,
+          max_over_read_ratio=2.0,
+          chunk_bytes=1 << 20,
+      )
 
 
 class RecordReadStatsTest(absltest.TestCase):
@@ -831,9 +837,9 @@ class SafetensorsLayoutEdgeCaseTest(
   async def test_options_override_partition_defaults(self):
     np_save_file({'a': np.arange(8, dtype=np.float32)}, self.file_path)
     layout = SafetensorsLayout()
-    # ratio 1.0 forces per-tensor block isolation; a tiny budget forces the
-    # scheduler to stream each block in multiple chunks. Correctness must
-    # hold under both -- callbacks must reassemble bytes across calls.
+    # ratio 1.0 forces per-tensor block isolation; a tiny budget forces each
+    # block to split into multiple chunk reads. Correctness must hold under
+    # both -- the chunks must reassemble into the full tensor bytes.
     with context_lib.Context(
         memory_options=options_lib.MemoryOptions(read_concurrent_bytes=16),
         safetensors_options=options_lib.SafetensorsOptions(
@@ -862,18 +868,18 @@ class SingleHostOneReadInvariantTest(
 
   async def _count_reads_during_load(self, abstract_state=None):
     read_count = 0
-    original = safetensors_layout._PerFileScheduler._read_block
+    original = safetensors_layout._read_chunk
 
-    async def counting_read_block(self, block):
+    async def counting_read_chunk(path, chunk, byte_budget):
       nonlocal read_count
       read_count += 1
-      return await original(self, block)
+      return await original(path, chunk, byte_budget)
 
     layout = SafetensorsLayout()
     with mock.patch.object(
-        safetensors_layout._PerFileScheduler,
-        '_read_block',
-        new=counting_read_block,
+        safetensors_layout,
+        '_read_chunk',
+        new=counting_read_chunk,
     ):
       restore_fn = await layout.load(
           self.file_path, abstract_state=abstract_state


### PR DESCRIPTION
## Description

Rewrites the v1 `SafetensorsLayout` load path to be driven by the target sharding: each process resolves which shards of each tensor its own devices need (`Sharding.devices_indices_map`), maps those index domains to byte ranges in the file, and reads exactly those ranges. Resharding happens purely through which bytes each process reads — there is no cross-process communication and no XLA compilation. This mirrors how the v0 array deserializer drives reads from the target sharding, with hand-computed byte ranges standing in for TensorStore's chunk index.

**Read planning.** Byte runs from every tensor a process needs in one file are coalesced under a bounded over-read policy: `SafetensorsOptions.max_over_read_ratio` (default 2.0) caps `block_size / needed_bytes`, so inner-dim (e.g. row-parallel TP) shardings can't amplify per-host reads to N × file size, while a 4 KiB gap floor prevents strided reads from shattering into microscopic requests. Coalesced blocks are split at a fixed 128 MiB chunk size and all chunks — across all blocks and files — are issued as concurrent ranged reads, so large blocks fetch at parallel-stream throughput instead of one long single-stream read. Every chunk's destination-buffer copies are precomputed, so chunks may complete in any order.

**Memory bound.** One shared `LimitInFlightBytes` (reusing `_src/serialization/limits.py`, keyed off `MemoryOptions.read_concurrent_bytes`, 2 GiB fallback) throttles all in-flight chunks together: peak host memory beyond the destination shard buffers is bounded by the budget regardless of block, shard, or file size. Tensors are assembled into `jax.Array`s per file as each file's reads complete, overlapping host-to-device transfer with the remaining reads and releasing host buffers progressively. File headers (and the fail-fast truncation check) are fetched concurrently across files.

**Generality.** Anything `devices_indices_map` can express now loads — inner-dim partitions, multi-axis partitions, N-D tensors — replacing the previous transient-array + collective-sum path, which required leading-dimension divisibility by the local device count and staged whole tensors on their owner hosts (the OOM risk tracked in its TODO).

**Behavior changes.**
- `SafetensorsOptions.ignore_load_sharding` is removed (its only users were its own tests; the converter it anticipated does not exist yet).
- The single-process path no longer rejects checkpoints containing non-finite values; the previous behavior was inconsistent between the single- and multi-host paths, and `inf`/`NaN` payloads (masks, sentinels) are legitimate.

**Observability.** Per-host reads are reported via `jax.monitoring` (`/jax/orbax/read/safetensors/{bytes_read,num_reads,storage_reads}`), and a one-shot warning fires when the over-read cap is what fragmented a load, pointing at `max_over_read_ratio`.

Tested with the single-process suite, a 4-process × 2-devices-per-process multiprocess suite covering the sharded read paths (including partial-replication, subset loads, and a peak-memory regression test), and the safetensors load benchmarks.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (alters existing behavior or a public API)
- [ ] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover this change and pass locally.
- [x] Public APIs and non-trivial functions are documented.
- [x] **If this change is user-facing, I have updated [`CHANGELOG.md`](CHANGELOG.md)** under the `[Unreleased]` section (or the relevant `checkpoint/` / `export/` changelog).
