### PR TITLE
Fix reached_preemption crash when JAX preemption service is disabled

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/multihost/multihost.py
+++ b/checkpoint/orbax/checkpoint/_src/multihost/multihost.py
@@ -423,9 +423,14 @@ def reached_preemption(step: int) -> bool:
   if is_proxy_pathways_backend():
     return False
 
-  preemption_sync_point_reached = multihost_utils.reached_preemption_sync_point(
-      step
-  )
+  try:
+    preemption_sync_point_reached = (
+        multihost_utils.reached_preemption_sync_point(step)
+    )
+  except RuntimeError:
+    # JAX raises RuntimeError when the preemption service is disabled
+    # via jax_enable_preemption_service config. Treat as no preemption.
+    return False
   _maybe_log_reached_preemption(step, preemption_sync_point_reached)
   return preemption_sync_point_reached
 

--- a/checkpoint/orbax/checkpoint/_src/multihost/multihost_test.py
+++ b/checkpoint/orbax/checkpoint/_src/multihost/multihost_test.py
@@ -244,5 +244,18 @@ class MultihostUtilsTestDistributedId(MultihostUtilsTestBase.Test):
     super().setUp()
 
 
+class ReachedPreemptionTest(parameterized.TestCase):
+
+  @mock.patch.object(multihost, 'is_proxy_pathways_backend', return_value=False)
+  @mock.patch.object(multihost.multihost_utils, 'reached_preemption_sync_point')
+  def test_returns_false_when_service_disabled(
+      self, mock_sync_point, mock_is_proxy
+  ):
+    mock_sync_point.side_effect = RuntimeError(
+        'Preemption sync manager has not been initialized.'
+    )
+    self.assertFalse(multihost.reached_preemption(step=5))
+
+
 if __name__ == '__main__':
   multiprocess_test.main()


### PR DESCRIPTION
## Description

Fixes https://github.com/google/orbax/issues/3406

When JAX's preemption service is disabled via `jax_enable_preemption_service=False`,
`multihost_utils.reached_preemption_sync_point` raises a `RuntimeError` because the
preemption sync manager is `None`. This causes `CheckpointManager.save()` to crash.

This change catches the `RuntimeError` in `reached_preemption()` and returns `False`,
gracefully treating a disabled preemption service as "no preemption detected".

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or a public API)
- [ ] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover this change and pass locally.
- [ ] Public APIs and non-trivial functions are documented.
- [ ] **If this change is user-facing, I have updated [`CHANGELOG.md`](CHANGELOG.md)** under the `[Unreleased]` section (or the relevant `checkpoint/` / `export/` changelog).
