### PR TITLE
Pick the safetensors over-read ratio per file and warn on heavy over-read

### DIFF
--- a/checkpoint/CHANGELOG.md
+++ b/checkpoint/CHANGELOG.md
@@ -17,11 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - #v1 Drive the safetensors load by the target sharding: each process reads
 only the byte ranges its own devices need (coalesced under
-`SafetensorsOptions.max_over_read_ratio`, fetched as concurrent ranged
-reads of `SafetensorsOptions.read_chunk_bytes` each, bounded by
+`SafetensorsOptions.max_over_read_ratio`, picked per file from the planned
+reads by default, fetched as concurrent ranged reads of
+`SafetensorsOptions.read_chunk_bytes` each, bounded by
 `MemoryOptions.read_concurrent_bytes`), replacing the transient-array
 resharding load. Supports arbitrary shardings, including inner-dimension
-partitions.
+partitions; a warning reports shardings whose fragmented byte layout forces
+heavy over-read.
 
 ## [0.12.1] - 2026-06-24
 

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/context/options.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/context/options.py
@@ -33,7 +33,6 @@ from orbax.checkpoint.experimental.v1._src.path import types as path_types
 from orbax.checkpoint.experimental.v1._src.serialization import types as serialization_types
 from orbax.checkpoint.experimental.v1._src.tree import types as tree_types
 
-
 FROZEN_IDS: contextvars.ContextVar[frozenset[int]] = contextvars.ContextVar(
     'orbax_frozen_option_ids', default=frozenset()
 )
@@ -606,8 +605,12 @@ class SafetensorsOptions(_ActiveContextGuard):
       coalescing per-host byte runs from one file into a single read. A higher
       value collapses more requests at the cost of more over-read; a value of
       1.0 disables any over-read. Worst-case per-host bytes from one file are
-      bounded at `max_over_read_ratio * ideal_bytes`. `None` selects an
-      implementation default (currently `2.0`).
+      bounded at `max_over_read_ratio * ideal_bytes`. `None` (the default)
+      picks the ratio per file from the planned reads: no over-read when the
+      target sharding already maps to few contiguous ranges, whole-span reads
+      when the plan would otherwise fragment into a very large number of
+      small strided requests (a warning reports the over-read cost of the
+      sharding in that case).
     read_chunk_bytes: Target size of one ranged read. Coalesced blocks are split
       at this size and the pieces are read concurrently, so it trades storage
       request count against read parallelism: larger values issue fewer requests

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout.py
@@ -24,9 +24,12 @@ reads. This mirrors how the v0 array deserializer
 standing in for TensorStore's chunk index.
 
 Byte runs from every tensor a process needs in one file are coalesced under a
-single bounded-over-read policy: a `max_over_read_ratio` cap on
-`block_size / needed_bytes` keeps cross-host egress from blowing up to
-N x file_size on inner-dim sharding. Each coalesced block is then split at a
+bounded-over-read policy: a `max_over_read_ratio` cap on
+`block_size / needed_bytes`. By default the cap is picked per file from the
+planned runs themselves -- no over-read when the sharding already maps to few
+contiguous reads, whole-span reads when the plan would otherwise fragment
+into a very large number of small strided requests (a warning then reports
+the over-read cost of that sharding). Each coalesced block is then split at a
 fixed chunk size and the chunks are read concurrently, with total in-flight
 bytes bounded by the shared restore budget
 (`MemoryOptions.read_concurrent_bytes`). Peak host memory beyond the
@@ -46,7 +49,7 @@ import itertools
 import json
 import math
 import time
-from typing import Any, NamedTuple, cast
+from typing import Any, cast, NamedTuple
 
 from absl import logging
 import humanize
@@ -77,13 +80,13 @@ SAFETENSORS_SUFFIX = ".safetensors"
 # (`max_over_read_ratio`) and the chunk size (`read_chunk_bytes`); the
 # in-flight budget comes from `MemoryOptions.read_concurrent_bytes`.
 #
-# `_DEFAULT_MAX_OVER_READ_RATIO` caps `block_size / needed_bytes` for any
-# coalesced read; a host's bytes pulled from one file are bounded at
-# `ratio * ideal_bytes`. The default trades up to 1x over-read for fewer
-# requests; the row-parallel inner-dim worst case (which would otherwise
-# collapse to "read the whole file on every host") is bounded at 2x and the
-# partitioner emits more, smaller reads instead.
-_DEFAULT_MAX_OVER_READ_RATIO = 2.0
+# With `max_over_read_ratio` unset, each file's ratio is picked from its
+# planned runs (`_auto_over_read_ratio`): 1.0 when coalescing at the gap floor
+# already leaves at most this many reads -- large contiguous shards gain
+# nothing from over-reading -- and the file's `span / needed` otherwise, which
+# collapses a fragmented (strided inner-dim) plan into whole-span reads
+# instead of an unbounded number of small requests.
+_AUTO_MAX_READS_PER_FILE = 1024
 # Always coalesce runs separated by less than this gap, regardless of the
 # over-read ratio. Below roughly a page the per-read overhead -- a syscall
 # locally, an RTT on object storage -- dwarfs the cost of reading the gap, so a
@@ -105,13 +108,12 @@ _DEFAULT_MAX_IN_FLIGHT_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
 # streams.
 _DEFAULT_READ_CHUNK_BYTES = 128 * 1024 * 1024  # 128 MiB
 
-# When the over-read cap fragments a load into many small reads -- the strided
-# inner-dim regime -- hint the user toward `max_over_read_ratio`. The warning
-# fires only when reads-per-file exceeds this factor *and* the achieved
-# over-read stayed near 1x (the cap blocked coalescing, rather than the load
-# genuinely spanning many files).
-_FRAGMENTED_READ_WARN_FACTOR = 8
-_FRAGMENTED_OVER_READ_CEILING = 1.2
+# Heavy over-read under the automatic ratio means the target sharding
+# fragments the checkpoint's byte layout and whole spans were read to keep the
+# request count bounded. Surface it so the extra bytes are diagnosable: the
+# sharding, not the loader, is the thing to change. Over-read from gap-floor
+# merges alone stays well below this.
+_OVER_READ_WARN_RATIO = 1.5
 
 
 def _get_dtypes() -> dict[str, Any]:
@@ -378,6 +380,45 @@ def _partition_runs(
   return blocks
 
 
+def _auto_over_read_ratio(runs: Sequence[tuple[int, int]]) -> float:
+  """Picks one file's over-read ratio from its planned run geometry.
+
+  No single ratio suits every sharding. A process reading a few large
+  contiguous runs gains nothing from merging across gaps -- that only
+  wastes bytes. One reading thousands of tiny strided runs is better off
+  reading the whole span, but the ratio where the plan collapses is the
+  file's `span / needed`, which shifts with sharding and topology. Values
+  in between buy more requests *and* more waste, so the choice is binary
+  and the runs themselves decide it.
+
+  Args:
+    runs: `(offset, length)` byte runs planned for one file; need not be
+      sorted. Assumed non-overlapping, as `index_domain_to_byte_runs`
+      produces.
+
+  Returns:
+    `1.0` when merging only sub-floor gaps already leaves at most
+    `_AUTO_MAX_READS_PER_FILE` reads; otherwise the file's whole-span ratio
+    `span / needed`, which bounds every block and collapses uniform strided
+    plans into whole-span reads.
+  """
+  if not runs:
+    return 1.0
+  ordered = sorted(runs)
+  needed = 0
+  num_reads = 1
+  prev_end = ordered[0][0]
+  for offset, length in ordered:
+    needed += length
+    if offset - prev_end > _DEFAULT_MIN_COALESCE_GAP:
+      num_reads += 1
+    prev_end = max(prev_end, offset + length)
+  if num_reads <= _AUTO_MAX_READS_PER_FILE:
+    return 1.0
+  span = prev_end - ordered[0][0]
+  return max(1.0, span / needed)
+
+
 def _replicated_sharding() -> jax.sharding.Sharding:
   """A `NamedSharding` that fully replicates an array across all devices."""
   mesh = jax.sharding.Mesh(np.asarray(jax.devices()), ("_safetensors_replica",))
@@ -427,7 +468,7 @@ class _ReadStats(NamedTuple):
 
 def _plan_chunk_reads(
     reads: Sequence[_Read],
-    max_over_read_ratio: float,
+    max_over_read_ratio: float | None,
     chunk_bytes: int,
 ) -> tuple[list[_ChunkRead], _ReadStats]:
   """Plans the ranged reads serving one file's byte runs.
@@ -442,15 +483,17 @@ def _plan_chunk_reads(
   Args:
     reads: The byte runs to serve, each with its destination buffer.
     max_over_read_ratio: Upper bound on `block_size / needed_bytes` per block.
+      `None` picks the ratio from this file's runs (`_auto_over_read_ratio`).
     chunk_bytes: Maximum size of one ranged read. Must be positive and at most
       the in-flight byte budget, so any single chunk can be reserved.
 
   Returns:
     The chunk reads covering every run, and the file's read accounting.
   """
-  blocks = _partition_runs(
-      [(r.offset, r.length) for r in reads], max_over_read_ratio
-  )
+  runs = [(r.offset, r.length) for r in reads]
+  if max_over_read_ratio is None:
+    max_over_read_ratio = _auto_over_read_ratio(runs)
+  blocks = _partition_runs(runs, max_over_read_ratio)
   chunks: list[_ChunkRead] = []
   for block in blocks:
     members = block.members  # Sorted by run offset (see `_partition_runs`).
@@ -531,7 +574,7 @@ async def _read_file(
     path: Path,
     reads: Sequence[_Read],
     byte_budget: limits.LimitInFlightBytes,
-    max_over_read_ratio: float,
+    max_over_read_ratio: float | None,
     chunk_bytes: int,
 ) -> _ReadStats:
   """Serves all of one file's byte runs with concurrent ranged reads.
@@ -541,6 +584,7 @@ async def _read_file(
     reads: The byte runs this host needs from the file.
     byte_budget: The shared in-flight byte limiter (shared across files).
     max_over_read_ratio: Upper bound on `block_size / needed_bytes` per block.
+      `None` picks the ratio from this file's runs (`_auto_over_read_ratio`).
     chunk_bytes: Maximum size of one ranged read.
 
   Returns:
@@ -716,54 +760,45 @@ def _record_read_stats(stats: Sequence[_ReadStats]) -> None:
   )
 
 
-def _warn_if_reads_fragmented(
+def _warn_if_over_read(
     stats: Sequence[_ReadStats],
-    num_files: int,
-    max_over_read_ratio_is_default: bool,
+    max_over_read_ratio_is_auto: bool,
 ) -> None:
-  """Logs a one-shot hint when the over-read cap fragmented the load.
+  """Logs a one-shot hint when the load read far more bytes than it needed.
 
-  In the strided inner-dim regime the `max_over_read_ratio` cap rejects merges
-  and the load degrades into many small ranged reads -- RTT-bound and slow on
-  object storage. This surfaces that case so a slow load is diagnosable without
-  profiling. It fires once, only on the primary process, and only when the user
-  is on the default ratio (someone who set the knob has already weighed the
-  tradeoff). The signal is a high reads-per-file count together with an achieved
-  over-read near 1x -- exactly "the cap blocked coalescing" rather than "the
-  load genuinely spans many files."
+  Under the automatic per-file ratio, heavy over-read happens only when the
+  target sharding maps to many small strided runs per process and whole spans
+  were read instead to keep the request count bounded. The extra bytes are
+  the cost of that sharding's byte layout, not a loader inefficiency, so the
+  actionable advice is a sharding whose per-process ranges are contiguous.
+  Fires once, only on the primary process, and only for the automatic ratio
+  (someone who set the knob has already weighed the tradeoff).
 
   Args:
     stats: Per-file read accounting from each file's reads.
-    num_files: Number of distinct files the load read from.
-    max_over_read_ratio_is_default: Whether the user left `max_over_read_ratio`
-      unset; only then is "raise the ratio" actionable advice.
+    max_over_read_ratio_is_auto: Whether the user left `max_over_read_ratio`
+      unset (the per-file automatic choice).
   """
-  if not max_over_read_ratio_is_default or num_files == 0:
+  if not max_over_read_ratio_is_auto:
     return
   if multihost.process_index() != 0:
     return
   total_needed = sum(s.needed_bytes for s in stats)
   total_read = sum(s.read_bytes for s in stats)
-  total_reads = sum(s.num_reads for s in stats)
   if total_needed == 0:
     return
-  achieved_over_read = total_read / total_needed
-  if (
-      total_reads <= _FRAGMENTED_READ_WARN_FACTOR * num_files
-      or achieved_over_read >= _FRAGMENTED_OVER_READ_CEILING
-  ):
+  over_read = total_read / total_needed
+  if over_read < _OVER_READ_WARN_RATIO:
     return
   logging.warning(
-      "Safetensors load issued %d ranged reads for %s across %d file(s)"
-      " (achieved over-read %.2fx). The target sharding produces strided reads"
-      " that the default max_over_read_ratio=%.1f keeps fragmented; raising"
-      " SafetensorsOptions.max_over_read_ratio trades bounded over-read for far"
-      " fewer reads (notably faster on object storage).",
-      total_reads,
+      "Safetensors load read %s to serve %s of needed bytes (%.1fx"
+      " over-read). The target sharding needs many small strided ranges per"
+      " process, so whole spans were read instead to keep the request count"
+      " bounded. A sharding whose per-process ranges are contiguous (e.g."
+      " partitioning the leading dimension) avoids the extra bytes.",
+      humanize.naturalsize(total_read, binary=True),
       humanize.naturalsize(total_needed, binary=True),
-      num_files,
-      achieved_over_read,
-      _DEFAULT_MAX_OVER_READ_RATIO,
+      over_read,
   )
 
 
@@ -930,11 +965,6 @@ class SafetensorsLayout(CheckpointLayout):
     """Background load phase: plans reads, reads files, assembles arrays."""
     context = context_lib.get_context()
     opts = context.safetensors_options
-    max_over_read_ratio = (
-        opts.max_over_read_ratio
-        if opts.max_over_read_ratio is not None
-        else _DEFAULT_MAX_OVER_READ_RATIO
-    )
     # In-flight read bytes reuse the shared restore knob,
     # `MemoryOptions.read_concurrent_bytes` (the same limit TensorStore restore
     # uses). `None` means "no limit" there, but the chunk sizing here needs a
@@ -1005,7 +1035,7 @@ class SafetensorsLayout(CheckpointLayout):
           file_path,
           reads_by_file[file_path],
           byte_budget,
-          max_over_read_ratio,
+          opts.max_over_read_ratio,
           chunk_bytes,
       )
       # Drop the read plan so each shard's host memory can be released as
@@ -1017,7 +1047,5 @@ class SafetensorsLayout(CheckpointLayout):
 
     stats = await asyncio.gather(*map(load_file, list(reads_by_file)))
     _record_read_stats(stats)
-    _warn_if_reads_fragmented(
-        stats, len(builds_by_file), opts.max_over_read_ratio is None
-    )
+    _warn_if_over_read(stats, opts.max_over_read_ratio is None)
     return {name: arrays[name] for name in names}

--- a/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_test.py
+++ b/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_test.py
@@ -637,6 +637,12 @@ class FileReadTest(unittest.IsolatedAsyncioTestCase, parameterized.TestCase):
     for off, b in zip(offsets, received):
       self.assertEqual(b, self.payload[off : off + 16])
 
+  async def test_delivers_bytes_with_auto_ratio(self):
+    offsets = [0, 1024, 2048]
+    received = await self._run(None, 1 << 20, offsets, [16] * 3)
+    for off, b in zip(offsets, received):
+      self.assertEqual(b, self.payload[off : off + 16])
+
   async def test_delivers_bytes_when_block_splits_into_chunks(self):
     # 5 dense 16-byte runs coalesce into one 80-byte block (ratio 1.0). A
     # 64-byte chunk size splits the block into two reads (64 + 16); the run
@@ -736,48 +742,131 @@ class RecordReadStatsTest(absltest.TestCase):
     self.assertEqual(emitted['/jax/orbax/read/safetensors/storage_reads'], 6.0)
 
 
-class FragmentationWarningTest(parameterized.TestCase):
-  """`_warn_if_reads_fragmented` fires only in the cap-bound strided regime."""
+class AutoOverReadRatioTest(absltest.TestCase):
+  """`_auto_over_read_ratio` picks 1.0 or whole-span from the run geometry."""
 
-  def _stats(self, needed, read, reads):
-    return safetensors_layout._ReadStats(
-        needed_bytes=needed, read_bytes=read, num_reads=reads, num_gets=reads
+  # A stride whose gaps stay above the coalesce floor, so every run is its
+  # own read at ratio 1.0.
+  _STRIDE = 8 + 2 * safetensors_layout._DEFAULT_MIN_COALESCE_GAP
+
+  def test_no_runs(self):
+    self.assertEqual(safetensors_layout._auto_over_read_ratio([]), 1.0)
+
+  def test_few_contiguous_runs_pick_no_over_read(self):
+    # Leading-dim shards: large contiguous slabs, far apart.
+    runs = [(i * (1 << 20), 1 << 18) for i in range(64)]
+    self.assertEqual(safetensors_layout._auto_over_read_ratio(runs), 1.0)
+
+  def test_sub_floor_gaps_count_as_merged(self):
+    # Many tiny runs whose gaps the floor always coalesces -> few effective
+    # reads -> no over-read needed.
+    gap = safetensors_layout._DEFAULT_MIN_COALESCE_GAP
+    runs = [(i * (8 + gap), 8) for i in range(10_000)]
+    self.assertEqual(safetensors_layout._auto_over_read_ratio(runs), 1.0)
+
+  def test_fragmented_runs_pick_whole_span(self):
+    n = safetensors_layout._AUTO_MAX_READS_PER_FILE + 1
+    runs = [(i * self._STRIDE, 8) for i in range(n)]
+    span = (n - 1) * self._STRIDE + 8
+    self.assertEqual(
+        safetensors_layout._auto_over_read_ratio(runs), span / (8 * n)
     )
 
-  def test_warns_when_fragmented_on_default_ratio(self):
-    # 512 reads for 1 file, achieved over-read 1.0x -> the cap is fragmenting.
-    stats = [self._stats(needed=8192, read=8192, reads=512)]
+  def test_read_count_at_cap_picks_no_over_read(self):
+    runs = [
+        (i * self._STRIDE, 8)
+        for i in range(safetensors_layout._AUTO_MAX_READS_PER_FILE)
+    ]
+    self.assertEqual(safetensors_layout._auto_over_read_ratio(runs), 1.0)
+
+  def test_unsorted_runs(self):
+    n = safetensors_layout._AUTO_MAX_READS_PER_FILE + 1
+    runs = [(i * self._STRIDE, 8) for i in reversed(range(n))]
+    span = (n - 1) * self._STRIDE + 8
+    self.assertEqual(
+        safetensors_layout._auto_over_read_ratio(runs), span / (8 * n)
+    )
+
+  def test_auto_ratio_collapses_fragmented_plan(self):
+    # Through the planner: the picked ratio turns a fragmented plan into a
+    # single whole-span block instead of one read per run.
+    n = safetensors_layout._AUTO_MAX_READS_PER_FILE + 1
+    reads = [
+        safetensors_layout._Read(
+            i * self._STRIDE, 8, np.zeros(8, dtype=np.uint8)
+        )
+        for i in range(n)
+    ]
+    _, stats = safetensors_layout._plan_chunk_reads(
+        reads, max_over_read_ratio=None, chunk_bytes=1 << 30
+    )
+    self.assertEqual(stats.num_reads, 1)
+    self.assertEqual(stats.needed_bytes, 8 * n)
+    self.assertEqual(stats.read_bytes, (n - 1) * self._STRIDE + 8)
+
+  def test_auto_ratio_keeps_contiguous_plan_exact(self):
+    # Leading-dim-style slabs stay unmerged: bytes read == bytes needed.
+    reads = [
+        safetensors_layout._Read(
+            i * (1 << 20), 1 << 18, np.zeros(1 << 18, dtype=np.uint8)
+        )
+        for i in range(64)
+    ]
+    _, stats = safetensors_layout._plan_chunk_reads(
+        reads, max_over_read_ratio=None, chunk_bytes=1 << 30
+    )
+    self.assertEqual(stats.num_reads, 64)
+    self.assertEqual(stats.read_bytes, stats.needed_bytes)
+
+
+class OverReadWarningTest(absltest.TestCase):
+  """`_warn_if_over_read` fires only on heavy over-read under the auto ratio."""
+
+  def _stats(self, needed, read):
+    return safetensors_layout._ReadStats(
+        needed_bytes=needed, read_bytes=read, num_reads=1, num_gets=1
+    )
+
+  def test_warns_on_heavy_over_read(self):
+    # Whole-span reads for a fragmenting sharding: 4x the needed bytes.
+    stats = [self._stats(needed=8192, read=32768)]
     with mock.patch.object(safetensors_layout.logging, 'warning') as warn:
-      safetensors_layout._warn_if_reads_fragmented(
-          stats, num_files=1, max_over_read_ratio_is_default=True
+      safetensors_layout._warn_if_over_read(
+          stats, max_over_read_ratio_is_auto=True
       )
     warn.assert_called_once()
 
-  def test_no_warn_when_coalesced(self):
-    # One read per file -> healthy load, no hint.
-    stats = [self._stats(needed=8192, read=8192, reads=1)]
+  def test_no_warn_when_reads_match_needs(self):
+    stats = [self._stats(needed=8192, read=8192)]
     with mock.patch.object(safetensors_layout.logging, 'warning') as warn:
-      safetensors_layout._warn_if_reads_fragmented(
-          stats, num_files=1, max_over_read_ratio_is_default=True
+      safetensors_layout._warn_if_over_read(
+          stats, max_over_read_ratio_is_auto=True
       )
     warn.assert_not_called()
 
-  def test_no_warn_when_over_read_high(self):
-    # Many reads but over-read near the cap -> coalescing happened, not the
-    # fragmented regime.
-    stats = [self._stats(needed=8192, read=16384, reads=512)]
+  def test_no_warn_below_threshold(self):
+    # Gap-floor merges cause mild over-read; not worth a warning.
+    stats = [self._stats(needed=8192, read=9000)]
     with mock.patch.object(safetensors_layout.logging, 'warning') as warn:
-      safetensors_layout._warn_if_reads_fragmented(
-          stats, num_files=1, max_over_read_ratio_is_default=True
+      safetensors_layout._warn_if_over_read(
+          stats, max_over_read_ratio_is_auto=True
       )
     warn.assert_not_called()
 
   def test_no_warn_when_user_set_ratio(self):
     # User already engaged with the knob -> stay quiet.
-    stats = [self._stats(needed=8192, read=8192, reads=512)]
+    stats = [self._stats(needed=8192, read=32768)]
     with mock.patch.object(safetensors_layout.logging, 'warning') as warn:
-      safetensors_layout._warn_if_reads_fragmented(
-          stats, num_files=1, max_over_read_ratio_is_default=False
+      safetensors_layout._warn_if_over_read(
+          stats, max_over_read_ratio_is_auto=False
+      )
+    warn.assert_not_called()
+
+  def test_no_warn_when_nothing_needed(self):
+    stats = [self._stats(needed=0, read=0)]
+    with mock.patch.object(safetensors_layout.logging, 'warning') as warn:
+      safetensors_layout._warn_if_over_read(
+          stats, max_over_read_ratio_is_auto=True
       )
     warn.assert_not_called()
 


### PR DESCRIPTION
## Description

Follow-up to #3455. With the sharding-driven safetensors load, no fixed `max_over_read_ratio` default serves every sharding: the ratio at which the greedy partitioner collapses a file's plan into whole-span reads is `span / needed`, which varies with the target sharding and the process topology.

Measured on Mistral-7B (8-way axis, real HF headers), the old fixed default of 2.0 lands on both failure modes:

- **Contiguous leading-dim shards, 2 processes x 4 devices**: each process owns half of every tensor, so the cumulative merge test passes on every step at ratio 2.0 and every process reads the *entire* checkpoint (2.0x egress for zero request savings). At 1.0 the same load is 227 clean reads with no over-read.
- **Inner-dim shards, same topology at ratio 1.0**: the plan fragments into ~131k strided reads per process; at larger scales (8 processes x 1 device) ~1.4M — enough to exhaust file handles. Intermediate ratios are strictly worse than either extreme (e.g. 3.9 on 4x2: 95k reads *and* 3.8x over-read).

This PR makes `max_over_read_ratio=None` (the default) pick the ratio per file from the planned runs, which are already available before any I/O:

- Count the reads a ratio-1.0 partition would produce (exactly `1 + gaps above the coalesce floor`, one pass over sorted runs). At or under 1024 reads, use `1.0` — contiguous shardings read exactly the bytes they need. Above it, use the file's `span / needed`, which collapses the fragmented plan into whole-span reads fetched as concurrent fixed-size chunks.
- Replace the read-fragmentation hint with an over-read warning: with the automatic ratio, reading well above the needed bytes (>= 1.5x) means the target sharding fragments the checkpoint's byte layout, so the warning points at the sharding rather than at a loader knob. Fires once, on the primary process only, and only when the ratio was left automatic.

An explicit `max_over_read_ratio` float keeps exactly the previous fixed-cap behavior.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or a public API)
- [ ] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover this change and pass locally.
- [x] Public APIs and non-trivial functions are documented.
- [x] **If this change is user-facing, I have updated [`CHANGELOG.md`](CHANGELOG.md)** under the `[Unreleased]` section (or the relevant `checkpoint/` / `export/` changelog).
