### PR TITLE
docs: fix typo in CONTRIBUTING.md pytype table row

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ enforce it, wired together through the
 |---|---|---|
 | [`pylint`](https://pylint.readthedocs.io/) | Linter | `.pylintrc` |
 | [`isort`](https://pycqa.github.io/isort/) | Import order | `[tool.isort]` in `pyproject.toml` |
-| [`pytype`](https://github.com/google/pytype) | Static Type Inferece & Verification | `.pre-commit-config.yaml` |
+| [`pytype`](https://github.com/google/pytype) | Static Type Inference & Verification | `.pre-commit-config.yaml` |
 
 Install the hooks once, then they run on every `git commit`:
 


### PR DESCRIPTION
## Description
This PR fixes a small typo in `CONTRIBUTING.md` under the Code Style & Linting section table.

## Details
Fixed `Inferece` -> `Inference` in the pytype description (`Static Type Inference & Verification`).