### PR TITLE
Pin pypi-auto-publish action to a commit hash

### DIFF
--- a/.github/workflows/auto-publish-dry-run.yml
+++ b/.github/workflows/auto-publish-dry-run.yml
@@ -7,6 +7,8 @@ jobs:
   dry-run-checkpoint-job:
     runs-on: ubuntu-latest
     if: github.repository == 'google/orbax'
+    permissions:
+      contents: read
     steps:
     - uses: etils-actions/pypi-auto-publish@d0603b1e896ce8b754fd7df30731623c93546e89 # v1
       with:

--- a/.github/workflows/auto-publish-dry-run.yml
+++ b/.github/workflows/auto-publish-dry-run.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'google/orbax'
     steps:
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@d0603b1e896ce8b754fd7df30731623c93546e89 # v1
       with:
         pypi-token: skip  # Skips PyPI upload
         # Omitting gh-token skips GitHub release creation

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     # 1. Publish the sub-packages first
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@d0603b1e896ce8b754fd7df30731623c93546e89 # v1
       with:
         pypi-token: ${{ secrets.PYPI_API_TOKEN_OBX_CKPT }}
         gh-token: ${{ secrets.GH_PUBLISH_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     # 1. Publish the sub-packages first
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@d0603b1e896ce8b754fd7df30731623c93546e89 # v1
       with:
         # NOTE: Do not use gh-token here, as it would conflict with orbax-checkpoint.
         pypi-token: ${{ secrets.PYPI_API_TOKEN_OBX_EXPT }}


### PR DESCRIPTION
## Description

zizmor's `unpinned-uses` check fails on `auto-publish.yml` (lines 20 and 42) because `etils-actions/pypi-auto-publish@v1` references a mutable tag. This pins all uses of the action to the commit `v1` currently resolves to (`d0603b1`), matching the hash-pinning style already used in `lint.yml` and `build.yml`. The same reference in `auto-publish-dry-run.yml` is pinned too so the blanket policy does not flag it next.

Also resolves the `excessive-permissions` warning on the dry-run job by scoping it to `contents: read`; the job only builds and parses the changelog (PyPI upload is skipped and no release is created), so the default token permissions are unnecessary.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or a public API)
- [x] Docs / tests / internal tooling (no user-facing behavior change)

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [ ] Tests cover this change and pass locally.
- [x] Public APIs and non-trivial functions are documented.
- [ ] **If this change is user-facing, I have updated [`CHANGELOG.md`](CHANGELOG.md)** under the `[Unreleased]` section (or the relevant `checkpoint/` / `export/` changelog).
