### PR TITLE
Allow maintainers to re-trigger lint validation via a recheck label

### DIFF
--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -1,7 +1,10 @@
 name: Auto Label PR
 
 on:
-  workflow_run:
+  # Safe use of workflow_run: this workflow never checks out or executes
+  # code from the triggering PR; it only calls the GitHub API to label,
+  # comment, and clean up.
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: ["Code Formatting & Lint Validation"]
     types:
       - completed
@@ -16,7 +19,7 @@ jobs:
     if: github.actor != 'copybara-service[bot]'
     steps:
       - name: Process Verification Outcome & Manage Dialogue
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const pulls = await github.rest.pulls.list({

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -33,6 +33,21 @@ jobs:
             const issue_number = pr.number;
             const conclusion = context.payload.workflow_run.conclusion;
 
+            // Consume the `recheck` trigger label (if this run came from one)
+            // so it can be re-applied to fire another validation run.
+            if (pr.labels.some(label => label.name === 'recheck')) {
+              try {
+                await github.rest.issues.removeLabel({
+                  issue_number: issue_number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'recheck',
+                });
+              } catch (e) {
+                console.log(`Could not remove recheck label: ${e.message}`);
+              }
+            }
+
             if (conclusion === 'failure') {
               console.log('Lint workflow failed. Posting guidance advice comment.');
               await github.rest.issues.createComment({

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,12 +22,13 @@ jobs:
       (github.event.action != 'labeled' || github.event.label.name == 'recheck')
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           # This reads from .github-python-version (the minimum Python version that Orbax supports).
           python-version-file: '.github-python-version'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,12 @@ name: Code Formatting & Lint Validation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # `labeled` lets a maintainer re-trigger validation on a fork PR whose
+    # workflow-approval window has lapsed: apply the `recheck` label and a
+    # fresh run fires with the maintainer as the triggering actor. The
+    # label is removed again by the Auto Label PR workflow once the result
+    # is processed, so it can be re-applied for another run.
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
 
@@ -12,7 +17,9 @@ permissions:
 jobs:
   style-check:
     runs-on: ubuntu-latest
-    if: github.actor != 'copybara-service[bot]'
+    if: >-
+      github.actor != 'copybara-service[bot]' &&
+      (github.event.action != 'labeled' || github.event.label.name == 'recheck')
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description

Fork PRs from outside collaborators need a maintainer to approve their workflow runs, and GitHub deletes runs that sit awaiting approval for more than 30 days. Once that happens the PR has no way to run `Code Formatting & Lint Validation` again, so the `Auto Label PR` workflow never fires and the PR can never receive `pull ready` (see #3414 and #3458, both of which aged out of their approval window and needed manual labeling).

This adds a `labeled` trigger to the lint workflow, gated to a single label: applying `recheck` to a PR fires a fresh validation run on the PR delta, with the labeling maintainer as the triggering actor. The run stays in the unprivileged `pull_request` context (read-only token, no secrets), and every existing trigger path is unchanged. `Auto Label PR` removes `recheck` after it processes the result, so the label can be re-applied whenever another run is needed.

Requires the `recheck` label to exist in the repo (create once under Issues → Labels).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or a public API)
- [x] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [ ] Tests cover this change and pass locally.
- [ ] Public APIs and non-trivial functions are documented.
- [ ] **If this change is user-facing, I have updated [`CHANGELOG.md`](CHANGELOG.md)** under the `[Unreleased]` section (or the relevant `checkpoint/` / `export/` changelog).
