### PR TITLE
Cache sharding metadata device mesh serialization

### DIFF
--- a/checkpoint/orbax/checkpoint/_src/metadata/sharding.py
+++ b/checkpoint/orbax/checkpoint/_src/metadata/sharding.py
@@ -17,18 +17,20 @@
 from __future__ import annotations
 
 import abc
+from collections.abc import Mapping, Sequence
 import dataclasses
 import enum
+import functools
 import json
 import logging
-from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any
 
 import jax
 import numpy as np
 from orbax.checkpoint._src.sharding_utils import make_single_device_sharding
 
 _AXIS_TYPE_MAP = {str(val): val for val in jax.sharding.AxisType}
-PartitionSpecElement = Union[None, str, Tuple[str, ...]]
+PartitionSpecElement = None | str | tuple[str, ...]
 
 _PARTITION_SPEC = 'partition_spec'
 _SHARDING = '_sharding'
@@ -41,6 +43,36 @@ _DEVICES_SHAPE = 'shape'
 _DEVICE_MESH = 'device_mesh'
 _MEMORY_KIND = 'memory_kind'
 _ID = 'id'
+
+
+def _device_id(device: jax.Device) -> int:
+  return device.id
+
+
+def _to_tuple_tree(value: Any) -> Any:
+  if isinstance(value, list):
+    return tuple(_to_tuple_tree(v) for v in value)
+  if isinstance(value, tuple):
+    return tuple(_to_tuple_tree(v) for v in value)
+  return value
+
+
+def _to_list_tree(value: Any) -> Any:
+  if isinstance(value, tuple):
+    return [_to_list_tree(v) for v in value]
+  return value
+
+
+def _mesh_device_ids(mesh: jax.sharding.Mesh) -> Any:
+  devices = mesh.devices
+  if isinstance(devices, np.ndarray):
+    devices = devices.tolist()
+  device_ids = jax.tree.map(
+      _device_id,
+      devices,
+      is_leaf=lambda x: isinstance(x, jax.Device),
+  )
+  return _to_tuple_tree(device_ids)
 
 
 class ShardingTypes(enum.Enum):
@@ -71,6 +103,10 @@ class DeviceMetadata:
     return self.id == other.id
 
 
+def _device_metadata_from_id(device_id: int) -> DeviceMetadata:
+  return DeviceMetadata(id=device_id)
+
+
 @dataclasses.dataclass
 class DeviceMetadataMesh:
   """Contain a mesh of DeviceMetadata class."""
@@ -90,7 +126,7 @@ class DeviceMetadataMesh:
   @classmethod
   def from_jax_mesh(
       cls, mesh: jax.sharding.Mesh
-  ) -> Optional[DeviceMetadataMesh]:
+  ) -> DeviceMetadataMesh | None:
     """Take in of jax.sharding.Mesh and convert into DeviceMetadata while keeping the sequences.
 
     Support only TPU-device.  If there is any non-TPU device, return None.
@@ -102,15 +138,20 @@ class DeviceMetadataMesh:
       DeviceMetadataMesh if only TPU-devices are in the mesh.
     """
 
-    if isinstance(devices := mesh.devices, np.ndarray):
-      devices = devices.tolist()
-    device_mesh = jax.tree.map(
-        DeviceMetadata.from_jax_device,
-        devices,
-        is_leaf=lambda x: isinstance(x, jax.Device),
-    )
+    return cls._from_device_ids(_mesh_device_ids(mesh))
 
-    return DeviceMetadataMesh(mesh=device_mesh)
+  @classmethod
+  @functools.lru_cache(maxsize=128)
+  def _from_device_ids(cls, device_ids: Any) -> DeviceMetadataMesh:
+    device_mesh = jax.tree.map(
+        _device_metadata_from_id,
+        _to_list_tree(device_ids),
+    )
+    return cls(mesh=device_mesh)
+
+  @functools.cached_property
+  def as_serialized_dict(self) -> dict[str, Any]:
+    return dataclasses.asdict(self)
 
   def to_jax_device_mesh(self):
     """return a jax Device mesh.
@@ -180,15 +221,15 @@ class NamedShardingMetadata(ShardingMetadata):
   """NamedShardingMetadata representing `jax.sharding.NamedSharding`."""
 
   shape: np.ndarray
-  axis_names: List[str]
-  partition_spec: Tuple[
+  axis_names: list[str]
+  partition_spec: tuple[
       PartitionSpecElement, ...
   ]  # Each element is either ``None``, a string, or a tuple of strings.
-  axis_types: Optional[Tuple[jax.sharding.AxisType, ...]] = None
+  axis_types: tuple[jax.sharding.AxisType, ...] | None = None
 
   # Optional device mesh.  If it's None, use jax.devices(),
   # otherwise, the stored device_mesh will be used to recreate NamedSharding.
-  device_mesh: Optional[DeviceMetadataMesh] = None
+  device_mesh: DeviceMetadataMesh | None = None
 
   @classmethod
   def from_jax_sharding(
@@ -199,7 +240,9 @@ class NamedShardingMetadata(ShardingMetadata):
         axis_names=list(jax_sharding.mesh.axis_names),
         axis_types=tuple(jax_sharding.mesh.axis_types),
         partition_spec=tuple(jax_sharding.spec),
-        device_mesh=DeviceMetadataMesh.from_jax_mesh(jax_sharding.mesh),  # pyrefly: ignore[bad-argument-type]
+        device_mesh=DeviceMetadataMesh.from_jax_mesh(
+            jax_sharding.mesh  # pyrefly: ignore[bad-argument-type]
+        ),
     )
 
   def to_jax_sharding(self) -> jax.sharding.NamedSharding:
@@ -258,7 +301,7 @@ class NamedShardingMetadata(ShardingMetadata):
       sharding_data[_MESH_AXIS_TYPES] = [str(a) for a in self.axis_types]
     sharding_data[_PARTITION_SPEC] = self.partition_spec
     if self.device_mesh:
-      sharding_data[_DEVICE_MESH] = dataclasses.asdict(self.device_mesh)
+      sharding_data[_DEVICE_MESH] = self.device_mesh.as_serialized_dict
     return json.dumps(sharding_data)
 
   def __repr__(self):
@@ -335,7 +378,7 @@ class SingleDeviceShardingMetadata(ShardingMetadata):
     )
 
 
-def from_jax_sharding(jax_sharding) -> Optional[ShardingMetadata]:
+def from_jax_sharding(jax_sharding) -> ShardingMetadata | None:
   """Converts `jax.sharding.Sharding` to `ShardingMetadata`."""
   if isinstance(jax_sharding, jax.sharding.NamedSharding):
     return NamedShardingMetadata.from_jax_sharding(jax_sharding)
@@ -345,6 +388,7 @@ def from_jax_sharding(jax_sharding) -> Optional[ShardingMetadata]:
     logging.warning(
         'Conversion for %s has not been implemented.', type(jax_sharding)
     )
+    return None
 
 
 def from_serialized_string(serialized_str) -> ShardingMetadata:
@@ -378,3 +422,4 @@ def get_sharding_or_none(serialized_string):
     return from_serialized_string(serialized_string.item()).to_jax_sharding()
   except ValueError as e:
     logging.error(e)
+    return None

--- a/checkpoint/orbax/checkpoint/_src/metadata/sharding_test.py
+++ b/checkpoint/orbax/checkpoint/_src/metadata/sharding_test.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+from unittest import mock
+
 from absl.testing import absltest
 import jax
 import numpy as np
@@ -85,6 +88,40 @@ class TestShardingMetadata(absltest.TestCase):
         converted_jax_sharding, jax.sharding.NamedSharding
     )
     self.assertEqual(converted_jax_sharding, jax_sharding)
+
+  def test_device_metadata_mesh_from_jax_mesh_reuses_device_id_tree(self):
+    devices = np.asarray(jax.devices())
+    mesh = jax.sharding.Mesh(devices, ("x",))
+    equivalent_mesh = jax.sharding.Mesh(devices.copy(), ("x",))
+
+    self.assertIs(
+        sharding_metadata.DeviceMetadataMesh.from_jax_mesh(mesh),
+        sharding_metadata.DeviceMetadataMesh.from_jax_mesh(equivalent_mesh),
+    )
+
+  def test_named_sharding_serializes_cached_device_mesh_dict(self):
+    device_mesh = sharding_metadata.DeviceMetadataMesh(
+        mesh=[sharding_metadata.DeviceMetadata(id=0)]
+    )
+    named_sharding_metadata = sharding_metadata.NamedShardingMetadata(
+        shape=np.array([1]),
+        axis_names=(["x"]),
+        partition_spec=(None,),
+        device_mesh=device_mesh,
+    )
+    original_asdict = sharding_metadata.dataclasses.asdict
+
+    with mock.patch.object(
+        sharding_metadata.dataclasses, "asdict", wraps=original_asdict
+    ) as asdict_mock:
+      serialized_string = named_sharding_metadata.to_serialized_string()
+      named_sharding_metadata.to_serialized_string()
+
+    self.assertEqual(asdict_mock.call_count, 1)
+    self.assertEqual(
+        json.loads(serialized_string)["device_mesh"],
+        {"mesh": [{"id": 0}]},
+    )
 
   def test_convert_between_jax_single_device_sharding_and_sharding_metadata(
       self,


### PR DESCRIPTION
## Summary

Fixes google/orbax#3494.

This PR deduplicates `NamedShardingMetadata` device-mesh serialization by caching the `DeviceMetadataMesh` conversion from a JAX mesh and by caching the serialized `dataclasses.asdict` output for each metadata mesh.

## Details

`NamedShardingMetadata.to_serialized_string()` previously called `dataclasses.asdict(self.device_mesh)` for every array metadata entry, which repeatedly deep-copied the same device mesh when many arrays shared one mesh.

This change:

- builds a hashable cache key from the mesh device-id tree instead of relying on `jax.sharding.Mesh` hashability
- memoizes `DeviceMetadataMesh` construction for repeated equivalent meshes
- stores the expensive serialized dictionary as a `cached_property`
- preserves the existing list-shaped device metadata used by serialization and round trips

## Validation

- `.venv/bin/python checkpoint/orbax/checkpoint/_src/metadata/sharding_test.py`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --files $(git diff --name-only origin/main)`
